### PR TITLE
U-NEXTにあるのに「なし」と判定される映画を修正

### DIFF
--- a/apps/scrapers/src/availability/__tests__/alternative-titles.test.ts
+++ b/apps/scrapers/src/availability/__tests__/alternative-titles.test.ts
@@ -1,0 +1,97 @@
+import {describe, expect, it, vi} from 'vitest';
+import {fetchJapaneseAlternativeTitles} from '../alternative-titles';
+
+const alternativeTitlesResponse = {
+  id: 18_747,
+  titles: [
+    {iso_3166_1: 'US', title: 'Election'},
+    {iso_3166_1: 'DE', title: 'Election 1'},
+    {iso_3166_1: 'JP', title: 'エレクション'},
+    {iso_3166_1: 'JP', title: 'エレクション 黒社会'},
+    {iso_3166_1: 'JP', title: 'エレクション：2005'},
+  ],
+};
+
+describe('fetchJapaneseAlternativeTitles', () => {
+  it('returns only titles registered for JP', async () => {
+    const fetchSpy = vi.fn<
+      (url: string, init?: RequestInit) => Promise<Response>
+    >(async () => Response.json(alternativeTitlesResponse));
+
+    const titles = await fetchJapaneseAlternativeTitles(
+      18_747,
+      'api-key',
+      fetchSpy,
+    );
+
+    expect(titles).toEqual([
+      'エレクション',
+      'エレクション 黒社会',
+      'エレクション：2005',
+    ]);
+  });
+
+  it('requests the alternative_titles endpoint of the given movie', async () => {
+    const fetchSpy = vi.fn<
+      (url: string, init?: RequestInit) => Promise<Response>
+    >(async () => Response.json(alternativeTitlesResponse));
+
+    await fetchJapaneseAlternativeTitles(18_747, 'api-key', fetchSpy);
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toContain(
+      '/movie/18747/alternative_titles',
+    );
+  });
+
+  it('drops empty and duplicated titles', async () => {
+    const fetchSpy = vi.fn(async () =>
+      Response.json({
+        titles: [
+          {iso_3166_1: 'JP', title: 'エレクション'},
+          {iso_3166_1: 'JP', title: 'エレクション'},
+          {iso_3166_1: 'JP', title: '  '},
+          {iso_3166_1: 'JP'},
+        ],
+      }),
+    );
+
+    const titles = await fetchJapaneseAlternativeTitles(
+      18_747,
+      'api-key',
+      fetchSpy,
+    );
+
+    expect(titles).toEqual(['エレクション']);
+  });
+
+  it('returns an empty list on HTTP failure', async () => {
+    const fetchSpy = vi.fn(
+      async () => new Response('unauthorized', {status: 401}),
+    );
+
+    await expect(
+      fetchJapaneseAlternativeTitles(18_747, 'api-key', fetchSpy),
+    ).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when fetch throws', async () => {
+    const failingFetch = vi.fn(async () => {
+      throw new Error('dns failure');
+    });
+
+    await expect(
+      fetchJapaneseAlternativeTitles(18_747, 'api-key', failingFetch),
+    ).resolves.toEqual([]);
+  });
+
+  it('returns an empty list without an API key', async () => {
+    const fetchSpy = vi.fn(async () =>
+      Response.json(alternativeTitlesResponse),
+    );
+
+    await expect(
+      fetchJapaneseAlternativeTitles(18_747, '', fetchSpy),
+    ).resolves.toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/scrapers/src/availability/__tests__/run.test.ts
+++ b/apps/scrapers/src/availability/__tests__/run.test.ts
@@ -434,11 +434,98 @@ describe('createApiClient', () => {
   });
 });
 
+const alternativeTitleMovie = {
+  uid: 'movie-a',
+  titles: ['エレクション'],
+  tmdbId: 18_747,
+};
+
+const buildAlternativeTitleFetchStub = () =>
+  vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(async url => {
+    if (url.includes('/alternative_titles')) {
+      return Response.json({
+        titles: [
+          {iso_3166_1: 'US', title: 'Election'},
+          {iso_3166_1: 'JP', title: 'エレクション 黒社会'},
+        ],
+      });
+    }
+
+    return Response.json({
+      data: {
+        webfront_videoFreewordSearch: {
+          titles: [{titleName: 'エレクション 黒社会'}],
+        },
+      },
+    });
+  });
+
 describe('buildSourceRunners', () => {
   it('does not include geo (blocked with constant HTTP 403)', () => {
     const runners = buildSourceRunners({
       environment: {TURSO_DATABASE_URL: '', TURSO_AUTH_TOKEN: ''},
     });
     expect(Object.keys(runners)).toEqual(['tmdb', 'unext', 'discas']);
+  });
+
+  describe('with TMDb Japanese alternative titles', () => {
+    it('matches a U-NEXT title that only appears as an alternative title', async () => {
+      const runners = buildSourceRunners({
+        environment: {
+          TURSO_DATABASE_URL: '',
+          TURSO_AUTH_TOKEN: '',
+          TMDB_API_KEY: 'api-key',
+        },
+        fetchImpl: buildAlternativeTitleFetchStub(),
+        waitMs: 0,
+      });
+
+      const result = await runners.unext!(alternativeTitleMovie);
+
+      expect(result.status).toBe('ok');
+    });
+
+    it('keeps the primary title as the search query', async () => {
+      const fetchStub = buildAlternativeTitleFetchStub();
+      const runners = buildSourceRunners({
+        environment: {
+          TURSO_DATABASE_URL: '',
+          TURSO_AUTH_TOKEN: '',
+          TMDB_API_KEY: 'api-key',
+        },
+        fetchImpl: fetchStub,
+        waitMs: 0,
+      });
+
+      await runners.unext!(alternativeTitleMovie);
+
+      const searchCall = fetchStub.mock.calls.find(call =>
+        call[0].includes('cc.unext.jp'),
+      );
+      expect(decodeURIComponent(searchCall![0])).toContain(
+        '"query":"エレクション"',
+      );
+    });
+
+    it('fetches alternative titles only once per movie', async () => {
+      const fetchStub = buildAlternativeTitleFetchStub();
+      const runners = buildSourceRunners({
+        environment: {
+          TURSO_DATABASE_URL: '',
+          TURSO_AUTH_TOKEN: '',
+          TMDB_API_KEY: 'api-key',
+        },
+        fetchImpl: fetchStub,
+        waitMs: 0,
+      });
+
+      await runners.unext!(alternativeTitleMovie);
+      await runners.unext!(alternativeTitleMovie);
+
+      const alternativeTitleCalls = fetchStub.mock.calls.filter(call =>
+        call[0].includes('/alternative_titles'),
+      );
+      expect(alternativeTitleCalls).toHaveLength(1);
+    });
   });
 });

--- a/apps/scrapers/src/availability/__tests__/title-match.test.ts
+++ b/apps/scrapers/src/availability/__tests__/title-match.test.ts
@@ -132,7 +132,7 @@ describe('titleMatches', () => {
     ).toBe(true);
   });
 
-  it('matches the content inside double angle brackets', () => {
-    expect(titleMatches('無防備都市《ローマ》', ['ローマ'])).toBe(true);
+  it('does not match a different film named inside double angle brackets', () => {
+    expect(titleMatches('無防備都市《ローマ》', ['ローマ'])).toBe(false);
   });
 });

--- a/apps/scrapers/src/availability/__tests__/title-match.test.ts
+++ b/apps/scrapers/src/availability/__tests__/title-match.test.ts
@@ -123,4 +123,16 @@ describe('titleMatches', () => {
       ]),
     ).toBe(false);
   });
+
+  it('matches a title decorated with a double angle bracket edition', () => {
+    expect(
+      titleMatches('エルミタージュ幻想《ニューマスター版》', [
+        'エルミタージュ幻想',
+      ]),
+    ).toBe(true);
+  });
+
+  it('matches the content inside double angle brackets', () => {
+    expect(titleMatches('無防備都市《ローマ》', ['ローマ'])).toBe(true);
+  });
 });

--- a/apps/scrapers/src/availability/alternative-titles.ts
+++ b/apps/scrapers/src/availability/alternative-titles.ts
@@ -1,0 +1,37 @@
+import type {FetchLike} from './types';
+
+type AlternativeTitlesResponse = {
+  titles?: Array<{iso_3166_1?: string; title?: string}>;
+};
+
+// U-NEXTやDISCASは邦題の別表記(副題付きなど)で登録されていることがあるため、
+// TMDbのJP別題を照合対象に加える。取得できなくてもチェックは継続する。
+export async function fetchJapaneseAlternativeTitles(
+  tmdbId: number,
+  apiKey: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<string[]> {
+  if (!apiKey) {
+    return [];
+  }
+
+  const url = `https://api.themoviedb.org/3/movie/${tmdbId}/alternative_titles?api_key=${apiKey}`;
+
+  try {
+    const response = await fetchImpl(url);
+    if (!response.ok) {
+      return [];
+    }
+
+    const body = (await response.json()) as AlternativeTitlesResponse;
+    const japaneseTitles = (body.titles ?? [])
+      .filter(entry => entry.iso_3166_1 === 'JP')
+      .map(entry => entry.title?.trim() ?? '')
+      .filter(title => title !== '');
+
+    return [...new Set(japaneseTitles)];
+  } catch (error) {
+    console.error(`Failed to fetch alternative titles for ${tmdbId}:`, error);
+    return [];
+  }
+}

--- a/apps/scrapers/src/availability/run.ts
+++ b/apps/scrapers/src/availability/run.ts
@@ -7,10 +7,12 @@ import {
   saveJapaneseTranslation,
   saveTMDBId,
 } from '../common/tmdb-utilities';
+import {fetchJapaneseAlternativeTitles} from './alternative-titles';
 import {hasJapaneseText} from './title-match';
 import {
   checkMovieAvailability,
   deleteNonOkChecks,
+  type MovieToCheck,
   type SourceRunners,
 } from './checker';
 import {
@@ -253,6 +255,27 @@ export function buildSourceRunners(options: {
   const fetchImpl = options.fetchImpl ?? fetch;
   const waitMs = options.waitMs ?? SCRAPE_WAIT_MS;
   const tmdbApiKey = options.environment.TMDB_API_KEY ?? '';
+  const alternativeTitlesCache = new Map<string, Promise<string[]>>();
+
+  // 検索クエリは先頭のタイトルが使われるため、別題は必ず後ろに足す
+  async function titlesForSearch(movie: MovieToCheck): Promise<string[]> {
+    if (!movie.tmdbId) {
+      return movie.titles;
+    }
+
+    let pending = alternativeTitlesCache.get(movie.uid);
+    if (!pending) {
+      pending = fetchJapaneseAlternativeTitles(
+        movie.tmdbId,
+        tmdbApiKey,
+        fetchImpl,
+      );
+      alternativeTitlesCache.set(movie.uid, pending);
+    }
+
+    const alternativeTitles = await pending;
+    return [...new Set([...movie.titles, ...alternativeTitles])];
+  }
 
   return {
     async tmdb(movie) {
@@ -277,11 +300,11 @@ export function buildSourceRunners(options: {
     },
     async unext(movie) {
       await sleep(waitMs);
-      return checkUnext(movie.titles, fetchImpl);
+      return checkUnext(await titlesForSearch(movie), fetchImpl);
     },
     async discas(movie) {
       await sleep(waitMs);
-      return checkDiscas(movie.titles, fetchImpl);
+      return checkDiscas(await titlesForSearch(movie), fetchImpl);
     },
   };
 }

--- a/apps/scrapers/src/availability/title-match.ts
+++ b/apps/scrapers/src/availability/title-match.ts
@@ -34,15 +34,23 @@ export function normalizeTitle(title: string): string {
   return result;
 }
 
+// 《》は版表記などの注釈にしか使われないため、除去のみ行い中身は照合しない
+const annotationPattern = /[（(《][^）)》]*[）)》]/g;
+const parenthesizedTitlePattern = /[（(]([^）)]+)[）)]/g;
+
 function candidateVariants(candidate: string): string[] {
   const variants = [candidate];
-  const parenSegments = [...candidate.matchAll(/[（(《]([^）)》]+)[）)》]/g)];
-  if (parenSegments.length > 0) {
-    variants.push(
-      candidate.replaceAll(/[（(《][^）)》]*[）)》]/g, ' '),
-      ...parenSegments.map(segment => segment[1]),
-    );
+
+  const withoutAnnotations = candidate.replaceAll(annotationPattern, ' ');
+  if (withoutAnnotations !== candidate) {
+    variants.push(withoutAnnotations);
   }
+
+  variants.push(
+    ...[...candidate.matchAll(parenthesizedTitlePattern)].map(
+      segment => segment[1],
+    ),
+  );
 
   return variants;
 }

--- a/apps/scrapers/src/availability/title-match.ts
+++ b/apps/scrapers/src/availability/title-match.ts
@@ -36,10 +36,10 @@ export function normalizeTitle(title: string): string {
 
 function candidateVariants(candidate: string): string[] {
   const variants = [candidate];
-  const parenSegments = [...candidate.matchAll(/[（(]([^）)]+)[）)]/g)];
+  const parenSegments = [...candidate.matchAll(/[（(《]([^）)》]+)[）)》]/g)];
   if (parenSegments.length > 0) {
     variants.push(
-      candidate.replaceAll(/[（(][^）)]*[）)]/g, ' '),
+      candidate.replaceAll(/[（(《][^）)》]*[）)》]/g, ' '),
       ...parenSegments.map(segment => segment[1]),
     );
   }

--- a/apps/scrapers/src/japanese-translations-cli.ts
+++ b/apps/scrapers/src/japanese-translations-cli.ts
@@ -29,6 +29,7 @@ async function main() {
     const arguments_ = process.argv.slice(2);
     const limitIndex = arguments_.indexOf('--limit');
     const isAllMode = arguments_.includes('--all');
+    const includeNonJapanese = arguments_.includes('--include-non-japanese');
 
     let batchSize = DEFAULT_BATCH_SIZE;
 
@@ -59,10 +60,15 @@ async function main() {
     const database = getDatabase(environment);
 
     // 日本語翻訳が未登録の映画データを取得
-    console.log('日本語翻訳が未登録の映画を検索中...');
+    console.log(
+      includeNonJapanese
+        ? '日本語翻訳が未登録、または原題のまま保存されている映画を検索中...'
+        : '日本語翻訳が未登録の映画を検索中...',
+    );
     const movies = await getMoviesWithoutJapaneseTranslation(
       database,
       batchSize,
+      includeNonJapanese,
     );
 
     if (movies.length === 0) {
@@ -166,6 +172,9 @@ function showUsage() {
   console.log('  --limit <数値>  処理する映画の件数を指定 (デフォルト: 20)');
   console.log(
     '  --all           全件処理モード（日本語翻訳がないすべての映画を処理）',
+  );
+  console.log(
+    '  --include-non-japanese  原題がそのまま ja として保存されている映画も取得し直す',
   );
   console.log('  --help, -h      このヘルプを表示');
   console.log('');

--- a/apps/scrapers/src/japanese-translations/repository.ts
+++ b/apps/scrapers/src/japanese-translations/repository.ts
@@ -11,7 +11,8 @@ import {selectMoviesNeedingJapaneseTitle} from './select-targets';
  */
 export type Movie = {
   uid: string;
-  imdbId: string;
+  /** movies.imdb_id は NULL 許容。無効値のまま外部検索に渡さないこと */
+  imdbId: string | undefined;
   englishTitle: string;
   year?: number;
   tmdbId: number | undefined;
@@ -47,6 +48,7 @@ export async function getMoviesWithoutJapaneseTranslation(
       imdbId: movies.imdbId,
       year: movies.year,
       tmdbId: movies.tmdbId,
+      englishTitle: translations.content,
     })
     .from(movies)
     .innerJoin(
@@ -65,13 +67,19 @@ export async function getMoviesWithoutJapaneseTranslation(
       : await moviesWithEnglishTitlesQuery.limit(limit * 5);
 
   // 映画UIDと英語タイトルのマッピングを作成
-  const movieData = new Map();
+  // englishTitle は上のJOINで取得済み（1件ずつ引き直すとN+1になる）
+  const movieData = new Map<string, Movie>();
   for (const movie of moviesWithEnglishTitles) {
+    if (!movie.englishTitle) {
+      continue;
+    }
+
     movieData.set(movie.movieUid, {
       uid: movie.movieUid,
-      imdbId: movie.imdbId,
-      year: movie.year,
-      tmdbId: movie.tmdbId,
+      imdbId: movie.imdbId ?? undefined,
+      year: movie.year ?? undefined,
+      tmdbId: movie.tmdbId ?? undefined,
+      englishTitle: movie.englishTitle,
     });
   }
 
@@ -90,56 +98,14 @@ export async function getMoviesWithoutJapaneseTranslation(
     );
 
   const moviesWithoutJapanese = selectMoviesNeedingJapaneseTitle(
-    [...movieData.values()] as Movie[],
+    [...movieData.values()],
     moviesWithJapaneseTitles,
     {includeNonJapanese},
   );
 
-  // 英語タイトルを取得
-  const result = [];
-  const moviesToProcess =
-    limit === 0 ? moviesWithoutJapanese : moviesWithoutJapanese.slice(0, limit);
-
-  for (const movie of moviesToProcess) {
-    const englishTitle = await getMovieTitle(database, movie.uid, 'en');
-    if (englishTitle) {
-      result.push({
-        ...movie,
-        englishTitle,
-      });
-    }
-  }
-
-  return result;
-}
-
-/**
- * 映画のタイトルを言語コードで取得する
- * @param drizzleDb Drizzleデータベース
- * @param movieUid 映画UID
- * @param languageCode 言語コード
- * @returns 映画タイトル
- */
-async function getMovieTitle(
-  database: ReturnType<typeof getDatabase>,
-  movieUid: string,
-  languageCode: string,
-): Promise<string | undefined> {
-  const result = await database
-    .select({
-      content: translations.content,
-    })
-    .from(translations)
-    .where(
-      and(
-        eq(translations.resourceType, 'movie_title'),
-        eq(translations.resourceUid, movieUid),
-        eq(translations.languageCode, languageCode),
-      ),
-    )
-    .limit(1);
-
-  return result.length > 0 ? result[0].content : undefined;
+  return limit === 0
+    ? moviesWithoutJapanese
+    : moviesWithoutJapanese.slice(0, limit);
 }
 
 /**

--- a/apps/scrapers/src/japanese-translations/repository.ts
+++ b/apps/scrapers/src/japanese-translations/repository.ts
@@ -4,6 +4,7 @@
 import {and, eq} from 'drizzle-orm';
 import {type getDatabase} from '@shine/database';
 import {movies, translations} from '@shine/database/schema/index';
+import {selectMoviesNeedingJapaneseTitle} from './select-targets';
 
 /**
  * 日本語翻訳用の型定義
@@ -29,13 +30,15 @@ export type Translation = {
 
 /**
  * 日本語翻訳が未登録の映画データを取得する
- * @param db D1データベース
+ * @param database Drizzleデータベース
  * @param limit 取得件数（0の場合は全件取得）
- * @returns 日本語翻訳が未登録の映画データ
+ * @param includeNonJapanese 原題がそのまま ja として保存されている映画も含める
+ * @returns 取得対象の映画データ
  */
 export async function getMoviesWithoutJapaneseTranslation(
   database: ReturnType<typeof getDatabase>,
   limit = 20,
+  includeNonJapanese = false,
 ): Promise<Movie[]> {
   // 英語タイトルを取得するために、まず英語の翻訳データを含む映画を取得
   const moviesWithEnglishTitlesQuery = database
@@ -76,6 +79,7 @@ export async function getMoviesWithoutJapaneseTranslation(
   const moviesWithJapaneseTitles = await database
     .select({
       movieUid: translations.resourceUid,
+      content: translations.content,
     })
     .from(translations)
     .where(
@@ -85,14 +89,10 @@ export async function getMoviesWithoutJapaneseTranslation(
       ),
     );
 
-  // 日本語翻訳が存在する映画UIDのセットを作成
-  const japaneseMovieUids = new Set(
-    moviesWithJapaneseTitles.map((movie: {movieUid: string}) => movie.movieUid),
-  );
-
-  // 日本語翻訳が存在しない映画のみをフィルタリング
-  const moviesWithoutJapanese = [...movieData.values()].filter(
-    (movie: Movie) => !japaneseMovieUids.has(movie.uid),
+  const moviesWithoutJapanese = selectMoviesNeedingJapaneseTitle(
+    [...movieData.values()] as Movie[],
+    moviesWithJapaneseTitles,
+    {includeNonJapanese},
   );
 
   // 英語タイトルを取得

--- a/apps/scrapers/src/japanese-translations/scrapers/imdb-id.test.ts
+++ b/apps/scrapers/src/japanese-translations/scrapers/imdb-id.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from 'vitest';
+import {isValidImdbId} from './imdb-id';
+
+describe('isValidImdbId', () => {
+  it('tt から始まる7桁以上の数字を有効とする', () => {
+    expect(isValidImdbId('tt0418819')).toBe(true);
+  });
+
+  it('8桁のIMDb IDも有効とする', () => {
+    expect(isValidImdbId('tt12345678')).toBe(true);
+  });
+
+  it('undefinedを無効とする', () => {
+    expect(isValidImdbId(undefined as unknown)).toBe(false);
+  });
+
+  it('nullを無効とする', () => {
+    // eslint-disable-next-line unicorn/no-null
+    expect(isValidImdbId(null)).toBe(false);
+  });
+
+  it('文字列のnullを無効とする', () => {
+    expect(isValidImdbId('null')).toBe(false);
+  });
+
+  it('空文字を無効とする', () => {
+    expect(isValidImdbId('')).toBe(false);
+  });
+
+  it('tt が付かない数字だけの値を無効とする', () => {
+    expect(isValidImdbId('0418819')).toBe(false);
+  });
+
+  it('桁数が足りない値を無効とする', () => {
+    expect(isValidImdbId('tt123')).toBe(false);
+  });
+});

--- a/apps/scrapers/src/japanese-translations/scrapers/imdb-id.ts
+++ b/apps/scrapers/src/japanese-translations/scrapers/imdb-id.ts
@@ -1,0 +1,12 @@
+const IMDB_ID_PATTERN = /^tt\d{7,}$/;
+
+/**
+ * IMDb ID として妥当な文字列かを判定する。
+ *
+ * movies.imdb_id は NULL を許容しており、値が無いまま Wikipedia 検索へ渡すと
+ * `?search=null` で「Null」という無関係な記事にヒットし、それを邦題として
+ * 保存してしまう事故が起きた。検索前に必ずこの関数で弾くこと。
+ */
+export function isValidImdbId(value: unknown): value is string {
+  return typeof value === 'string' && IMDB_ID_PATTERN.test(value);
+}

--- a/apps/scrapers/src/japanese-translations/scrapers/tmdb-scraper.ts
+++ b/apps/scrapers/src/japanese-translations/scrapers/tmdb-scraper.ts
@@ -1,6 +1,7 @@
 import {eq} from 'drizzle-orm';
 import {getDatabase, type Environment} from '@shine/database';
 import {movies} from '@shine/database/schema/movies';
+import {isValidImdbId} from './imdb-id';
 
 const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
 
@@ -12,7 +13,7 @@ const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
  * @returns 日本語タイトル（見つからない場合はundefined）
  */
 export async function fetchJapaneseTitleFromTMDB(
-  imdbId: string,
+  imdbId: string | undefined,
   tmdbId: number | undefined,
   environment: Environment,
 ): Promise<string | undefined> {
@@ -28,6 +29,11 @@ export async function fetchJapaneseTitleFromTMDB(
 
     // TMDB IDがない場合は、IMDb IDから検索
     if (!movieTmdbId) {
+      if (!isValidImdbId(imdbId)) {
+        console.log(`  Skipped TMDb lookup: no TMDb ID and invalid IMDb ID`);
+        return undefined;
+      }
+
       console.log(`  TMDB ID not found, searching by IMDb ID: ${imdbId}`);
 
       const findUrl = new URL(`${TMDB_API_BASE_URL}/find/${imdbId}`);

--- a/apps/scrapers/src/japanese-translations/scrapers/wikipedia-scraper.ts
+++ b/apps/scrapers/src/japanese-translations/scrapers/wikipedia-scraper.ts
@@ -8,6 +8,7 @@ import {
   extractWikipediaJsonLD,
   parseHTML,
 } from '../../common/parser-utilities';
+import {isValidImdbId} from './imdb-id';
 
 /**
  * IMDb IDからWikipedia日本語版の映画タイトルを取得
@@ -15,8 +16,15 @@ import {
  * @returns 日本語タイトル (見つからない場合はundefined)
  */
 export async function scrapeJapaneseTitleFromWikipedia(
-  imdbId: string,
+  imdbId: string | undefined,
 ): Promise<string | undefined> {
+  // IMDb ID が無いまま検索すると ?search=null で「Null」の記事にヒットし、
+  // それを邦題として保存してしまうため、必ず形式を検証してから進む
+  if (!isValidImdbId(imdbId)) {
+    console.log(`Skipped Wikipedia lookup for invalid IMDb ID: ${imdbId}`);
+    return undefined;
+  }
+
   try {
     // まずIMDb IDで日本語版Wikipediaを検索
     const searchUrl = `https://ja.wikipedia.org/w/index.php?search=${imdbId}`;

--- a/apps/scrapers/src/japanese-translations/select-targets.test.ts
+++ b/apps/scrapers/src/japanese-translations/select-targets.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from 'vitest';
+import {selectMoviesNeedingJapaneseTitle} from './select-targets';
+
+const movie = (uid: string) => ({
+  uid,
+  imdbId: `tt${uid}`,
+  englishTitle: `Title ${uid}`,
+  year: 2000,
+  tmdbId: undefined,
+});
+
+const candidates = [movie('a'), movie('b'), movie('c')];
+
+const existing = [
+  {movieUid: 'b', content: '恋人たち'},
+  {movieUid: 'c', content: 'Pather Panchali'},
+];
+
+describe('selectMoviesNeedingJapaneseTitle', () => {
+  it('ja翻訳が無い映画は対象になる', () => {
+    const result = selectMoviesNeedingJapaneseTitle(candidates, existing, {
+      includeNonJapanese: false,
+    });
+
+    expect(result.map(m => m.uid)).toContain('a');
+  });
+
+  it('日本語文字を含むja翻訳がある映画は対象外', () => {
+    const result = selectMoviesNeedingJapaneseTitle(candidates, existing, {
+      includeNonJapanese: false,
+    });
+
+    expect(result.map(m => m.uid)).not.toContain('b');
+  });
+
+  it('既定では英字のみのja翻訳がある映画は対象外', () => {
+    const result = selectMoviesNeedingJapaneseTitle(candidates, existing, {
+      includeNonJapanese: false,
+    });
+
+    expect(result.map(m => m.uid)).not.toContain('c');
+  });
+
+  it('includeNonJapaneseを指定すると英字のみのja翻訳がある映画も対象になる', () => {
+    const result = selectMoviesNeedingJapaneseTitle(candidates, existing, {
+      includeNonJapanese: true,
+    });
+
+    expect(result.map(m => m.uid)).toContain('c');
+  });
+
+  it('includeNonJapaneseを指定しても日本語文字を含む映画は対象外のまま', () => {
+    const result = selectMoviesNeedingJapaneseTitle(candidates, existing, {
+      includeNonJapanese: true,
+    });
+
+    expect(result.map(m => m.uid)).not.toContain('b');
+  });
+
+  it('カタカナのみのja翻訳は日本語として扱い対象外にする', () => {
+    const result = selectMoviesNeedingJapaneseTitle(
+      [movie('d')],
+      [{movieUid: 'd', content: 'ランド・オブ・ザ・デッド'}],
+      {includeNonJapanese: true},
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('記号混じりでも日本語文字を含めば対象外にする', () => {
+    const result = selectMoviesNeedingJapaneseTitle(
+      [movie('e')],
+      [{movieUid: 'e', content: 'M/OTHER 大河のうた'}],
+      {includeNonJapanese: true},
+    );
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/apps/scrapers/src/japanese-translations/select-targets.ts
+++ b/apps/scrapers/src/japanese-translations/select-targets.ts
@@ -1,0 +1,29 @@
+import {hasJapaneseText} from '../availability/title-match';
+import {type Movie} from './repository';
+
+type ExistingJapaneseTitle = {
+  movieUid: string;
+  content: string;
+};
+
+type SelectOptions = {
+  /**
+   * 原題がそのまま ja の translation として保存されている映画も対象に含める。
+   * 例: "Pather Panchali"（邦題は「大地のうた」）
+   */
+  includeNonJapanese: boolean;
+};
+
+export function selectMoviesNeedingJapaneseTitle<T extends Pick<Movie, 'uid'>>(
+  candidates: T[],
+  existingJapaneseTitles: ExistingJapaneseTitle[],
+  {includeNonJapanese}: SelectOptions,
+): T[] {
+  const satisfied = new Set(
+    existingJapaneseTitles
+      .filter(row => !includeNonJapanese || hasJapaneseText(row.content))
+      .map(row => row.movieUid),
+  );
+
+  return candidates.filter(candidate => !satisfied.has(candidate.uid));
+}


### PR DESCRIPTION
トップページの「エルミタージュ幻想」「エレクション」がU-NEXTで配信されているのにバッジが出ていなかった。原因はタイトル照合の取りこぼし2種。

- U-NEXT側が `エルミタージュ幻想《ニューマスター版》` で登録されており、`《》` を装飾として扱っていなかった。丸括弧と同じくvariantとして分解するようにした。
- U-NEXT側が `エレクション 黒社会` で登録されており、DBの邦題「エレクション」と一致しなかった。TMDbのJP別題を照合対象に加えた。検索クエリには先頭のタイトルが使われるので、別題は末尾に足している。

本番DBには90日TTLの `ng` キャッシュが残っていたので、`unext`/`discas` が最新で非okだった15本のキャッシュを削除して再チェック済み。両作品とも `ok` になり、本番サイトにU-NEXTバッジが出ることを確認した。

再チェック中に `Tico-Tico no Fubá` がU-NEXTの音楽ライブ映像 `Tico-Tico No Fubá (Live On The Ed Sullivan Show, October 19, 1958)` に誤マッチしたため、その行は削除した。日本語タイトルを持たない映画を英語原題で照合すると誤マッチしやすい点は既存の課題として残っている。

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x