### PR TITLE
APIキャッシュを実際に機能させ、トップページのクエリを並列化

### DIFF
--- a/apps/api/src/__tests__/selections-locale-cache.test.ts
+++ b/apps/api/src/__tests__/selections-locale-cache.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {SelectionsService} from '../services/selections-service';
+import {EdgeCache} from '../utils/cache';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+function createStatefulCacheStub() {
+  const store = new Map<string, Response>();
+  return {
+    async match(key: string) {
+      return store.get(key)?.clone();
+    },
+    async put(key: string, response: Response) {
+      store.set(key, response);
+    },
+    async delete(key: string) {
+      return store.delete(key);
+    },
+    async keys() {
+      return [...store.keys()].map(key => new Request(key));
+    },
+  } as unknown as Cache;
+}
+
+describe('selections cache and locale', () => {
+  let environment: Environment;
+  let service: SelectionsService;
+
+  beforeEach(async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-test-'));
+    environment = {
+      TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+      TURSO_AUTH_TOKEN: '',
+    } as Environment;
+    const database = getDatabase(environment);
+    await migrate(database, {migrationsFolder});
+
+    await database
+      .insert(awardOrganizations)
+      .values({uid: 'org-1', name: 'Test Award'});
+    await database
+      .insert(awardCeremonies)
+      .values({uid: 'ceremony-1', organizationUid: 'org-1', year: 2020});
+    await database.insert(awardCategories).values({
+      uid: 'category-1',
+      organizationUid: 'org-1',
+      name: 'Best Picture',
+    });
+    await database.insert(movies).values({uid: 'movie-a', year: 2020});
+    await database.insert(translations).values([
+      {
+        resourceType: 'movie_title',
+        resourceUid: 'movie-a',
+        languageCode: 'en',
+        content: 'Movie A',
+        isDefault: 1,
+      },
+      {
+        resourceType: 'movie_title',
+        resourceUid: 'movie-a',
+        languageCode: 'ja',
+        content: '映画A',
+        isDefault: 0,
+      },
+    ]);
+    await database.insert(nominations).values({
+      movieUid: 'movie-a',
+      ceremonyUid: 'ceremony-1',
+      categoryUid: 'category-1',
+    });
+
+    service = new SelectionsService(
+      environment,
+      new EdgeCache(createStatefulCacheStub()),
+    );
+  });
+
+  it('does not leak cached selections across locales', async () => {
+    const date = new Date('2024-06-24');
+
+    const english = await service.getDateSeededSelections({
+      locale: 'en',
+      date,
+    });
+    const japanese = await service.getDateSeededSelections({
+      locale: 'ja',
+      date,
+    });
+
+    expect(english.daily.title).toBe('Movie A');
+    expect(japanese.daily.title).toBe('映画A');
+  });
+
+  it('serves repeated same-locale requests from cache', async () => {
+    const date = new Date('2024-06-24');
+
+    const first = await service.getDateSeededSelections({locale: 'ja', date});
+    const second = await service.getDateSeededSelections({locale: 'ja', date});
+
+    expect(second.daily.title).toBe(first.daily.title);
+    expect(second.daily.uid).toBe('movie-a');
+  });
+});

--- a/apps/api/src/cache.test.ts
+++ b/apps/api/src/cache.test.ts
@@ -32,10 +32,12 @@ describe('Cache Utilities', () => {
       const movieId = 'test-movie-123';
       const basicKey = getCacheKeyForMovie(movieId, false);
       const fullKey = getCacheKeyForMovie(movieId, true);
+      const englishKey = getCacheKeyForMovie(movieId, false, 'en');
 
-      expect(basicKey).toBe(`movie:${movieId}:basic:v1`);
-      expect(fullKey).toBe(`movie:${movieId}:full:v1`);
+      expect(basicKey).toBe(`movie:${movieId}:basic:ja:v2`);
+      expect(fullKey).toBe(`movie:${movieId}:full:ja:v2`);
       expect(basicKey).not.toBe(fullKey);
+      expect(englishKey).not.toBe(basicKey);
     });
   });
 
@@ -190,9 +192,9 @@ describe('Cache Utilities', () => {
       // Test with invalid key that might cause errors
       const invalidKey = '';
 
-      // Should not throw errors, should return undefined/true in development
+      // Should not throw errors
       await expect(cache.get(invalidKey)).resolves.toBeUndefined();
-      await expect(cache.delete(invalidKey)).resolves.toBe(true); // Returns true in development mode
+      await expect(cache.delete(invalidKey)).resolves.toBe(false);
     });
   });
 

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -15,6 +15,8 @@ import {MoviesService} from '../services';
 import {
   checkETag,
   createCachedResponse,
+  getMovieCacheKeysForAllLocales,
+  normalizeCacheLocale,
   createETag,
   EdgeCache,
   getCacheKeyForMovie,
@@ -132,8 +134,11 @@ moviesRoutes.get('/:id', async c => {
     const locale = c.req.query('locale') || 'ja';
 
     // Check cache first
-    const cacheKey = getCacheKeyForMovie(movieId, true);
-    const cachedResponse = await cache.get(cacheKey);
+    const cacheLocale = normalizeCacheLocale(locale);
+    const cacheKey = cacheLocale
+      ? getCacheKeyForMovie(movieId, true, cacheLocale)
+      : undefined;
+    const cachedResponse = cacheKey ? await cache.get(cacheKey) : undefined;
 
     if (cachedResponse) {
       console.log('Cache hit for movie details:', movieId);
@@ -180,8 +185,10 @@ moviesRoutes.get('/:id', async c => {
       'X-Cache-Status': 'MISS',
     });
 
-    // Store in cache
-    await cache.put(cacheKey, response, ttl);
+    // Store in cache (reader expects the {data, cachedAt} envelope from set())
+    if (cacheKey) {
+      await cache.set(cacheKey, result, ttl);
+    }
 
     return response;
   } catch (error) {
@@ -233,11 +240,11 @@ moviesRoutes.post('/:id/translations', authMiddleware, async c => {
     );
 
     // Invalidate movie details cache
-    await Promise.all([
-      cache.delete(getCacheKeyForMovie(movieId, true)),
-      cache.delete(getCacheKeyForMovie(movieId, false)),
-      cache.deleteByPattern('selections:all:'), // Invalidate main selections that might include this movie
-    ]);
+    await Promise.all(
+      getMovieCacheKeysForAllLocales(movieId).map(async key =>
+        cache.delete(key),
+      ),
+    );
 
     console.log(
       `Cache invalidated for movie ${movieId} after translation update`,
@@ -268,11 +275,11 @@ moviesRoutes.delete('/:id/translations/:lang', authMiddleware, async c => {
     await moviesService.deleteMovieTranslation(movieId, languageCode);
 
     // Invalidate movie details cache
-    await Promise.all([
-      cache.delete(getCacheKeyForMovie(movieId, true)),
-      cache.delete(getCacheKeyForMovie(movieId, false)),
-      cache.deleteByPattern('selections:all:'),
-    ]);
+    await Promise.all(
+      getMovieCacheKeysForAllLocales(movieId).map(async key =>
+        cache.delete(key),
+      ),
+    );
 
     console.log(
       `Cache invalidated for movie ${movieId} after translation deletion`,

--- a/apps/api/src/services/movies-service.ts
+++ b/apps/api/src/services/movies-service.ts
@@ -7,7 +7,13 @@ import {movies} from '@shine/database/schema/movies';
 import {nominations} from '@shine/database/schema/nominations';
 import {posterUrls} from '@shine/database/schema/poster-urls';
 import {translations} from '@shine/database/schema/translations';
-import {EdgeCache, getCacheKeyForMovie} from '../utils/cache';
+import {
+  EdgeCache,
+  getCacheKeyForMovie,
+  getCacheTTL,
+  getMovieCacheKeysForAllLocales,
+  normalizeCacheLocale,
+} from '../utils/cache';
 import {BaseService} from './base-service';
 import type {MovieSelection, SearchOptions} from '@shine/types';
 
@@ -186,10 +192,13 @@ export class MoviesService extends BaseService {
     movieId: string,
     locale = 'ja',
   ): Promise<MovieSelection> {
-    const cacheKey = getCacheKeyForMovie(movieId);
+    const cacheLocale = normalizeCacheLocale(locale);
+    const cacheKey = cacheLocale
+      ? getCacheKeyForMovie(movieId, false, cacheLocale)
+      : undefined;
 
     // Try to get cached result
-    const cached = await this.cache.get(cacheKey);
+    const cached = cacheKey ? await this.cache.get(cacheKey) : undefined;
     if (cached?.data) {
       return cached.data as MovieSelection;
     }
@@ -332,10 +341,9 @@ export class MoviesService extends BaseService {
     };
 
     // Cache result
-    const response = Response.json(movieDetails, {
-      headers: {'Content-Type': 'application/json'},
-    });
-    await this.cache.put(cacheKey, response);
+    if (cacheKey) {
+      await this.cache.set(cacheKey, movieDetails, getCacheTTL.movie.basic);
+    }
 
     return movieDetails;
   }
@@ -441,8 +449,11 @@ export class MoviesService extends BaseService {
     });
 
     // Invalidate cache
-    const cacheKey = getCacheKeyForMovie(movieId);
-    await this.cache.delete(cacheKey);
+    await Promise.all(
+      getMovieCacheKeysForAllLocales(movieId).map(async key =>
+        this.cache.delete(key),
+      ),
+    );
   }
 
   async deleteMovieTranslation(
@@ -461,7 +472,10 @@ export class MoviesService extends BaseService {
       );
 
     // Invalidate cache
-    const cacheKey = getCacheKeyForMovie(movieId);
-    await this.cache.delete(cacheKey);
+    await Promise.all(
+      getMovieCacheKeysForAllLocales(movieId).map(async key =>
+        this.cache.delete(key),
+      ),
+    );
   }
 }

--- a/apps/api/src/services/selections-service.ts
+++ b/apps/api/src/services/selections-service.ts
@@ -1,4 +1,11 @@
-import {and, eq, isNull, notInArray, sql} from '@shine/database';
+import {
+  and,
+  eq,
+  isNull,
+  notInArray,
+  sql,
+  type Environment,
+} from '@shine/database';
 import {articleLinks} from '@shine/database/schema/article-links';
 import {awardCategories} from '@shine/database/schema/award-categories';
 import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
@@ -9,7 +16,13 @@ import {movies} from '@shine/database/schema/movies';
 import {nominations} from '@shine/database/schema/nominations';
 import {posterUrls} from '@shine/database/schema/poster-urls';
 import {translations} from '@shine/database/schema/translations';
-import {EdgeCache} from '../utils/cache';
+import {
+  CACHEABLE_LOCALES,
+  EdgeCache,
+  getCacheKeyForSelection,
+  getCacheTTL,
+  normalizeCacheLocale,
+} from '../utils/cache';
 import {simpleHash} from '../utils/hash';
 import {BaseService} from './base-service';
 import type {DateSeedOptions, MovieSelection} from '@shine/types';
@@ -17,7 +30,12 @@ import type {DateSeedOptions, MovieSelection} from '@shine/types';
 type SelectionType = 'daily' | 'weekly' | 'monthly';
 
 export class SelectionsService extends BaseService {
-  private readonly cache = new EdgeCache();
+  private readonly cache: EdgeCache;
+
+  constructor(environment: Environment, cache = new EdgeCache()) {
+    super(environment);
+    this.cache = cache;
+  }
 
   async getDateSeededSelections(options: DateSeedOptions): Promise<{
     daily: MovieSelection;
@@ -26,9 +44,11 @@ export class SelectionsService extends BaseService {
   }> {
     const {locale, date = new Date()} = options;
 
-    const dailyMovie = await this.getMovieByDateSeed(date, 'daily', locale);
-    const weeklyMovie = await this.getMovieByDateSeed(date, 'weekly', locale);
-    const monthlyMovie = await this.getMovieByDateSeed(date, 'monthly', locale);
+    const [dailyMovie, weeklyMovie, monthlyMovie] = await Promise.all([
+      this.getMovieByDateSeed(date, 'daily', locale),
+      this.getMovieByDateSeed(date, 'weekly', locale),
+      this.getMovieByDateSeed(date, 'monthly', locale),
+    ]);
 
     return {
       daily: dailyMovie,
@@ -56,7 +76,7 @@ export class SelectionsService extends BaseService {
       );
 
     // Clear cache
-    await this.cache.delete(`selection-${type}-${selectionDate}`);
+    await this.purgeSelectionCache(type, selectionDate);
 
     // Generate new selection with randomness
     const movieUid = await this.selectMovieFromNominations(
@@ -74,11 +94,14 @@ export class SelectionsService extends BaseService {
     const movie = await this.getCompleteMovieData(movieUid, locale);
 
     // Cache result
-    const cacheKey = `selection-${type}-${selectionDate}`;
-    const response = Response.json(movie, {
-      headers: {'Content-Type': 'application/json'},
-    });
-    await this.cache.put(cacheKey, response);
+    const cacheLocale = normalizeCacheLocale(locale);
+    if (cacheLocale) {
+      await this.cache.set(
+        getCacheKeyForSelection(type, selectionDate, cacheLocale),
+        movie,
+        getCacheTTL.selections[type],
+      );
+    }
 
     return movie;
   }
@@ -238,7 +261,7 @@ export class SelectionsService extends BaseService {
     });
 
     // Clear cache
-    await this.cache.delete(`selection-${type}-${selectionDate}`);
+    await this.purgeSelectionCache(type, selectionDate);
   }
 
   private async getMovieByDateSeed(
@@ -247,10 +270,13 @@ export class SelectionsService extends BaseService {
     locale: string,
   ): Promise<MovieSelection> {
     const selectionDate = this.getSelectionDate(date, type);
-    const cacheKey = `selection-${type}-${selectionDate}`;
+    const cacheLocale = normalizeCacheLocale(locale);
+    const cacheKey = cacheLocale
+      ? getCacheKeyForSelection(type, selectionDate, cacheLocale)
+      : undefined;
 
     // Try to get cached result
-    const cached = await this.cache.get(cacheKey);
+    const cached = cacheKey ? await this.cache.get(cacheKey) : undefined;
     if (cached?.data) {
       return cached.data as MovieSelection;
     }
@@ -319,12 +345,22 @@ export class SelectionsService extends BaseService {
     }
 
     // Cache result
-    const response = Response.json(movie, {
-      headers: {'Content-Type': 'application/json'},
-    });
-    await this.cache.put(cacheKey, response);
+    if (cacheKey) {
+      await this.cache.set(cacheKey, movie, getCacheTTL.selections[type]);
+    }
 
     return movie;
+  }
+
+  private async purgeSelectionCache(
+    type: SelectionType,
+    selectionDate: string,
+  ): Promise<void> {
+    await Promise.all(
+      CACHEABLE_LOCALES.map(async locale =>
+        this.cache.delete(getCacheKeyForSelection(type, selectionDate, locale)),
+      ),
+    );
   }
 
   private async generateMovieSelection(
@@ -370,108 +406,109 @@ export class SelectionsService extends BaseService {
 
     const movie = movieResult[0];
 
-    // Get all translations for the movie
-    const allTranslations = await this.database
-      .select({
-        languageCode: translations.languageCode,
-        content: translations.content,
-        isDefault: translations.isDefault,
-        resourceType: translations.resourceType,
-      })
-      .from(translations)
-      .where(
-        and(
-          eq(translations.resourceUid, movieId),
-          eq(translations.resourceType, 'movie_title'),
+    // Fetch the movie's related data in parallel
+    const [
+      allTranslations,
+      descriptionResult,
+      nominationsData,
+      posters,
+      topArticles,
+      availability,
+    ] = await Promise.all([
+      this.database
+        .select({
+          languageCode: translations.languageCode,
+          content: translations.content,
+          isDefault: translations.isDefault,
+          resourceType: translations.resourceType,
+        })
+        .from(translations)
+        .where(
+          and(
+            eq(translations.resourceUid, movieId),
+            eq(translations.resourceType, 'movie_title'),
+          ),
         ),
-      );
+      this.database
+        .select({
+          content: translations.content,
+        })
+        .from(translations)
+        .where(
+          and(
+            eq(translations.resourceUid, movieId),
+            eq(translations.resourceType, 'movie_description'),
+            eq(translations.languageCode, locale),
+          ),
+        )
+        .limit(1),
+      this.database
+        .select({
+          nominationUid: nominations.uid,
+          isWinner: nominations.isWinner,
+          specialMention: nominations.specialMention,
+          categoryUid: awardCategories.uid,
+          categoryName: awardCategories.name,
+          ceremonyUid: awardCeremonies.uid,
+          ceremonyNumber: awardCeremonies.ceremonyNumber,
+          ceremonyYear: awardCeremonies.year,
+          organizationUid: awardOrganizations.uid,
+          organizationName: awardOrganizations.name,
+          organizationShortName: awardOrganizations.shortName,
+        })
+        .from(nominations)
+        .innerJoin(
+          awardCategories,
+          eq(awardCategories.uid, nominations.categoryUid),
+        )
+        .innerJoin(
+          awardCeremonies,
+          eq(awardCeremonies.uid, nominations.ceremonyUid),
+        )
+        .innerJoin(
+          awardOrganizations,
+          eq(awardOrganizations.uid, awardCeremonies.organizationUid),
+        )
+        .where(eq(nominations.movieUid, movieId))
+        .orderBy(awardCeremonies.year, awardCategories.name),
+      this.database
+        .select({
+          url: posterUrls.url,
+          languageCode: posterUrls.languageCode,
+          isPrimary: posterUrls.isPrimary,
+        })
+        .from(posterUrls)
+        .where(eq(posterUrls.movieUid, movieId))
+        .orderBy(
+          sql`${posterUrls.isPrimary} DESC, ${posterUrls.createdAt} ASC`,
+        ),
+      this.database
+        .select({
+          uid: articleLinks.uid,
+          url: articleLinks.url,
+          title: articleLinks.title,
+          description: articleLinks.description || undefined,
+        })
+        .from(articleLinks)
+        .where(
+          and(
+            eq(articleLinks.movieUid, movieId),
+            eq(articleLinks.isSpam, false),
+            eq(articleLinks.isFlagged, false),
+          ),
+        )
+        .orderBy(sql`${articleLinks.submittedAt} DESC`)
+        .limit(3),
+      this.getMovieAvailability(movieId),
+    ]);
 
     const selectedTitle = this.resolveTitle(allTranslations, locale);
-
-    // Get description for the locale
-    const descriptionResult = await this.database
-      .select({
-        content: translations.content,
-      })
-      .from(translations)
-      .where(
-        and(
-          eq(translations.resourceUid, movieId),
-          eq(translations.resourceType, 'movie_description'),
-          eq(translations.languageCode, locale),
-        ),
-      )
-      .limit(1);
-
     const description = descriptionResult[0]?.content || undefined;
-
-    // Get nominations
-    const nominationsData = await this.database
-      .select({
-        nominationUid: nominations.uid,
-        isWinner: nominations.isWinner,
-        specialMention: nominations.specialMention,
-        categoryUid: awardCategories.uid,
-        categoryName: awardCategories.name,
-        ceremonyUid: awardCeremonies.uid,
-        ceremonyNumber: awardCeremonies.ceremonyNumber,
-        ceremonyYear: awardCeremonies.year,
-        organizationUid: awardOrganizations.uid,
-        organizationName: awardOrganizations.name,
-        organizationShortName: awardOrganizations.shortName,
-      })
-      .from(nominations)
-      .innerJoin(
-        awardCategories,
-        eq(awardCategories.uid, nominations.categoryUid),
-      )
-      .innerJoin(
-        awardCeremonies,
-        eq(awardCeremonies.uid, nominations.ceremonyUid),
-      )
-      .innerJoin(
-        awardOrganizations,
-        eq(awardOrganizations.uid, awardCeremonies.organizationUid),
-      )
-      .where(eq(nominations.movieUid, movieId))
-      .orderBy(awardCeremonies.year, awardCategories.name);
-
-    // Get all posters for this movie
-    const posters = await this.database
-      .select({
-        url: posterUrls.url,
-        languageCode: posterUrls.languageCode,
-        isPrimary: posterUrls.isPrimary,
-      })
-      .from(posterUrls)
-      .where(eq(posterUrls.movieUid, movieId))
-      .orderBy(sql`${posterUrls.isPrimary} DESC, ${posterUrls.createdAt} ASC`);
-
-    // Get article links
-    const topArticles = await this.database
-      .select({
-        uid: articleLinks.uid,
-        url: articleLinks.url,
-        title: articleLinks.title,
-        description: articleLinks.description || undefined,
-      })
-      .from(articleLinks)
-      .where(
-        and(
-          eq(articleLinks.movieUid, movieId),
-          eq(articleLinks.isSpam, false),
-          eq(articleLinks.isFlagged, false),
-        ),
-      )
-      .orderBy(sql`${articleLinks.submittedAt} DESC`)
-      .limit(3);
 
     // Generate IMDb URL if IMDb ID exists
     const imdbUrl = movie.imdbId
       ? `https://www.imdb.com/title/${movie.imdbId}/`
       : undefined;
-
-    const availability = await this.getMovieAvailability(movieId);
 
     return {
       uid: movie.uid,
@@ -625,33 +662,41 @@ export class SelectionsService extends BaseService {
     excludeMovieUids: string[] = [],
   ): Promise<string | undefined> {
     // Movies with more nominations have proportionally higher chance of being selected
-    const availableNominations = await this.database
-      .select({
-        nominationUid: nominations.uid,
-        movieUid: nominations.movieUid,
-      })
+    const whereClause = and(
+      isNull(movies.deletedAt),
+      excludeMovieUids.length > 0
+        ? notInArray(nominations.movieUid, excludeMovieUids)
+        : undefined,
+    );
+
+    const [countRow] = await this.database
+      .select({total: sql<number>`count(*)`})
       .from(nominations)
       .innerJoin(movies, eq(movies.uid, nominations.movieUid))
-      .where(
-        and(
-          isNull(movies.deletedAt),
-          excludeMovieUids.length > 0
-            ? notInArray(nominations.movieUid, excludeMovieUids)
-            : undefined,
-        ),
-      )
-      .orderBy(nominations.movieUid, nominations.uid);
+      .where(whereClause);
 
-    if (availableNominations.length === 0) {
+    const total = Number(countRow?.total ?? 0);
+    if (total === 0) {
       return undefined;
     }
 
     const selectedIndex =
-      seed === 'random'
-        ? Math.floor(Math.random() * availableNominations.length)
-        : seed % availableNominations.length;
+      seed === 'random' ? Math.floor(Math.random() * total) : seed % total;
 
-    const selectedMovieUid = availableNominations[selectedIndex].movieUid;
+    const [selectedNomination] = await this.database
+      .select({movieUid: nominations.movieUid})
+      .from(nominations)
+      .innerJoin(movies, eq(movies.uid, nominations.movieUid))
+      .where(whereClause)
+      .orderBy(nominations.movieUid, nominations.uid)
+      .limit(1)
+      .offset(selectedIndex);
+
+    if (!selectedNomination) {
+      return undefined;
+    }
+
+    const selectedMovieUid = selectedNomination.movieUid;
 
     if (persistSelection) {
       const selectionDate = this.getSelectionDate(date, type);

--- a/apps/api/src/utils/__tests__/edge-cache.test.ts
+++ b/apps/api/src/utils/__tests__/edge-cache.test.ts
@@ -1,0 +1,67 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {EdgeCache} from '../cache';
+
+function createStatefulCacheStub() {
+  const store = new Map<string, Response>();
+  return {
+    async match(key: string) {
+      const cached = store.get(key);
+      return cached?.clone();
+    },
+    async put(key: string, response: Response) {
+      store.set(key, response);
+    },
+    async delete(key: string) {
+      return store.delete(key);
+    },
+    async keys() {
+      return [...store.keys()].map(key => new Request(`http://cache/${key}`));
+    },
+  };
+}
+
+describe('EdgeCache', () => {
+  let cacheStub: ReturnType<typeof createStatefulCacheStub>;
+
+  beforeEach(() => {
+    cacheStub = createStatefulCacheStub();
+  });
+
+  it('caches and returns data for non-preview keys', async () => {
+    const cache = new EdgeCache(cacheStub as unknown as Cache);
+    await cache.set('selections:daily:2024-06-24:en:v1', {title: 'Movie'}, 60);
+
+    const cached = await cache.get('selections:daily:2024-06-24:en:v1');
+
+    expect(cached?.data).toEqual({title: 'Movie'});
+  });
+
+  it('returns undefined for keys that were never set', async () => {
+    const cache = new EdgeCache(cacheStub as unknown as Cache);
+
+    const cached = await cache.get('selections:daily:2024-06-24:en:v1');
+
+    expect(cached).toBeUndefined();
+  });
+
+  it('deletes cached entries', async () => {
+    const cache = new EdgeCache(cacheStub as unknown as Cache);
+    await cache.set('movie:abc:basic:ja:v2', {title: 'Movie'}, 60);
+
+    await cache.delete('movie:abc:basic:ja:v2');
+
+    expect(await cache.get('movie:abc:basic:ja:v2')).toBeUndefined();
+  });
+
+  it('keeps entries for different locales separate', async () => {
+    const cache = new EdgeCache(cacheStub as unknown as Cache);
+    await cache.set('selections:daily:2024-06-24:en:v1', {title: 'Movie'}, 60);
+    await cache.set('selections:daily:2024-06-24:ja:v1', {title: '映画'}, 60);
+
+    const en = await cache.get('selections:daily:2024-06-24:en:v1');
+    const ja = await cache.get('selections:daily:2024-06-24:ja:v1');
+
+    expect(en?.data).toEqual({title: 'Movie'});
+    expect(ja?.data).toEqual({title: '映画'});
+  });
+});

--- a/apps/api/src/utils/cache.ts
+++ b/apps/api/src/utils/cache.ts
@@ -11,22 +11,22 @@ export type CacheMetrics = {
 };
 
 export class EdgeCache {
-  private readonly cache = (caches as unknown as {default: Cache}).default;
+  private readonly cache: Cache;
   private readonly metrics: CacheMetrics = {hits: 0, misses: 0, hitRate: 0};
-  private get isDevelopment() {
-    return true; // Always disable cache in development
+
+  constructor(cacheStorage?: Cache) {
+    this.cache =
+      cacheStorage ?? (caches as unknown as {default: Cache}).default;
+  }
+
+  // Cache API keys must be valid request URLs; map logical keys onto one
+  private keyToUrl(key: string): string {
+    return `https://edge-cache.internal/${encodeURIComponent(key)}`;
   }
 
   async getResponse(key: string): Promise<Response | undefined> {
-    // Allow caching for preview keys even in development
-    if (this.isDevelopment && !key.startsWith('preview-')) {
-      this.metrics.misses++;
-      this.updateHitRate();
-      return undefined;
-    }
-
     try {
-      const cached = await this.cache.match(key);
+      const cached = await this.cache.match(this.keyToUrl(key));
       if (cached) {
         this.metrics.hits++;
         this.updateHitRate();
@@ -45,11 +45,6 @@ export class EdgeCache {
   }
 
   async put(key: string, response: Response, ttl?: number): Promise<void> {
-    // Allow caching for preview keys even in development
-    if (this.isDevelopment && !key.startsWith('preview-')) {
-      return;
-    }
-
     try {
       const responseToCache = response.clone();
 
@@ -61,9 +56,9 @@ export class EdgeCache {
           statusText: responseToCache.statusText,
           headers,
         });
-        await this.cache.put(key, cachedResponse);
+        await this.cache.put(this.keyToUrl(key), cachedResponse);
       } else {
-        await this.cache.put(key, responseToCache);
+        await this.cache.put(this.keyToUrl(key), responseToCache);
       }
     } catch (error) {
       console.error('Cache put error:', error);
@@ -71,11 +66,6 @@ export class EdgeCache {
   }
 
   async set(key: string, data: unknown, ttl = 3600): Promise<void> {
-    // Allow caching for preview keys even in development
-    if (this.isDevelopment && !key.startsWith('preview-')) {
-      return;
-    }
-
     try {
       const response = Response.json(
         {data, cachedAt: Date.now()},
@@ -86,7 +76,7 @@ export class EdgeCache {
           },
         },
       );
-      await this.cache.put(key, response);
+      await this.cache.put(this.keyToUrl(key), response);
     } catch (error) {
       console.error('Cache set error:', error);
     }
@@ -95,15 +85,8 @@ export class EdgeCache {
   async get(
     key: string,
   ): Promise<{data: unknown; cachedAt: number} | undefined> {
-    // Allow caching for preview keys even in development
-    if (this.isDevelopment && !key.startsWith('preview-')) {
-      this.metrics.misses++;
-      this.updateHitRate();
-      return undefined;
-    }
-
     try {
-      const cached = await this.cache.match(key);
+      const cached = await this.cache.match(this.keyToUrl(key));
       if (cached) {
         const result: {
           data: unknown;
@@ -126,12 +109,8 @@ export class EdgeCache {
   }
 
   async delete(key: string): Promise<boolean> {
-    if (this.isDevelopment && !key.startsWith('preview-')) {
-      return true;
-    }
-
     try {
-      return await this.cache.delete(key);
+      return await this.cache.delete(this.keyToUrl(key));
     } catch (error) {
       console.error('Cache delete error:', error);
       return false;
@@ -139,14 +118,13 @@ export class EdgeCache {
   }
 
   async deleteByPattern(pattern: string): Promise<number> {
-    if (this.isDevelopment && !pattern.includes('preview-')) {
-      return 0;
-    }
-
     try {
+      // Note: cache.keys() is unsupported on Cloudflare Workers; this only
+      // works in tests. Prefer explicit key deletion.
       const keys = await this.cache.keys();
+      const encodedPattern = encodeURIComponent(pattern);
       const deletePromises = keys
-        .filter(request => request.url.includes(pattern))
+        .filter(request => request.url.includes(encodedPattern))
         .map(async request => this.cache.delete(request));
 
       const results = await Promise.all(deletePromises);
@@ -169,6 +147,17 @@ export class EdgeCache {
   }
 }
 
+export const CACHEABLE_LOCALES = ['en', 'ja'] as const;
+export type CacheableLocale = (typeof CACHEABLE_LOCALES)[number];
+
+// Cached payloads are locale-dependent; only cache locales we can purge later
+export const normalizeCacheLocale = (
+  locale: string,
+): CacheableLocale | undefined => {
+  const language = locale.split('-')[0] as CacheableLocale;
+  return CACHEABLE_LOCALES.includes(language) ? language : undefined;
+};
+
 export const getCacheKeyForSelection = (
   type: string,
   date: string,
@@ -178,10 +167,17 @@ export const getCacheKeyForSelection = (
 export const getCacheKeyForMovie = (
   movieId: string,
   includeDetails = false,
+  locale: string = 'ja',
 ): string => {
   const suffix = includeDetails ? 'full' : 'basic';
-  return `movie:${movieId}:${suffix}:v1`;
+  return `movie:${movieId}:${suffix}:${locale}:v2`;
 };
+
+export const getMovieCacheKeysForAllLocales = (movieId: string): string[] =>
+  CACHEABLE_LOCALES.flatMap(locale => [
+    getCacheKeyForMovie(movieId, true, locale),
+    getCacheKeyForMovie(movieId, false, locale),
+  ]);
 
 export const getCacheKeyForSearch = (
   query: string,


### PR DESCRIPTION
調査で判明した3つの構造問題を修正:

1. **キャッシュが一度も効いていなかった**: `EdgeCache.isDevelopment` が `true` 固定で全操作no-op。さらにキーが有効なURLでないためWorkers上ではput自体が例外→握り潰し、加えて書き込み(put/Response)と読み出し(get/{data}形式)の形式不一致という三重の理由で永遠にミスしていた
2. **localeキー**: キャッシュキーにlocaleが入っていなかったため、有効化するとen/jaの内容が混線する。キーにlocaleを含め、reselect時は全localeをパージ
3. **クエリ効率**: GET / が約18回の逐次DBラウンドトリップだったのをPromise.all化。抽選も全ノミネーション読み込み→COUNT+OFFSETに変更

実DB(libsql file:)+ステートフルキャッシュスタブでlocale混線を検出する回帰テストを追加。

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x