### PR TITLE
APIの認証・セキュリティ強化（JWT有効期限、loginレートリミット、SSRF対策）

### DIFF
--- a/apps/api/src/__tests__/app-auth.test.ts
+++ b/apps/api/src/__tests__/app-auth.test.ts
@@ -1,0 +1,69 @@
+import {SignJWT} from 'jose';
+import {describe, expect, it} from 'vitest';
+import {createJWT} from '../auth';
+import app from '../index';
+
+const JWT_SECRET = 'test-jwt-secret';
+
+const environment = {
+  JWT_SECRET,
+} as never;
+
+describe('admin routes authentication (via app.request)', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const response = await app.request('/admin/movies', {}, environment);
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as {
+      code: string;
+      details: {reason: string};
+    };
+    expect(body.code).toBe('AUTHENTICATION_ERROR');
+    expect(body.details.reason).toBe('MISSING_TOKEN');
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    const response = await app.request(
+      '/admin/movies',
+      {headers: {Authorization: 'Bearer invalid-token'}},
+      environment,
+    );
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as {
+      code: string;
+      details: {reason: string};
+    };
+    expect(body.code).toBe('AUTHENTICATION_ERROR');
+    expect(body.details.reason).toBe('INVALID_TOKEN');
+  });
+
+  it('returns 401 when token is expired', async () => {
+    const secretKey = new TextEncoder().encode(JWT_SECRET);
+    const expiredToken = await new SignJWT({role: 'admin'})
+      .setProtectedHeader({alg: 'HS256'})
+      .setIssuedAt()
+      .setExpirationTime('-1s')
+      .sign(secretKey);
+
+    const response = await app.request(
+      '/admin/movies',
+      {headers: {Authorization: `Bearer ${expiredToken}`}},
+      environment,
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('createJWT', () => {
+  it('issues tokens with an expiration time', async () => {
+    const token = await createJWT(JWT_SECRET);
+    const payload = JSON.parse(
+      Buffer.from(token.split('.')[1], 'base64url').toString(),
+    ) as {exp?: number; iat?: number};
+
+    expect(payload.exp).toBeDefined();
+    expect(payload.exp).toBeGreaterThan(payload.iat!);
+  });
+});

--- a/apps/api/src/__tests__/fetch-url-title.test.ts
+++ b/apps/api/src/__tests__/fetch-url-title.test.ts
@@ -1,0 +1,94 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import app from '../index';
+
+const environment = {} as never;
+
+const postUrl = async (url: unknown) =>
+  app.request(
+    '/fetch-url-title',
+    {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({url}),
+    },
+    environment,
+  );
+
+describe('POST /fetch-url-title', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  it('returns the page title for an allowed URL', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('<html><head><title>Example Article</title></head></html>', {
+        status: 200,
+      }),
+    );
+
+    const response = await postUrl('https://example.com/article');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({title: 'Example Article'});
+  });
+
+  it('rejects private addresses without fetching', async () => {
+    const response = await postUrl('http://127.0.0.1/admin');
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects internal hostnames without fetching', async () => {
+    const response = await postUrl('http://localhost:8787/');
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-http protocols without fetching', async () => {
+    const response = await postUrl('file:///etc/passwd');
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects redirects to private addresses', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(undefined, {
+        status: 302,
+        headers: {Location: 'http://169.254.169.254/latest/meta-data/'},
+      }),
+    );
+
+    const response = await postUrl('https://example.com/redirect');
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows redirects to allowed URLs', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(undefined, {
+          status: 301,
+          headers: {Location: 'https://other.example.com/page'},
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('<title>Redirected</title>', {status: 200}),
+      );
+
+    const response = await postUrl('https://example.com/old');
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({title: 'Redirected'});
+  });
+});

--- a/apps/api/src/__tests__/login-rate-limit.test.ts
+++ b/apps/api/src/__tests__/login-rate-limit.test.ts
@@ -1,0 +1,111 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {createLoginRateLimiter, loginRateLimiter} from '../login-rate-limiter';
+import app from '../index';
+
+const environment = {
+  ADMIN_PASSWORD: 'correct-password',
+  JWT_SECRET: 'test-jwt-secret',
+} as never;
+
+const login = async (password: string, ip = '203.0.113.1') =>
+  app.request(
+    '/auth/login',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'CF-Connecting-IP': ip,
+      },
+      body: JSON.stringify({password}),
+    },
+    environment,
+  );
+
+describe('createLoginRateLimiter', () => {
+  it('blocks after the configured number of failures within the window', () => {
+    const limiter = createLoginRateLimiter({limit: 3, windowMs: 60_000});
+    const now = 1_000_000;
+
+    limiter.recordFailure('ip-a', now);
+    limiter.recordFailure('ip-a', now + 1);
+    expect(limiter.isBlocked('ip-a', now + 2)).toBe(false);
+
+    limiter.recordFailure('ip-a', now + 3);
+    expect(limiter.isBlocked('ip-a', now + 4)).toBe(true);
+  });
+
+  it('unblocks after the window has passed', () => {
+    const limiter = createLoginRateLimiter({limit: 1, windowMs: 60_000});
+    const now = 1_000_000;
+
+    limiter.recordFailure('ip-a', now);
+    expect(limiter.isBlocked('ip-a', now + 1)).toBe(true);
+    expect(limiter.isBlocked('ip-a', now + 60_001)).toBe(false);
+  });
+
+  it('tracks each key independently', () => {
+    const limiter = createLoginRateLimiter({limit: 1, windowMs: 60_000});
+    const now = 1_000_000;
+
+    limiter.recordFailure('ip-a', now);
+    expect(limiter.isBlocked('ip-a', now + 1)).toBe(true);
+    expect(limiter.isBlocked('ip-b', now + 1)).toBe(false);
+  });
+
+  it('clears failures for a key on demand', () => {
+    const limiter = createLoginRateLimiter({limit: 1, windowMs: 60_000});
+    const now = 1_000_000;
+
+    limiter.recordFailure('ip-a', now);
+    limiter.clear('ip-a');
+    expect(limiter.isBlocked('ip-a', now + 1)).toBe(false);
+  });
+});
+
+describe('POST /auth/login rate limiting', () => {
+  beforeEach(() => {
+    loginRateLimiter.reset();
+  });
+
+  it('returns 429 after repeated failed logins from the same IP', async () => {
+    for (let index = 0; index < 5; index++) {
+      const response = await login('wrong-password');
+      expect(response.status).toBe(401);
+    }
+
+    const blocked = await login('wrong-password');
+    expect(blocked.status).toBe(429);
+    const body = (await blocked.json()) as {code: string};
+    expect(body.code).toBe('RATE_LIMIT_EXCEEDED');
+  });
+
+  it('rejects even correct passwords while blocked', async () => {
+    for (let index = 0; index < 5; index++) {
+      await login('wrong-password');
+    }
+
+    const blocked = await login('correct-password');
+    expect(blocked.status).toBe(429);
+  });
+
+  it('does not rate limit other IPs', async () => {
+    for (let index = 0; index < 5; index++) {
+      await login('wrong-password', '203.0.113.1');
+    }
+
+    const other = await login('correct-password', '203.0.113.2');
+    expect(other.status).toBe(200);
+  });
+
+  it('clears the failure count after a successful login', async () => {
+    for (let index = 0; index < 4; index++) {
+      await login('wrong-password');
+    }
+
+    const success = await login('correct-password');
+    expect(success.status).toBe(200);
+
+    const after = await login('wrong-password');
+    expect(after.status).toBe(401);
+  });
+});

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -16,6 +16,7 @@ export async function createJWT(secret: string): Promise<string> {
   const jwt = await new SignJWT({role: 'admin'})
     .setProtectedHeader({alg: JWT_ALGORITHM})
     .setIssuedAt()
+    .setExpirationTime('7d')
     .sign(secretKey);
 
   return jwt;
@@ -29,7 +30,7 @@ export async function verifyJWT(
     const encoder = new TextEncoder();
     const secretKey = encoder.encode(secret);
 
-    await jwtVerify(token, secretKey);
+    await jwtVerify(token, secretKey, {algorithms: [JWT_ALGORITHM]});
     return true;
   } catch {
     return false;

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -22,6 +22,26 @@ export async function createJWT(secret: string): Promise<string> {
   return jwt;
 }
 
+export async function passwordsMatch(
+  provided: string,
+  expected: string,
+): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const [providedHash, expectedHash] = await Promise.all([
+    crypto.subtle.digest('SHA-256', encoder.encode(provided)),
+    crypto.subtle.digest('SHA-256', encoder.encode(expected)),
+  ]);
+
+  const providedView = new Uint8Array(providedHash);
+  const expectedView = new Uint8Array(expectedHash);
+  let difference = 0;
+  for (const [index, byte] of providedView.entries()) {
+    difference |= byte ^ expectedView[index];
+  }
+
+  return difference === 0;
+}
+
 export async function verifyJWT(
   token: string,
   secret: string,

--- a/apps/api/src/login-rate-limiter.ts
+++ b/apps/api/src/login-rate-limiter.ts
@@ -1,0 +1,44 @@
+type LoginRateLimiterOptions = {
+  limit?: number;
+  windowMs?: number;
+};
+
+export function createLoginRateLimiter(options: LoginRateLimiterOptions = {}) {
+  const limit = options.limit ?? 5;
+  const windowMs = options.windowMs ?? 15 * 60 * 1000;
+  const failures = new Map<string, number[]>();
+
+  const prune = (key: string, now: number): number[] => {
+    const timestamps = (failures.get(key) ?? []).filter(
+      timestamp => now - timestamp < windowMs,
+    );
+    if (timestamps.length > 0) {
+      failures.set(key, timestamps);
+    } else {
+      failures.delete(key);
+    }
+
+    return timestamps;
+  };
+
+  return {
+    limit,
+    windowMs,
+    isBlocked(key: string, now = Date.now()): boolean {
+      return prune(key, now).length >= limit;
+    },
+    recordFailure(key: string, now = Date.now()): void {
+      const timestamps = prune(key, now);
+      timestamps.push(now);
+      failures.set(key, timestamps);
+    },
+    clear(key: string): void {
+      failures.delete(key);
+    },
+    reset(): void {
+      failures.clear();
+    },
+  };
+}
+
+export const loginRateLimiter = createLoginRateLimiter();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,9 +1,11 @@
 import type {Environment} from '@shine/database';
 import {Hono} from 'hono';
-import {createJWT} from '../auth';
+import {createJWT, passwordsMatch} from '../auth';
+import {loginRateLimiter} from '../login-rate-limiter';
 import {
   createAuthenticationError,
   createInternalServerError,
+  createRateLimitError,
   createValidationError,
 } from '../utils/error-handlers';
 
@@ -11,6 +13,15 @@ export const authRoutes = new Hono<{Bindings: Environment}>();
 
 authRoutes.post('/login', async c => {
   try {
+    const clientIp = c.req.header('CF-Connecting-IP') ?? 'unknown';
+    if (loginRateLimiter.isBlocked(clientIp)) {
+      return createRateLimitError(
+        c,
+        Date.now() + loginRateLimiter.windowMs,
+        loginRateLimiter.limit,
+      );
+    }
+
     const {password} = await c.req.json();
 
     if (!password) {
@@ -35,10 +46,12 @@ authRoutes.post('/login', async c => {
       );
     }
 
-    if (password !== c.env.ADMIN_PASSWORD) {
+    if (!(await passwordsMatch(password, c.env.ADMIN_PASSWORD))) {
+      loginRateLimiter.recordFailure(clientIp);
       return createAuthenticationError(c, 'INVALID_CREDENTIALS');
     }
 
+    loginRateLimiter.clear(clientIp);
     const token = await createJWT(c.env.JWT_SECRET);
     return c.json({token});
   } catch (error) {

--- a/apps/api/src/routes/utilities.ts
+++ b/apps/api/src/routes/utilities.ts
@@ -1,5 +1,10 @@
 import type {Environment} from '@shine/database';
 import {Hono} from 'hono';
+import {validateExternalUrl} from '../utils/url-safety';
+
+const MAX_REDIRECTS = 5;
+const FETCH_TIMEOUT_MS = 10_000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 export const utilitiesRoutes = new Hono<{Bindings: Environment}>();
 
@@ -8,26 +13,48 @@ utilitiesRoutes.post('/fetch-url-title', async c => {
   try {
     const {url} = await c.req.json();
 
-    // Validate URL
     if (!url) {
       return c.json({error: 'URL is required'}, 400);
     }
 
-    try {
-      new URL(url);
-    } catch {
-      return c.json({error: 'Invalid URL format'}, 400);
+    const validation = validateExternalUrl(String(url));
+    if (!validation.ok) {
+      return c.json({error: validation.reason}, 400);
     }
 
-    // Fetch URL content
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-      },
-    });
+    let currentUrl = validation.url;
+    let response: Response | undefined;
 
-    if (!response.ok) {
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      response = await fetch(currentUrl.toString(), {
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        },
+        redirect: 'manual',
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+
+      if (!REDIRECT_STATUSES.has(response.status)) {
+        break;
+      }
+
+      const location = response.headers.get('location');
+      if (!location) {
+        break;
+      }
+
+      const nextValidation = validateExternalUrl(
+        new URL(location, currentUrl).toString(),
+      );
+      if (!nextValidation.ok) {
+        return c.json({error: 'Failed to fetch URL'}, 400);
+      }
+
+      currentUrl = nextValidation.url;
+    }
+
+    if (!response?.ok) {
       return c.json({error: 'Failed to fetch URL'}, 400);
     }
 

--- a/apps/api/src/utils/__tests__/url-safety.test.ts
+++ b/apps/api/src/utils/__tests__/url-safety.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'vitest';
+import {validateExternalUrl} from '../url-safety';
+
+describe('validateExternalUrl', () => {
+  it('accepts a normal https URL', () => {
+    expect(validateExternalUrl('https://example.com/article').ok).toBe(true);
+  });
+
+  it('accepts a normal http URL', () => {
+    expect(validateExternalUrl('http://example.com/').ok).toBe(true);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(validateExternalUrl('not a url').ok).toBe(false);
+  });
+
+  it('rejects non-http protocols', () => {
+    expect(validateExternalUrl('file:///etc/passwd').ok).toBe(false);
+    expect(validateExternalUrl('ftp://example.com/').ok).toBe(false);
+    expect(validateExternalUrl('gopher://example.com/').ok).toBe(false);
+  });
+
+  it('rejects localhost', () => {
+    expect(validateExternalUrl('http://localhost/admin').ok).toBe(false);
+    expect(validateExternalUrl('http://LOCALHOST:8080/').ok).toBe(false);
+  });
+
+  it('rejects loopback addresses', () => {
+    expect(validateExternalUrl('http://127.0.0.1/').ok).toBe(false);
+    expect(validateExternalUrl('http://127.1.2.3/').ok).toBe(false);
+    expect(validateExternalUrl('http://[::1]/').ok).toBe(false);
+  });
+
+  it('rejects private IPv4 ranges', () => {
+    expect(validateExternalUrl('http://10.0.0.1/').ok).toBe(false);
+    expect(validateExternalUrl('http://172.16.0.1/').ok).toBe(false);
+    expect(validateExternalUrl('http://172.31.255.255/').ok).toBe(false);
+    expect(validateExternalUrl('http://192.168.1.1/').ok).toBe(false);
+    expect(validateExternalUrl('http://169.254.169.254/').ok).toBe(false);
+    expect(validateExternalUrl('http://0.0.0.0/').ok).toBe(false);
+  });
+
+  it('accepts public IPv4 addresses outside private ranges', () => {
+    expect(validateExternalUrl('http://172.32.0.1/').ok).toBe(true);
+    expect(validateExternalUrl('http://8.8.8.8/').ok).toBe(true);
+  });
+
+  it('rejects integer and hex notation IPv4 addresses', () => {
+    expect(validateExternalUrl('http://2130706433/').ok).toBe(false);
+    expect(validateExternalUrl('http://0x7f000001/').ok).toBe(false);
+  });
+
+  it('rejects private IPv6 ranges', () => {
+    expect(validateExternalUrl('http://[fc00::1]/').ok).toBe(false);
+    expect(validateExternalUrl('http://[fe80::1]/').ok).toBe(false);
+  });
+
+  it('rejects non-default ports', () => {
+    expect(validateExternalUrl('http://example.com:8787/').ok).toBe(false);
+    expect(validateExternalUrl('https://example.com:8443/').ok).toBe(false);
+  });
+
+  it('accepts explicit default ports', () => {
+    expect(validateExternalUrl('http://example.com:80/').ok).toBe(true);
+    expect(validateExternalUrl('https://example.com:443/').ok).toBe(true);
+  });
+
+  it('rejects .local and .internal hostnames', () => {
+    expect(validateExternalUrl('http://printer.local/').ok).toBe(false);
+    expect(validateExternalUrl('http://metadata.internal/').ok).toBe(false);
+  });
+});

--- a/apps/api/src/utils/__tests__/url-safety.test.ts
+++ b/apps/api/src/utils/__tests__/url-safety.test.ts
@@ -65,6 +65,12 @@ describe('validateExternalUrl', () => {
     expect(validateExternalUrl('https://example.com:443/').ok).toBe(true);
   });
 
+  it('rejects hostnames with trailing dots that alias blocked hosts', () => {
+    expect(validateExternalUrl('http://localhost./').ok).toBe(false);
+    expect(validateExternalUrl('http://printer.local./').ok).toBe(false);
+    expect(validateExternalUrl('http://127.0.0.1./').ok).toBe(false);
+  });
+
   it('rejects .local and .internal hostnames', () => {
     expect(validateExternalUrl('http://printer.local/').ok).toBe(false);
     expect(validateExternalUrl('http://metadata.internal/').ok).toBe(false);

--- a/apps/api/src/utils/url-safety.ts
+++ b/apps/api/src/utils/url-safety.ts
@@ -1,0 +1,104 @@
+type UrlValidationResult = {ok: true; url: URL} | {ok: false; reason: string};
+
+const BLOCKED_HOSTNAMES = new Set(['localhost', '0.0.0.0']);
+const BLOCKED_HOSTNAME_SUFFIXES = ['.local', '.internal', '.localhost'];
+
+function parseIpv4(hostname: string): number | undefined {
+  if (/^\d+$/.test(hostname)) {
+    const value = Number(hostname);
+    return value <= 0xff_ff_ff_ff ? value : undefined;
+  }
+
+  if (/^0x[\da-f]+$/i.test(hostname)) {
+    const value = Number.parseInt(hostname, 16);
+    return value <= 0xff_ff_ff_ff ? value : undefined;
+  }
+
+  const dottedMatch = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(
+    hostname,
+  );
+  if (!dottedMatch) {
+    return undefined;
+  }
+
+  const octets = dottedMatch.slice(1).map(Number);
+  if (octets.some(octet => octet > 255)) {
+    return undefined;
+  }
+
+  return (
+    ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0
+  );
+}
+
+function isPrivateIpv4(address: number): boolean {
+  const firstOctet = address >>> 24;
+  const secondOctet = (address >>> 16) & 0xff;
+
+  return (
+    firstOctet === 0 ||
+    firstOctet === 10 ||
+    firstOctet === 127 ||
+    (firstOctet === 100 && secondOctet >= 64 && secondOctet <= 127) ||
+    (firstOctet === 169 && secondOctet === 254) ||
+    (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31) ||
+    (firstOctet === 192 && secondOctet === 168)
+  );
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const address = hostname.replaceAll(/^\[|]$/g, '').toLowerCase();
+  return (
+    address === '::1' ||
+    address === '::' ||
+    address.startsWith('fc') ||
+    address.startsWith('fd') ||
+    address.startsWith('fe80') ||
+    address.startsWith('::ffff:')
+  );
+}
+
+export function validateExternalUrl(rawUrl: string): UrlValidationResult {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return {ok: false, reason: 'Invalid URL format'};
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return {ok: false, reason: 'Only http and https URLs are allowed'};
+  }
+
+  if (url.port !== '') {
+    return {ok: false, reason: 'Non-default ports are not allowed'};
+  }
+
+  const hostname = url.hostname.toLowerCase();
+
+  if (
+    BLOCKED_HOSTNAMES.has(hostname) ||
+    BLOCKED_HOSTNAME_SUFFIXES.some(suffix => hostname.endsWith(suffix))
+  ) {
+    return {ok: false, reason: 'Host is not allowed'};
+  }
+
+  if (hostname.startsWith('[')) {
+    if (isPrivateIpv6(hostname)) {
+      return {ok: false, reason: 'Host is not allowed'};
+    }
+
+    return {ok: true, url};
+  }
+
+  const ipv4 = parseIpv4(hostname);
+  if (ipv4 !== undefined && isPrivateIpv4(ipv4)) {
+    return {ok: false, reason: 'Host is not allowed'};
+  }
+
+  if (ipv4 === undefined && /^[\d.x]+$/i.test(hostname)) {
+    return {ok: false, reason: 'Host is not allowed'};
+  }
+
+  return {ok: true, url};
+}

--- a/apps/api/src/utils/url-safety.ts
+++ b/apps/api/src/utils/url-safety.ts
@@ -74,7 +74,7 @@ export function validateExternalUrl(rawUrl: string): UrlValidationResult {
     return {ok: false, reason: 'Non-default ports are not allowed'};
   }
 
-  const hostname = url.hostname.toLowerCase();
+  const hostname = url.hostname.toLowerCase().replace(/\.+$/, '');
 
   if (
     BLOCKED_HOSTNAMES.has(hostname) ||


### PR DESCRIPTION
- JWTに7日の有効期限を追加し、検証をHS256に固定。これまで管理者トークンは無期限に有効だった
- POST /auth/login にIPごとのレートリミット（15分で5回失敗まで）と定数時間パスワード比較を追加
- POST /fetch-url-title のSSRFを防止。プライベートIP・localhost・非httpプロトコル・非デフォルトポートを拒否し、リダイレクトを1ホップずつ再検証
- app.request()でマウント済みアプリを直接叩く認証・レートリミット・SSRFのテストを追加

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x