### PR TITLE
scrapers CLIの失敗握り潰しと誤ったenvファイル読込を修正

### DIFF
--- a/apps/scrapers/src/assign-imdb-ids.ts
+++ b/apps/scrapers/src/assign-imdb-ids.ts
@@ -1,4 +1,3 @@
-import {config} from 'dotenv';
 import {Command} from 'commander';
 import {and, eq, isNull} from 'drizzle-orm';
 import {getDatabase} from '@shine/database';
@@ -7,9 +6,9 @@ import {
   searchTMDBMovie,
   fetchTMDBMovieDetails,
 } from './common/tmdb-utilities.js';
+import {loadEnvironmentFiles} from './common/environment.js';
 
-// Load environment variables
-config({path: '../.dev.vars'});
+loadEnvironmentFiles();
 
 const program = new Command();
 

--- a/apps/scrapers/src/assign-tmdb-ids.ts
+++ b/apps/scrapers/src/assign-tmdb-ids.ts
@@ -1,10 +1,10 @@
-import {config} from 'dotenv';
 import {and, isNotNull, isNull, eq, not} from 'drizzle-orm';
 import {getDatabase, type Environment} from '@shine/database';
 import {movies} from '@shine/database/schema/movies';
 import {findTMDBByImdbId} from './common/tmdb-utilities';
+import {loadEnvironmentFiles} from './common/environment';
 
-config({path: '.dev.vars'});
+loadEnvironmentFiles();
 
 const environment: Environment = {
   TURSO_DATABASE_URL: process.env.TURSO_DATABASE_URL!,

--- a/apps/scrapers/src/japan-academy-awards-cli.ts
+++ b/apps/scrapers/src/japan-academy-awards-cli.ts
@@ -4,10 +4,15 @@
  * 日本アカデミー賞スクレイピングのCLIエントリーポイント
  */
 import japanAcademyAwards from './japan-academy-awards';
-import {buildEnvironment, loadEnvironmentFiles} from './common/environment';
+import {
+  assertDatabaseEnvironment,
+  buildEnvironment,
+  loadEnvironmentFiles,
+} from './common/environment';
 
 loadEnvironmentFiles();
 const environment = buildEnvironment(process.env);
+assertDatabaseEnvironment(environment);
 
 const arguments_ = process.argv.slice(2);
 const shouldSeed = arguments_.includes('--seed');
@@ -56,7 +61,14 @@ try {
       ? 'http://localhost/seed?dry-run=true'
       : 'http://localhost/seed';
     const seedRequest = new Request(seedUrl);
-    await japanAcademyAwards.fetch(seedRequest, environment);
+    const seedResponse = await japanAcademyAwards.fetch(
+      seedRequest,
+      environment,
+    );
+    if (!seedResponse.ok) {
+      throw new Error(`Seeding failed: ${await seedResponse.text()}`);
+    }
+
     console.log('Seeding completed successfully');
   }
 
@@ -73,7 +85,11 @@ try {
 
   const url = `${baseUrl}?${searchParameters.toString()}`;
   const request = new Request(url);
-  await japanAcademyAwards.fetch(request, environment);
+  const response = await japanAcademyAwards.fetch(request, environment);
+  if (!response.ok) {
+    throw new Error(`Scraping failed: ${await response.text()}`);
+  }
+
   console.log('Scraping completed successfully');
 } catch (error) {
   console.error('Error:', error);

--- a/apps/scrapers/src/movie-import-from-list-cli.ts
+++ b/apps/scrapers/src/movie-import-from-list-cli.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-import {config} from 'dotenv';
 import {importMoviesFromList} from './movie-import-from-list';
+import {loadEnvironmentFiles} from './common/environment';
 
-// .envファイルを読み込み
-config({path: '../.dev.vars'});
+loadEnvironmentFiles();
 
 async function main(): Promise<void> {
   const arguments_ = process.argv.slice(2);


### PR DESCRIPTION
- japan-academy-awards-cli がレスポンスのstatusを見ずに「Scraping completed successfully」と報告してexit 0していた。500でも成功扱いだったので、失敗時はexit 1にする
- movie-import-from-list-cli と assign-imdb-ids の `config({path: '../.dev.vars'})` はcwd相対で `apps/.dev.vars`（実在する別ファイル）に解決される。古い認証情報で本番DBに書き込む危険があったため、共通の loadEnvironmentFiles() に統一

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x