### PR TITLE
front: ダミーデータ表示の廃止とAPI URL解決の一本化

### DIFF
--- a/apps/front/app/lib/api.ts
+++ b/apps/front/app/lib/api.ts
@@ -1,0 +1,10 @@
+type CloudflareContext = {
+  cloudflare?: {env?: {PUBLIC_API_URL?: string}};
+};
+
+export function resolveApiUrl(context: unknown): string {
+  return (
+    (context as CloudflareContext)?.cloudflare?.env?.PUBLIC_API_URL ??
+    'http://localhost:8787'
+  );
+}

--- a/apps/front/app/lib/sitemap-source.ts
+++ b/apps/front/app/lib/sitemap-source.ts
@@ -1,22 +1,15 @@
+import {resolveApiUrl} from './api';
+
 export const MOVIES_PER_SITEMAP = 100;
 
 const SITEMAP_CACHE_CONTROL = 'public, max-age=3600';
-
-type CloudflareContext = {
-  cloudflare?: {env?: {PUBLIC_API_URL?: string}};
-};
 
 type SearchResponse = {
   movies?: Array<{uid: string}>;
   pagination?: {totalCount?: number};
 };
 
-export function resolveApiUrl(context: unknown): string {
-  return (
-    (context as CloudflareContext)?.cloudflare?.env?.PUBLIC_API_URL ??
-    'http://localhost:8787'
-  );
-}
+export {resolveApiUrl} from './api';
 
 async function fetchSearchPage(
   context: unknown,

--- a/apps/front/app/routes/admin.ceremonies.$uid.tsx
+++ b/apps/front/app/routes/admin.ceremonies.$uid.tsx
@@ -5,6 +5,7 @@ import {Button} from '@/components/ui/button';
 import {Input} from '@/components/ui/input';
 import {Textarea} from '@/components/ui/textarea';
 import type {Route} from './+types/admin.ceremonies.$uid';
+import {resolveApiUrl} from '@/lib/api';
 
 type LoaderData = {
   apiUrl: string;
@@ -166,12 +167,8 @@ export async function loader({context, params}: Route.LoaderArgs) {
     throw new Response('Not Found', {status: 404});
   }
 
-  const cloudflareEnvironment = (
-    context.cloudflare as {env?: {PUBLIC_API_URL?: string}} | undefined
-  )?.env;
-
   return {
-    apiUrl: cloudflareEnvironment?.PUBLIC_API_URL ?? 'http://localhost:8787',
+    apiUrl: resolveApiUrl(context),
     ceremonyUid,
   };
 }

--- a/apps/front/app/routes/admin.ceremonies.tsx
+++ b/apps/front/app/routes/admin.ceremonies.tsx
@@ -11,6 +11,7 @@ import {
 import {Input} from '@/components/ui/input';
 import {Label} from '@/components/ui/label';
 import type {Route} from './+types/admin.ceremonies';
+import {resolveApiUrl} from '@/lib/api';
 
 type CeremonyListItem = {
   uid: string;
@@ -41,12 +42,8 @@ export function meta() {
 }
 
 export async function loader({context}: Route.LoaderArgs) {
-  const cloudflareEnvironment = (
-    context.cloudflare as {env?: {PUBLIC_API_URL?: string}} | undefined
-  )?.env;
-
   return {
-    apiUrl: cloudflareEnvironment?.PUBLIC_API_URL ?? 'http://localhost:8787',
+    apiUrl: resolveApiUrl(context),
   };
 }
 

--- a/apps/front/app/routes/admin.login.tsx
+++ b/apps/front/app/routes/admin.login.tsx
@@ -2,6 +2,7 @@ import {useEffect} from 'react';
 import {useNavigate} from 'react-router';
 import type {Route} from './+types/admin.login';
 import {Button} from '@/components/ui/button';
+import {resolveApiUrl} from '@/lib/api';
 
 export function meta(): Route.MetaDescriptors {
   return [
@@ -21,9 +22,7 @@ export async function action({context, request}: Route.ActionArgs) {
     const formData = await request.formData();
     const password = formData.get('password') as string;
 
-    const apiUrl =
-      (context.cloudflare as {env: {PUBLIC_API_URL?: string}}).env
-        .PUBLIC_API_URL || 'http://localhost:8787';
+    const apiUrl = resolveApiUrl(context);
     const response = await fetch(`${apiUrl}/auth/login`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},

--- a/apps/front/app/routes/admin.movies.$id.tsx
+++ b/apps/front/app/routes/admin.movies.$id.tsx
@@ -6,6 +6,7 @@ import MovieInfoEditor from '../components/movie-info-editor';
 import NominationManager from '../components/nomination-manager';
 import ArticleLinkManager from '../components/article-link-manager';
 import type {Route} from './+types/admin.movies.$id';
+import {resolveApiUrl} from '@/lib/api';
 
 export type Translation = {
   uid: string;
@@ -82,9 +83,7 @@ export async function loader({context, params}: Route.LoaderArgs) {
     throw new Response('Movie ID is required', {status: 400});
   }
 
-  const apiUrl =
-    (context.cloudflare as {env: {PUBLIC_API_URL?: string}}).env
-      .PUBLIC_API_URL || 'http://localhost:8787';
+  const apiUrl = resolveApiUrl(context);
 
   return {
     apiUrl,

--- a/apps/front/app/routes/admin.movies.selections.tsx
+++ b/apps/front/app/routes/admin.movies.selections.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/card';
 import {Input} from '@/components/ui/input';
 import type {Route} from './+types/admin.movies.selections';
+import {resolveApiUrl} from '@/lib/api';
 
 type SelectionData = {
   date: string;
@@ -108,9 +109,7 @@ export function meta(): Route.MetaDescriptors {
 
 export async function loader({context}: Route.LoaderArgs) {
   return {
-    apiUrl:
-      (context.cloudflare as {env: {PUBLIC_API_URL?: string}}).env
-        .PUBLIC_API_URL || 'http://localhost:8787',
+    apiUrl: resolveApiUrl(context),
   };
 }
 

--- a/apps/front/app/routes/admin.movies.tsx
+++ b/apps/front/app/routes/admin.movies.tsx
@@ -12,6 +12,7 @@ import {
 import {Input} from '@/components/ui/input';
 import {Label} from '@/components/ui/label';
 import type {Route} from './+types/admin.movies';
+import {resolveApiUrl} from '@/lib/api';
 
 type Movie = {
   uid: string;
@@ -51,12 +52,6 @@ type CreateMovieResponse = {
   error?: string;
 };
 
-type CloudflareContext = {
-  env?: {
-    PUBLIC_API_URL?: string;
-  };
-};
-
 type SearchTimeoutGlobal = typeof globalThis & {
   searchTimeout?: ReturnType<typeof setTimeout>;
 };
@@ -86,11 +81,8 @@ export async function loader({context, request}: Route.LoaderArgs) {
   const limit = url.searchParams.get('limit') || '20';
   const search = url.searchParams.get('search') || '';
 
-  const cloudflareEnvironment = (
-    context.cloudflare as CloudflareContext | undefined
-  )?.env;
   return {
-    apiUrl: cloudflareEnvironment?.PUBLIC_API_URL ?? 'http://localhost:8787',
+    apiUrl: resolveApiUrl(context),
     page: Number.parseInt(page, 10),
     limit: Number.parseInt(limit, 10),
     search,

--- a/apps/front/app/routes/home.test.tsx
+++ b/apps/front/app/routes/home.test.tsx
@@ -1,5 +1,5 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Home, {loader, meta} from './home';
 import type {Route} from './+types/home';
@@ -418,9 +418,37 @@ describe('Home Component', () => {
 
       expect(
         screen.getByText(
-          /APIから映画データを取得できませんでした。フォールバック映画を表示しています。エラー: APIへの接続に失敗しました/,
+          /APIから映画データを取得できませんでした。エラー: APIへの接続に失敗しました/,
         ),
       ).toBeInTheDocument();
+    });
+
+    it('クライアント再取得に失敗してもダミー映画を表示しない', async () => {
+      const mockFetch = vi.mocked(globalThis.fetch);
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const loaderData = cast<ComponentProperties['loaderData']>(
+        createErrorLoaderData(),
+      );
+
+      render(
+        <Home
+          loaderData={loaderData}
+          actionData={createActionData()}
+          params={createParameters()}
+          matches={createMatches(loaderData)}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/APIから映画データを取得できませんでした/),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText(/The Shawshank Redemption/),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/front/app/routes/home.tsx
+++ b/apps/front/app/routes/home.tsx
@@ -232,15 +232,6 @@ export default function Home({loaderData}: Route.ComponentProps) {
           setError(
             error_ instanceof Error ? error_.message : 'Unknown error occurred',
           );
-          setMovies({
-            daily: {uid: '1', title: 'The Shawshank Redemption', year: 1994},
-            weekly: {uid: '1', title: 'The Shawshank Redemption', year: 1994},
-            monthly: {
-              uid: '1',
-              title: 'The Shawshank Redemption',
-              year: 1994,
-            },
-          });
         } finally {
           setLoading(false);
         }
@@ -664,8 +655,8 @@ function Movies({
       {error && (
         <div className="mb-4 p-4 border-2 border-red-600 text-red-600 font-mono text-sm">
           {locale === 'ja'
-            ? `APIから映画データを取得できませんでした。フォールバック映画を表示しています。エラー: ${error}…`
-            : `Failed to fetch movie data from API. Showing fallback movies. Error: ${error}…`}
+            ? `APIから映画データを取得できませんでした。エラー: ${error}`
+            : `Failed to fetch movie data from API. Error: ${error}`}
         </div>
       )}
 

--- a/apps/front/app/routes/home.tsx
+++ b/apps/front/app/routes/home.tsx
@@ -9,6 +9,7 @@ import {DEFAULT_LOCALE, getLocaleFromRequest} from '@/lib/locale';
 import {SITE_URL, buildSocialMeta} from '@/lib/meta';
 import {FilmCard} from '@/components/editorial/film-card';
 import type {FilmCardMovie} from '@/components/editorial/film-card';
+import {resolveApiUrl} from '@/lib/api';
 
 type HighlightedMovies = {
   daily?: FilmCardMovie;
@@ -114,9 +115,7 @@ export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
 
 export async function loader({context, request}: Route.LoaderArgs) {
   const locale = getLocaleFromRequest(request);
-  const apiUrl =
-    (context.cloudflare as {env: {PUBLIC_API_URL?: string}}).env
-      .PUBLIC_API_URL || 'http://localhost:8787';
+  const apiUrl = resolveApiUrl(context);
 
   try {
     // Cloudflare Workers環境ではfetchが利用可能

--- a/apps/front/app/routes/movies.$id.test.tsx
+++ b/apps/front/app/routes/movies.$id.test.tsx
@@ -136,13 +136,14 @@ const createLoaderData = (
   movieDetail: mockMovieDetail,
   turnstileSiteKey: 'test-site-key',
   locale: 'ja',
+  apiUrl: 'http://localhost:8787',
   ...overrides,
 });
 
 const successMeta = () =>
   meta(
     createMetaArguments(
-      {movieDetail: mockMovieDetail, locale: 'ja'},
+      {movieDetail: mockMovieDetail, locale: 'ja', apiUrl: 'http://localhost:8787'},
       {id: 'movie-123'},
     ),
   );
@@ -222,6 +223,7 @@ describe('MovieDetail Component', () => {
         movieDetail: mockMovieDetail,
         turnstileSiteKey: 'test-site-key',
         locale: 'ja',
+        apiUrl: 'http://localhost:8787',
       });
     });
 

--- a/apps/front/app/routes/movies.$id.tsx
+++ b/apps/front/app/routes/movies.$id.tsx
@@ -2,6 +2,7 @@ import {Turnstile} from '@marsidev/react-turnstile';
 import {useCallback, useState, type ChangeEvent, type ElementType} from 'react';
 import {Form, redirect} from 'react-router';
 import type {Route} from './+types/movies.$id';
+import {resolveApiUrl} from '@/lib/api';
 import {AwardTree} from '@/components/editorial/award-tree';
 import {BigYear} from '@/components/editorial/big-year';
 import {MetaLine} from '@/components/editorial/meta-line';
@@ -71,6 +72,7 @@ type LoaderSuccessResponse = {
   movieDetail: MovieDetailData;
   turnstileSiteKey?: string;
   locale: Locale;
+  apiUrl?: string;
 };
 
 type LoaderData = LoaderErrorResponse | LoaderSuccessResponse;
@@ -110,6 +112,7 @@ function useIsTestMode(): boolean {
 function useArticleLinkForm(
   isTestMode: boolean,
   actionData: Route.ComponentProps['actionData'],
+  apiUrl: string,
 ): ArticleLinkFormReturn {
   const [formData, setFormData] = useState<ArticleLinkFormState>({
     url: '',
@@ -137,9 +140,6 @@ function useArticleLinkForm(
       setTitleError('');
 
       try {
-        const apiUrl = isTestMode
-          ? 'http://localhost:8787'
-          : 'https://shine-api.yuta25.workers.dev';
         const response = await fetch(`${apiUrl}/fetch-url-title`, {
           method: 'POST',
           headers: {
@@ -483,8 +483,7 @@ export async function loader({
     const cloudflareEnvironment = (
       context.cloudflare as CloudflareContext | undefined
     )?.env;
-    const apiUrl =
-      cloudflareEnvironment?.PUBLIC_API_URL ?? 'http://localhost:8787';
+    const apiUrl = resolveApiUrl(context);
     const response = await fetch(`${apiUrl}/movies/${params.id}`, {
       signal: request.signal, // React Router v7推奨：abortシグナル
     });
@@ -507,7 +506,7 @@ export async function loader({
 
     const movieDetail = (await response.json()) as MovieDetailData;
     const turnstileSiteKey = cloudflareEnvironment?.PUBLIC_TURNSTILE_SITE_KEY;
-    return {movieDetail, turnstileSiteKey, locale};
+    return {movieDetail, turnstileSiteKey, locale, apiUrl};
   } catch {
     return {
       error: 'APIへの接続に失敗しました',
@@ -519,11 +518,7 @@ export async function loader({
 
 export async function action({context, params, request}: Route.ActionArgs) {
   try {
-    const cloudflareEnvironment = (
-      context.cloudflare as CloudflareContext | undefined
-    )?.env;
-    const apiUrl =
-      cloudflareEnvironment?.PUBLIC_API_URL ?? 'http://localhost:8787';
+    const apiUrl = resolveApiUrl(context);
     const formData = await request.formData();
 
     const url = formData.get('url') as string;
@@ -585,6 +580,9 @@ export default function MovieDetail({
   actionData,
 }: Route.ComponentProps) {
   const isTestMode = useIsTestMode();
+  const data = loaderData as LoaderData;
+  const apiUrl =
+    ('apiUrl' in data ? data.apiUrl : undefined) ?? 'http://localhost:8787';
   const {
     formData,
     handleInputChange,
@@ -592,9 +590,7 @@ export default function MovieDetail({
     isLoadingTitle,
     titleError,
     submissionResult,
-  } = useArticleLinkForm(isTestMode, actionData);
-
-  const data = loaderData as LoaderData;
+  } = useArticleLinkForm(isTestMode, actionData, apiUrl);
 
   if (isLoaderError(data)) {
     return (

--- a/apps/front/app/routes/og-movie.tsx
+++ b/apps/front/app/routes/og-movie.tsx
@@ -7,6 +7,7 @@ import {
 import {fetchPosterAsDataUri, loadGoogleFont} from '@/lib/og/assets';
 import {OG_HEIGHT, OG_WIDTH, buildMovieCardHtml} from '@/lib/og/template';
 import {upgradePosterForSharing} from '@/lib/meta';
+import {resolveApiUrl} from '@/lib/api';
 
 type MovieDetail = {
   title?: string;
@@ -33,9 +34,7 @@ export async function loader({context, request}: Route.LoaderArgs) {
     return new Response('Not Found', {status: 404});
   }
 
-  const apiUrl =
-    (context.cloudflare as {env: {PUBLIC_API_URL?: string}}).env
-      .PUBLIC_API_URL ?? 'http://localhost:8787';
+  const apiUrl = resolveApiUrl(context);
 
   const response = await fetch(`${apiUrl}/movies/${id}`, {
     signal: request.signal,

--- a/apps/front/app/routes/search.tsx
+++ b/apps/front/app/routes/search.tsx
@@ -6,6 +6,7 @@ import {selectBestPoster} from '@/lib/poster';
 import type {PosterInfo} from '@/lib/poster';
 import {DEFAULT_LOCALE, getLocaleFromRequest, type Locale} from '@/lib/locale';
 import {buildSocialMeta} from '@/lib/meta';
+import {resolveApiUrl} from '@/lib/api';
 
 type SearchMovieData = {
   uid: string;
@@ -65,9 +66,7 @@ export async function loader({context, request}: Route.LoaderArgs) {
   }
 
   try {
-    const apiUrl =
-      (context.cloudflare as {env: {PUBLIC_API_URL?: string}}).env
-        .PUBLIC_API_URL || 'http://localhost:8787';
+    const apiUrl = resolveApiUrl(context);
     const response = await fetch(
       `${apiUrl}/movies/search?q=${encodeURIComponent(searchQuery)}&page=${page}&limit=${limit}`,
       {


### PR DESCRIPTION
- API取得が失敗したとき「The Shawshank Redemption」の偽データを実在の選出のように表示していたのを廃止し、エラーバナーのみ表示するように変更
- `context.cloudflare` の手書きキャスト+フォールバックが10箇所に散在していたのを `lib/api.ts` の `resolveApiUrl()` に集約
- movies.$id のクライアントコードが本番APIホストを直書きしていた箇所を、loader経由の apiUrl に置き換え

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x