### PR TITLE
fix: normalize TMDB scraper types

### DIFF
--- a/api/src/__tests__/movie-selections-api.test.ts
+++ b/api/src/__tests__/movie-selections-api.test.ts
@@ -52,7 +52,7 @@ const mockDatabase = {
 };
 
 vi.mock('db', async (importOriginal) => {
-	const actual = (await importOriginal()) as Record<string, unknown>;
+	const actual: Record<string, unknown> = await importOriginal();
 	return {
 		...actual,
 		getDatabase: vi.fn(() => mockDatabase),

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -153,14 +153,15 @@ adminRoutes.post('/movies/:id/posters', authMiddleware, async (c) => {
 		}
 
 		// Basic URL validation
+		let normalizedUrl: string;
 		try {
-			new URL(url);
+			normalizedUrl = new URL(url).toString();
 		} catch {
 			return c.json({error: 'Invalid URL format'}, 400);
 		}
 
 		const newPoster = await adminService.addPoster(movieId, {
-			url,
+			url: normalizedUrl,
 			width,
 			height,
 			language: languageCode,
@@ -402,9 +403,9 @@ adminRoutes.put('/movies/:id/tmdb-id', authMiddleware, async (c) => {
 						`https://api.themoviedb.org/3/movie/${tmdbId}?api_key=${c.env.TMDB_API_KEY}`,
 					);
 					const movieData = (await movieResponse.json()) as {
-					original_language?: string;
-					original_title?: string;
-				};
+						original_language?: string;
+						original_title?: string;
+					};
 
 					// Always update original language from TMDb
 					if (movieData.original_language) {

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -369,7 +369,7 @@ adminRoutes.put('/movies/:id/tmdb-id', authMiddleware, async (c) => {
 
 				const imagesResponse = await fetch(imagesUrl.toString());
 				if (imagesResponse.ok) {
-					const images = (await imagesResponse.json()) as TMDBMovieImages;
+					const images: TMDBMovieImages = await imagesResponse.json();
 					if (images.posters && images.posters.length > 0) {
 						const savedPosters = await savePosterUrls(
 							movieId,
@@ -402,10 +402,10 @@ adminRoutes.put('/movies/:id/tmdb-id', authMiddleware, async (c) => {
 					const movieResponse = await fetch(
 						`https://api.themoviedb.org/3/movie/${tmdbId}?api_key=${c.env.TMDB_API_KEY}`,
 					);
-					const movieData = (await movieResponse.json()) as {
+					const movieData: {
 						original_language?: string;
 						original_title?: string;
-					};
+					} = await movieResponse.json();
 
 					// Always update original language from TMDb
 					if (movieData.original_language) {
@@ -819,7 +819,7 @@ adminRoutes.post('/movies/:id/auto-fetch-tmdb', authMiddleware, async (c) => {
 
 			const imagesResponse = await fetch(imagesUrl.toString());
 			if (imagesResponse.ok) {
-				const images = (await imagesResponse.json()) as TMDBMovieImages;
+				const images: TMDBMovieImages = await imagesResponse.json();
 				if (images.posters && images.posters.length > 0) {
 					const savedPosters = await savePosterUrls(
 						movieId,
@@ -844,10 +844,10 @@ adminRoutes.post('/movies/:id/auto-fetch-tmdb', authMiddleware, async (c) => {
 			const movieResponse = await fetch(
 				`https://api.themoviedb.org/3/movie/${movieTmdbId}?api_key=${tmdbApiKey}`,
 			);
-			const movieData = (await movieResponse.json()) as {
+			const movieData: {
 				original_language?: string;
 				original_title?: string;
-			};
+			} = await movieResponse.json();
 
 			// Always update original language from TMDb
 			if (movieData.original_language) {
@@ -1000,7 +1000,7 @@ adminRoutes.post('/movies/:id/refresh-tmdb', authMiddleware, async (c) => {
 
 			const imagesResponse = await fetch(imagesUrl.toString());
 			if (imagesResponse.ok) {
-				const images = (await imagesResponse.json()) as TMDBMovieImages;
+				const images: TMDBMovieImages = await imagesResponse.json();
 				if (images.posters && images.posters.length > 0) {
 					const savedPosters = await savePosterUrls(
 						movieId,
@@ -1025,10 +1025,10 @@ adminRoutes.post('/movies/:id/refresh-tmdb', authMiddleware, async (c) => {
 			const movieResponse = await fetch(
 				`https://api.themoviedb.org/3/movie/${tmdbId}?api_key=${c.env.TMDB_API_KEY}`,
 			);
-			const movieData = (await movieResponse.json()) as {
+			const movieData: {
 				original_language?: string;
 				original_title?: string;
-			};
+			} = await movieResponse.json();
 
 			// Always update original language from TMDb
 			if (movieData.original_language) {

--- a/api/src/services/admin-service.ts
+++ b/api/src/services/admin-service.ts
@@ -583,9 +583,9 @@ export class AdminService extends BaseService {
 			throw new Error(`TMDB API error: ${findResponse.statusText}`);
 		}
 
-		const findData = (await findResponse.json()) as {
+		const findData: {
 			movie_results?: Array<{id: number}>;
-		};
+		} = await findResponse.json();
 		if (!findData.movie_results || findData.movie_results.length === 0) {
 			return undefined;
 		}
@@ -601,7 +601,7 @@ export class AdminService extends BaseService {
 			throw new Error(`TMDB API error: ${movieResponse.statusText}`);
 		}
 
-		const movieData = (await movieResponse.json()) as TMDBMovieData;
+		const movieData: TMDBMovieData = await movieResponse.json();
 
 		return {
 			tmdbId,

--- a/api/src/utils/cache.ts
+++ b/api/src/utils/cache.ts
@@ -105,7 +105,10 @@ export class EdgeCache {
 		try {
 			const cached = await this.cache.match(key);
 			if (cached) {
-				const result = (await cached.json()) as {data: unknown; cachedAt: number};
+				const result = (await cached.json()) as {
+					data: unknown;
+					cachedAt: number;
+				};
 				this.metrics.hits++;
 				this.updateHitRate();
 				return result;

--- a/api/src/utils/cache.ts
+++ b/api/src/utils/cache.ts
@@ -105,10 +105,10 @@ export class EdgeCache {
 		try {
 			const cached = await this.cache.match(key);
 			if (cached) {
-				const result = (await cached.json()) as {
+				const result: {
 					data: unknown;
 					cachedAt: number;
-				};
+				} = await cached.json();
 				this.metrics.hits++;
 				this.updateHitRate();
 				return result;

--- a/package.json
+++ b/package.json
@@ -94,6 +94,17 @@
       "**/scripts/**",
       "**/package.json"
     ],
+    "languageOptions": {
+      "parserOptions": {
+        "project": [
+          "./tsconfig.json",
+          "./api/tsconfig.json",
+          "./front/tsconfig.json",
+          "./scrapers/tsconfig.json",
+          "./scripts/tsconfig.json"
+        ]
+      }
+    },
     "rules": {
       "@typescript-eslint/naming-convention": "off",
       "import-x/no-extraneous-dependencies": "off",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
         "warn",
         8
       ],
-      "@typescript-eslint/no-unnecessary-type-assertion": "off",
       "@typescript-eslint/prefer-nullish-coalescing": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:fix": "xo --fix",
     "lint:front": "cd front && npx eslint --ext .ts,.tsx .",
     "lint:front:fix": "cd front && npx eslint --ext .ts,.tsx . --fix",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc -b",
     "check": "concurrently -n \"lint,types\" -c \"yellow,green\" \"xo\" \"tsc --build --noEmit\"",
     "typegen": "cd front && npx react-router typegen"
   },

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "warn",
         8
       ],
+      "@typescript-eslint/no-unnecessary-type-assertion": "off",
       "@typescript-eslint/prefer-nullish-coalescing": [
         "error",
         {

--- a/scrapers/src/cannes-film-festival.ts
+++ b/scrapers/src/cannes-film-festival.ts
@@ -1074,13 +1074,13 @@ async function searchTMDatabaseMovie(
 			throw new Error(`TMDb API error: ${response.statusText}`);
 		}
 
-		const data = (await response.json()) as {
+		const data: {
 			results: Array<{
 				id: number;
 				title: string;
 				release_date: string;
 			}>;
-		};
+		} = await response.json();
 
 		// 結果をフィルタリング
 		const matches = data.results.filter((movie) => {
@@ -1121,10 +1121,10 @@ async function fetchTMDatabaseMovieDetails(
 			throw new Error(`TMDb API error: ${responseEn.statusText}`);
 		}
 
-		const dataEn = (await responseEn.json()) as {
+		const dataEn: {
 			imdb_id?: string;
 			poster_path?: string;
-		};
+		} = await responseEn.json();
 
 		// 日本語版の詳細情報を取得
 		const detailsUrlJa = new URL(`${TMDB_API_BASE_URL}/movie/${movieId}`);
@@ -1136,10 +1136,10 @@ async function fetchTMDatabaseMovieDetails(
 			throw new Error(`TMDb API error: ${responseJa.statusText}`);
 		}
 
-		const dataJa = (await responseJa.json()) as {
+		const dataJa: {
 			title?: string;
 			original_title?: string;
-		};
+		} = await responseJa.json();
 
 		// 日本語タイトルが英語タイトルと異なる場合のみ保存
 		const japaneseTitle =
@@ -1148,8 +1148,8 @@ async function fetchTMDatabaseMovieDetails(
 				: undefined;
 
 		return {
-			imdbId: (dataEn as any).imdb_id || undefined,
-			posterPath: (dataEn as any).poster_path || undefined,
+			imdbId: dataEn.imdb_id || undefined,
+			posterPath: dataEn.poster_path || undefined,
 			japaneseTitle,
 		};
 	} catch (error) {

--- a/scrapers/src/common/tmdb-utilities.ts
+++ b/scrapers/src/common/tmdb-utilities.ts
@@ -89,7 +89,7 @@ export async function fetchTMDBMovieTranslations(
 			throw new Error(`TMDb API error: ${response.statusText}`);
 		}
 
-		const data = (await response.json()) as TMDBTranslationsResponse;
+		const data: TMDBTranslationsResponse = await response.json();
 		return data;
 	} catch (error) {
 		console.error(
@@ -121,7 +121,7 @@ export async function searchTMDBMovie(
 			throw new Error(`TMDb API error: ${responseWithYear.statusText}`);
 		}
 
-		const dataWithYear = (await responseWithYear.json()) as TMDBSearchResponse;
+		const dataWithYear: TMDBSearchResponse = await responseWithYear.json();
 
 		// 年パラメータ付きで結果があった場合
 		if (dataWithYear.results.length > 0) {
@@ -146,7 +146,7 @@ export async function searchTMDBMovie(
 			throw new Error(`TMDb API error: ${responseNoYear.statusText}`);
 		}
 
-		const dataNoYear = (await responseNoYear.json()) as TMDBSearchResponse;
+		const dataNoYear: TMDBSearchResponse = await responseNoYear.json();
 
 		// 年パラメータなしでも結果をフィルタリング
 		const matches = dataNoYear.results.filter((movie) => {
@@ -189,7 +189,7 @@ export async function fetchTMDBMovieDetails(
 			throw new Error(`TMDb API error: ${response.statusText}`);
 		}
 
-		const data = (await response.json()) as TMDBTranslationsResponse;
+		const data: TMDBTranslationsResponse = await response.json();
 		return data;
 	} catch (error) {
 		console.error(
@@ -217,7 +217,7 @@ export async function findTMDBByImdbId(
 			throw new Error(`TMDb API error: ${response.statusText}`);
 		}
 
-		const data = (await response.json()) as TMDBFindResponse;
+		const data: TMDBFindResponse = await response.json();
 		const movieResults = data.movie_results;
 
 		if (!movieResults || movieResults.length === 0) {
@@ -315,7 +315,7 @@ export async function fetchTMDBMovieImages(
 			throw new Error(`TMDb API error: ${imagesResponse.statusText}`);
 		}
 
-		const images = (await imagesResponse.json()) as TMDBMovieImages;
+		const images: TMDBMovieImages = await imagesResponse.json();
 		return {images, tmdbId};
 	} catch (error) {
 		console.error(`Error fetching TMDb images for IMDb ID ${imdbId}:`, error);

--- a/scrapers/src/common/tmdb-utilities.ts
+++ b/scrapers/src/common/tmdb-utilities.ts
@@ -189,7 +189,7 @@ export async function fetchTMDBMovieDetails(
 			throw new Error(`TMDb API error: ${response.statusText}`);
 		}
 
-		const data: TMDBTranslationsResponse = await response.json();
+		const data: TMDBMovieData = await response.json();
 		return data;
 	} catch (error) {
 		console.error(

--- a/scrapers/src/japan-academy-awards.ts
+++ b/scrapers/src/japan-academy-awards.ts
@@ -983,9 +983,9 @@ async function fetchEnglishTitleFromTMDB(
 			return undefined;
 		}
 
-		const data = (await response.json()) as {
+		const data: {
 			movie_results?: Array<{title: string}>;
-		};
+		} = await response.json();
 		const movieResults = data.movie_results;
 
 		if (!movieResults || movieResults.length === 0) {

--- a/scrapers/src/japanese-translations/scrapers/tmdb-scraper.ts
+++ b/scrapers/src/japanese-translations/scrapers/tmdb-scraper.ts
@@ -50,9 +50,9 @@ export async function fetchJapaneseTitleFromTMDB(
 				throw new Error(`TMDb API error: ${findResponse.statusText}`);
 			}
 
-			const findData = (await findResponse.json()) as {
+			const findData: {
 				movie_results?: Array<{id: number}>;
-			};
+			} = await findResponse.json();
 			const movieResults = findData.movie_results;
 
 			if (!movieResults || movieResults.length === 0) {
@@ -77,10 +77,10 @@ export async function fetchJapaneseTitleFromTMDB(
 			throw new Error(`TMDb API error: ${movieResponse.statusText}`);
 		}
 
-		const movieData = (await movieResponse.json()) as {
+		const movieData: {
 			title?: string;
 			original_title?: string;
-		};
+		} = await movieResponse.json();
 
 		// 日本語タイトルが取得できたか確認
 		if (movieData.title && movieData.title !== movieData.original_title) {

--- a/scrapers/src/movie-import-from-list.ts
+++ b/scrapers/src/movie-import-from-list.ts
@@ -382,14 +382,14 @@ async function searchMovieOnTMDB(
 			throw new Error(`TMDB API error: ${response.statusText}`);
 		}
 
-		const data = (await response.json()) as {
+		const data: {
 			results: Array<{
 				title: string;
 				release_date?: string;
 				id: number;
 				imdb_id?: string;
 			}>;
-		};
+		} = await response.json();
 
 		if (data.results.length === 0) {
 			return undefined;

--- a/scrapers/src/movie-import-from-list.ts
+++ b/scrapers/src/movie-import-from-list.ts
@@ -22,8 +22,18 @@ type TMDBMovieData = {
 	overview: string;
 };
 
+type TMDBMovieSearchResult = {
+	id: number;
+	title: string;
+	original_title?: string;
+	release_date?: string;
+	poster_path?: string;
+	imdb_id?: string;
+	overview?: string;
+};
+
 type TMDBSearchResponse = {
-	results: TMDBMovieData[];
+	results: TMDBMovieSearchResult[];
 	total_results: number;
 };
 
@@ -382,14 +392,7 @@ async function searchMovieOnTMDB(
 			throw new Error(`TMDB API error: ${response.statusText}`);
 		}
 
-		const data: {
-			results: Array<{
-				title: string;
-				release_date?: string;
-				id: number;
-				imdb_id?: string;
-			}>;
-		} = await response.json();
+		const data: TMDBSearchResponse = await response.json();
 
 		if (data.results.length === 0) {
 			return undefined;
@@ -397,13 +400,22 @@ async function searchMovieOnTMDB(
 
 		// 最初の結果を返す（最も関連性が高いとされる）
 		const movie = data.results[0];
+		const sanitizedMovie: TMDBMovieData = {
+			id: movie.id,
+			title: movie.title,
+			original_title: movie.original_title ?? movie.title,
+			release_date: movie.release_date ?? '',
+			poster_path: movie.poster_path ?? undefined,
+			imdb_id: movie.imdb_id ?? undefined,
+			overview: movie.overview ?? '',
+		};
 		console.log(
-			`  Found on TMDB: ${movie.title} (${
-				movie.release_date?.split('-')[0] || 'Unknown'
+			`  Found on TMDB: ${sanitizedMovie.title} (${
+				sanitizedMovie.release_date.split('-')[0] || 'Unknown'
 			})`,
 		);
 
-		return movie;
+		return sanitizedMovie;
 	} catch (error) {
 		console.error(`Error searching TMDB for ${title}:`, error);
 		return undefined;

--- a/scrapers/src/movie-posters.ts
+++ b/scrapers/src/movie-posters.ts
@@ -81,10 +81,10 @@ async function getMoviesWithImdbId(limit = 10): Promise<MovieWithImdbId[]> {
 
 	const filteredMoviesWithoutPosters = moviesWithoutPosters
 		.filter((movie) => movie.imdbId !== null)
-		.map((movie) => ({
+		.map<MovieWithImdbId>((movie) => ({
 			...movie,
 			tmdbId: movie.tmdbId ?? undefined,
-		})) as MovieWithImdbId[];
+		}));
 
 	if (filteredMoviesWithoutPosters.length > 0) {
 		return filteredMoviesWithoutPosters;
@@ -103,10 +103,10 @@ async function getMoviesWithImdbId(limit = 10): Promise<MovieWithImdbId[]> {
 	const filteredMoviesWithoutPostersButWithTmdb =
 		moviesWithoutPostersButWithTmdb
 			.filter((movie) => movie.imdbId !== null)
-			.map((movie) => ({
+			.map<MovieWithImdbId>((movie) => ({
 				...movie,
 				tmdbId: movie.tmdbId ?? undefined,
-			})) as MovieWithImdbId[];
+			}));
 
 	if (filteredMoviesWithoutPostersButWithTmdb.length > 0) {
 		return filteredMoviesWithoutPostersButWithTmdb;
@@ -121,10 +121,10 @@ async function getMoviesWithImdbId(limit = 10): Promise<MovieWithImdbId[]> {
 
 	return moviesWithImdbIdNoTmdb
 		.filter((movie) => movie.imdbId !== null)
-		.map((movie) => ({
+		.map<MovieWithImdbId>((movie) => ({
 			...movie,
 			tmdbId: movie.tmdbId ?? undefined,
-		})) as MovieWithImdbId[];
+		}));
 }
 
 async function fetchMovieImages(
@@ -145,9 +145,9 @@ async function fetchMovieImages(
 			throw new Error(`TMDb API error: ${findResponse.statusText}`);
 		}
 
-		const findData = (await findResponse.json()) as {
+		const findData: {
 			movie_results?: Array<{id: number}>;
-		};
+		} = await findResponse.json();
 		const movieResults = findData.movie_results;
 
 		if (!movieResults || movieResults.length === 0) {
@@ -165,7 +165,7 @@ async function fetchMovieImages(
 			throw new Error(`TMDb API error: ${imagesResponse.statusText}`);
 		}
 
-		const images = (await imagesResponse.json()) as TMDBMovieImages;
+		const images: TMDBMovieImages = await imagesResponse.json();
 		return {images, tmdbId};
 	} catch (error) {
 		console.error(`Error fetching TMDb images for IMDb ID ${imdbId}:`, error);
@@ -374,7 +374,7 @@ async function fetchAndStorePosterUrls(limit = 10): Promise<{
 					throw new Error(`TMDb API error: ${imagesResponse.statusText}`);
 				}
 
-				const images = (await imagesResponse.json()) as TMDBMovieImages;
+				const images: TMDBMovieImages = await imagesResponse.json();
 
 				if (!images.posters || images.posters.length === 0) {
 					result.error = 'No posters found';

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": false,
+		"module": "commonjs",
+		"moduleResolution": "node16",
+		"target": "es2022",
+		"types": ["node"],
+		"noEmit": true,
+		"esModuleInterop": true
+	},
+	"include": ["./**/*.cjs"]
+}


### PR DESCRIPTION
## Summary
- ensure TMDb movie detail responses are treated as `TMDBMovieData`
- normalize TMDb search responses before persisting scraper data
- add helpers to filter database rows to movies with IMDb IDs

## Testing
- pnpm exec tsc --project scrapers/tsconfig.json --noEmit
- pnpm lint