### PR TITLE
scrapersがソフトデリート済み映画に書き込む問題を修正

### DIFF
--- a/apps/scrapers/src/academy-awards.ts
+++ b/apps/scrapers/src/academy-awards.ts
@@ -1,6 +1,6 @@
 import * as cheerio from 'cheerio';
 import {type Element} from 'domhandler';
-import {and, eq} from 'drizzle-orm';
+import {and, eq, isNull} from 'drizzle-orm';
 import {getDatabase, type Environment} from '@shine/database';
 import {awardCategories} from '@shine/database/schema/award-categories';
 import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
@@ -527,7 +527,7 @@ async function processMovieForBatch(
           eq(translations.isDefault, 1),
         ),
       )
-      .where(eq(translations.content, title));
+      .where(and(eq(translations.content, title), isNull(movies.deletedAt)));
 
     let movieUid: string;
     const translationsBatch: Array<typeof translations.$inferInsert> = [];
@@ -682,7 +682,7 @@ async function processMovie(
           eq(translations.isDefault, 1),
         ),
       )
-      .where(eq(translations.content, title));
+      .where(and(eq(translations.content, title), isNull(movies.deletedAt)));
 
     let movieUid: string;
 

--- a/apps/scrapers/src/assign-imdb-ids.ts
+++ b/apps/scrapers/src/assign-imdb-ids.ts
@@ -46,8 +46,12 @@ async function assignImdbIds() {
 
     // Build complete query with all conditions
     const whereClause = options.year
-      ? and(isNull(movies.imdbId), eq(movies.year, options.year))
-      : isNull(movies.imdbId);
+      ? and(
+          isNull(movies.imdbId),
+          isNull(movies.deletedAt),
+          eq(movies.year, options.year),
+        )
+      : and(isNull(movies.imdbId), isNull(movies.deletedAt));
 
     const baseQuery = database
       .select({

--- a/apps/scrapers/src/assign-tmdb-ids.ts
+++ b/apps/scrapers/src/assign-tmdb-ids.ts
@@ -25,7 +25,13 @@ async function assignTmdbIds() {
       year: movies.year,
     })
     .from(movies)
-    .where(and(isNotNull(movies.imdbId), isNull(movies.tmdbId)));
+    .where(
+      and(
+        isNotNull(movies.imdbId),
+        isNull(movies.tmdbId),
+        isNull(movies.deletedAt),
+      ),
+    );
 
   console.log(`Found ${moviesWithoutTmdbId.length} movies to process`);
 

--- a/apps/scrapers/src/cannes-film-festival.ts
+++ b/apps/scrapers/src/cannes-film-festival.ts
@@ -1,6 +1,6 @@
 import * as cheerio from 'cheerio';
 import {type Element} from 'domhandler';
-import {and, eq} from 'drizzle-orm';
+import {and, eq, isNull} from 'drizzle-orm';
 import {getDatabase, type Environment} from '@shine/database';
 import {awardCategories} from '@shine/database/schema/award-categories';
 import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
@@ -1043,7 +1043,12 @@ async function updateWinnerStatus(
           eq(translations.isDefault, 1),
         ),
       )
-      .where(eq(translations.content, movieInfo.title));
+      .where(
+        and(
+          eq(translations.content, movieInfo.title),
+          isNull(movies.deletedAt),
+        ),
+      );
 
     if (existingMovies.length === 0) {
       console.log(`Movie not found in database: ${movieInfo.title}`);
@@ -1318,7 +1323,9 @@ async function resolveMovieUid(
         eq(translations.isDefault, 1),
       ),
     )
-    .where(eq(translations.content, movieInfo.title));
+    .where(
+      and(eq(translations.content, movieInfo.title), isNull(movies.deletedAt)),
+    );
 
   if (existingMovies.length > 0) {
     const existingMovie = existingMovies[0].movies;

--- a/apps/scrapers/src/common/__tests__/tmdb-utilities-soft-delete.test.ts
+++ b/apps/scrapers/src/common/__tests__/tmdb-utilities-soft-delete.test.ts
@@ -1,0 +1,67 @@
+import {mkdtempSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {eq} from 'drizzle-orm';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {saveTMDBId} from '../tmdb-utilities';
+
+const MOVIES_DDL = `CREATE TABLE movies (
+  uid text PRIMARY KEY,
+  original_language text NOT NULL DEFAULT 'en',
+  year integer,
+  imdb_id text UNIQUE,
+  tmdb_id integer UNIQUE,
+  media_type text NOT NULL DEFAULT 'movie',
+  release_date text,
+  created_at integer NOT NULL DEFAULT (unixepoch()),
+  updated_at integer NOT NULL DEFAULT (unixepoch()),
+  deleted_at integer
+)`;
+
+describe('saveTMDBId and soft-deleted movies', () => {
+  let environment: Environment;
+  let database: ReturnType<typeof getDatabase>;
+
+  beforeEach(async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), 'shine-test-'));
+    environment = {
+      TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+      TURSO_AUTH_TOKEN: '',
+    } as Environment;
+    database = getDatabase(environment);
+    await database.run(MOVIES_DDL);
+  });
+
+  it('does not assign a TMDb ID to a soft-deleted movie', async () => {
+    await database.insert(movies).values({
+      uid: 'deleted-movie',
+      imdbId: 'tt0000001',
+      deletedAt: 1_700_000_000,
+    });
+
+    await saveTMDBId('tt0000001', 42, environment);
+
+    const [row] = await database
+      .select({tmdbId: movies.tmdbId})
+      .from(movies)
+      .where(eq(movies.uid, 'deleted-movie'));
+    expect(row.tmdbId).toBeNull();
+  });
+
+  it('assigns a TMDb ID to an active movie', async () => {
+    await database.insert(movies).values({
+      uid: 'active-movie',
+      imdbId: 'tt0000002',
+    });
+
+    await saveTMDBId('tt0000002', 43, environment);
+
+    const [row] = await database
+      .select({tmdbId: movies.tmdbId})
+      .from(movies)
+      .where(eq(movies.uid, 'active-movie'));
+    expect(row.tmdbId).toBe(43);
+  });
+});

--- a/apps/scrapers/src/common/tmdb-utilities.ts
+++ b/apps/scrapers/src/common/tmdb-utilities.ts
@@ -421,13 +421,22 @@ export async function saveTMDBId(
   try {
     // IMDb IDで映画を検索
     const movie = await database
-      .select({uid: movies.uid, tmdbId: movies.tmdbId})
+      .select({
+        uid: movies.uid,
+        tmdbId: movies.tmdbId,
+        deletedAt: movies.deletedAt,
+      })
       .from(movies)
       .where(eq(movies.imdbId, imdbId))
       .limit(1);
 
     if (movie.length === 0) {
       console.error(`  Movie not found with IMDb ID: ${imdbId}`);
+      return;
+    }
+
+    if (movie[0].deletedAt !== null) {
+      console.log(`  Movie is soft-deleted, skipping: ${imdbId}`);
       return;
     }
 

--- a/apps/scrapers/src/import-imdb-list.ts
+++ b/apps/scrapers/src/import-imdb-list.ts
@@ -142,14 +142,21 @@ export async function importMoviesFromCsv({
             uid: movies.uid,
             imdbId: movies.imdbId,
             tmdbId: movies.tmdbId,
+            deletedAt: movies.deletedAt,
           })
           .from(movies)
           .where(and(isNotNull(movies.imdbId), inArray(movies.imdbId, imdbIds)))
       : [];
 
   const existingByImdbId = new Map<string, ExistingMovieRecord>();
+  const softDeletedImdbIds = new Set<string>();
   for (const movie of existingMovies) {
     if (!movie.imdbId) {
+      continue;
+    }
+
+    if (movie.deletedAt !== null) {
+      softDeletedImdbIds.add(movie.imdbId);
       continue;
     }
 
@@ -171,7 +178,9 @@ export async function importMoviesFromCsv({
   const newRecords: CsvMovieRow[] = [];
   for (const record of uniqueRecords) {
     const imdbId = record.Const.trim();
-    if (existingByImdbId.has(imdbId)) {
+    if (softDeletedImdbIds.has(imdbId)) {
+      console.log(`Skipping soft-deleted movie: ${imdbId}`);
+    } else if (existingByImdbId.has(imdbId)) {
       existingRecords.push(record);
     } else {
       newRecords.push(record);

--- a/apps/scrapers/src/japan-academy-awards.ts
+++ b/apps/scrapers/src/japan-academy-awards.ts
@@ -1,6 +1,6 @@
 import * as cheerio from 'cheerio';
 import type {AnyNode} from 'domhandler';
-import {and, eq} from 'drizzle-orm';
+import {and, eq, isNull} from 'drizzle-orm';
 import {getDatabase, type Environment} from '@shine/database';
 import {awardCategories} from '@shine/database/schema/award-categories';
 import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
@@ -597,7 +597,12 @@ async function processMovieForBatch(movieInfo: MovieInfo): Promise<
           eq(translations.isDefault, 1),
         ),
       )
-      .where(eq(translations.content, movieInfo.title));
+      .where(
+        and(
+          eq(translations.content, movieInfo.title),
+          isNull(movies.deletedAt),
+        ),
+      );
 
     // IMDb IDでも検索
     let existingMovieByImdbId;
@@ -607,6 +612,13 @@ async function processMovieForBatch(movieInfo: MovieInfo): Promise<
         .from(movies)
         .where(eq(movies.imdbId, imdbId));
       existingMovieByImdbId = result[0];
+
+      if (existingMovieByImdbId?.deletedAt) {
+        console.log(
+          `Movie is soft-deleted, skipping: ${movieInfo.title} (${imdbId})`,
+        );
+        return undefined;
+      }
     }
 
     // どちらかで既存の映画が見つかった場合
@@ -801,7 +813,12 @@ async function processMovie(movieInfo: MovieInfo) {
           eq(translations.isDefault, 1),
         ),
       )
-      .where(eq(translations.content, movieInfo.title));
+      .where(
+        and(
+          eq(translations.content, movieInfo.title),
+          isNull(movies.deletedAt),
+        ),
+      );
 
     // IMDb IDでも検索
     let existingMovieByImdbId;
@@ -811,6 +828,13 @@ async function processMovie(movieInfo: MovieInfo) {
         .from(movies)
         .where(eq(movies.imdbId, imdbId));
       existingMovieByImdbId = result[0];
+
+      if (existingMovieByImdbId?.deletedAt) {
+        console.log(
+          `Movie is soft-deleted, skipping: ${movieInfo.title} (${imdbId})`,
+        );
+        return;
+      }
     }
 
     // どちらかで既存の映画が見つかった場合

--- a/apps/scrapers/src/japanese-translations/repository.ts
+++ b/apps/scrapers/src/japanese-translations/repository.ts
@@ -1,7 +1,7 @@
 /**
  * 日本語翻訳データの取得と保存を行うリポジトリモジュール
  */
-import {and, eq} from 'drizzle-orm';
+import {and, eq, isNull} from 'drizzle-orm';
 import {type getDatabase} from '@shine/database';
 import {movies, translations} from '@shine/database/schema/index';
 import {selectMoviesNeedingJapaneseTitle} from './select-targets';
@@ -58,7 +58,8 @@ export async function getMoviesWithoutJapaneseTranslation(
         eq(translations.resourceUid, movies.uid),
         eq(translations.languageCode, 'en'),
       ),
-    );
+    )
+    .where(isNull(movies.deletedAt));
 
   // Limitが0の場合は全件取得、それ以外は指定された件数の5倍取得（後でフィルタリング）
   const moviesWithEnglishTitles =

--- a/apps/scrapers/src/japanese-translations/scrapers/tmdb-scraper.ts
+++ b/apps/scrapers/src/japanese-translations/scrapers/tmdb-scraper.ts
@@ -110,13 +110,22 @@ async function saveTMDBId(
   try {
     // IMDb IDで映画を検索
     const movie = await database
-      .select({uid: movies.uid, tmdbId: movies.tmdbId})
+      .select({
+        uid: movies.uid,
+        tmdbId: movies.tmdbId,
+        deletedAt: movies.deletedAt,
+      })
       .from(movies)
       .where(eq(movies.imdbId, imdbId))
       .limit(1);
 
     if (movie.length === 0) {
       console.error(`  Movie not found with IMDb ID: ${imdbId}`);
+      return;
+    }
+
+    if (movie[0].deletedAt !== null) {
+      console.log(`  Movie is soft-deleted, skipping: ${imdbId}`);
       return;
     }
 

--- a/apps/scrapers/src/movie-import-from-list.ts
+++ b/apps/scrapers/src/movie-import-from-list.ts
@@ -324,6 +324,13 @@ async function processMovieForBatch(
       .limit(1);
   }
 
+  if (existingMovie?.deletedAt) {
+    console.log(
+      `  Movie is soft-deleted, skipping: ${tmdbMovie.title} (UID: ${existingMovie.uid})`,
+    );
+    return undefined;
+  }
+
   let movieUid: string;
   const translationsBatch: Array<typeof translations.$inferInsert> = [];
   let posterUrlData: typeof posterUrls.$inferInsert | undefined;

--- a/apps/scrapers/src/movie-posters.ts
+++ b/apps/scrapers/src/movie-posters.ts
@@ -87,7 +87,7 @@ async function getMoviesWithImdbId(limit = 10): Promise<MovieWithImdbId[]> {
     .from(movies)
     .leftJoin(posterUrls, eq(movies.uid, posterUrls.movieUid))
     .where(
-      sql`${movies.imdbId} IS NOT NULL AND ${posterUrls.uid} IS NULL AND ${movies.tmdbId} IS NULL`,
+      sql`${movies.imdbId} IS NOT NULL AND ${posterUrls.uid} IS NULL AND ${movies.tmdbId} IS NULL AND ${movies.deletedAt} IS NULL`,
     )
     .limit(limit);
 
@@ -105,7 +105,7 @@ async function getMoviesWithImdbId(limit = 10): Promise<MovieWithImdbId[]> {
     .from(movies)
     .leftJoin(posterUrls, eq(movies.uid, posterUrls.movieUid))
     .where(
-      sql`${movies.imdbId} IS NOT NULL AND ${posterUrls.uid} IS NULL AND ${movies.tmdbId} IS NOT NULL`,
+      sql`${movies.imdbId} IS NOT NULL AND ${posterUrls.uid} IS NULL AND ${movies.tmdbId} IS NOT NULL AND ${movies.deletedAt} IS NULL`,
     )
     .limit(limit);
 
@@ -121,7 +121,9 @@ async function getMoviesWithImdbId(limit = 10): Promise<MovieWithImdbId[]> {
   const moviesWithImdbIdNoTmdb = await database
     .select({uid: movies.uid, imdbId: movies.imdbId, tmdbId: movies.tmdbId})
     .from(movies)
-    .where(sql`${movies.imdbId} IS NOT NULL AND ${movies.tmdbId} IS NULL`)
+    .where(
+      sql`${movies.imdbId} IS NOT NULL AND ${movies.tmdbId} IS NULL AND ${movies.deletedAt} IS NULL`,
+    )
     .limit(limit);
 
   return filterMoviesWithImdbId(normalizeMovies(moviesWithImdbIdNoTmdb));


### PR DESCRIPTION
削除済み映画831件がスクレイパーからは「存在する」扱いになっており、imdbId一致で翻訳・ノミネーション・ポスターが再付与されthen消える(API側では不可視)状態だった。

- ワークリスト系クエリは deleted_at IS NULL でフィルタ
- ID一致で削除済みが見つかったら処理をスキップ(unique制約があるため「見つからない」扱いにすると新規作成でconstraint違反になる)
- 重複チェックは制約保護のため削除済みを含めたまま
- file:プロトコルのlibsqlを使った実DBでの回帰テストを追加

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x