### PR TITLE
phantom依存の明示・react-hooks lint導入・scripts/を型/静的検査の対象に

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,8 +11,10 @@
     "@shine/scrapers": "workspace:*",
     "@shine/types": "workspace:*",
     "dompurify": "^3.3.2",
+    "drizzle-orm": "^0.45.1",
     "hono": "^4.12.7",
-    "jose": "^6.2.1"
+    "jose": "^6.2.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@cloudflare/puppeteer": "^1.0.6"

--- a/apps/scrapers/tsconfig.json
+++ b/apps/scrapers/tsconfig.json
@@ -13,15 +13,5 @@
     "../../packages/database/src/**/*",
     "../../packages/utils/src/**/*"
   ],
-  "exclude": ["node_modules", "dist"],
-  "ts-node": {
-    "esm": true,
-    "experimentalSpecifierResolution": "node",
-    "transpileOnly": true,
-    "compilerOptions": {
-      "module": "ESNext",
-      "target": "ES2022",
-      "allowImportingTsExtensions": false
-    }
-  }
+  "exclude": ["node_modules", "dist"]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
+import reactHooks from 'eslint-plugin-react-hooks';
 const ignores = [
   '**/.wrangler/**',
   '**/dist/**',
@@ -11,7 +12,6 @@ const ignores = [
   '**/*.mjs',
   '**/*.js',
   '**/*.cjs',
-  '**/.astro/**',
   '**/worker-configuration.d.ts',
   '**/build/**',
   '**/test-results/**',
@@ -19,13 +19,8 @@ const ignores = [
   '**/coverage/**',
   '**/.cache/**',
   '**/tmp/**',
-  '**/scripts/**',
   '**/package.json',
 ];
-
-const projectRules = {};
-
-const stylisticRules = {};
 
 export default tseslint.config(
   {
@@ -42,11 +37,13 @@ export default tseslint.config(
       },
     },
   },
-  eslintConfigPrettier,
   {
+    files: ['**/*.tsx'],
+    plugins: {'react-hooks': reactHooks},
     rules: {
-      ...projectRules,
-      ...stylisticRules,
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'error',
     },
-  }
+  },
+  eslintConfigPrettier
 );

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "format:fix": "prettier --write .",
     "type-check": "pnpm --filter @shine/front run typecheck && tsc -b --clean && tsc -b",
     "check": "concurrently -n \"lint,types\" -c \"yellow,green\" \"pnpm lint\" \"tsc --build --noEmit\"",
-    "typegen": "cd apps/front && npx react-router typegen"
+    "typegen": "cd apps/front && npx react-router typegen",
+    "scrapers:sns-post": "pnpm --filter @shine/scrapers run sns-post"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260310.1",
@@ -64,12 +65,12 @@
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-promise": "^7.2.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-unicorn": "^63.0.0",
     "globals": "^17.4.0",
     "jsdom": "^28.1.0",
     "msw": "^2.12.10",
     "prettier": "^3.8.1",
-    "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       eslint-plugin-promise:
         specifier: ^7.2.1
         version: 7.2.1(eslint@10.0.3(jiti@2.6.1))
+      eslint-plugin-react-hooks:
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.0.3(jiti@2.6.1))
       eslint-plugin-unicorn:
         specifier: ^63.0.0
         version: 63.0.0(eslint@10.0.3(jiti@2.6.1))
@@ -81,9 +84,6 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.4.0)(typescript@5.9.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -114,12 +114,18 @@ importers:
       dompurify:
         specifier: ^3.3.2
         version: 3.3.2
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@cloudflare/workers-types@4.20260310.1)(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.6.2)(gel@2.1.0)
       hono:
         specifier: ^4.12.7
         version: 4.12.7
       jose:
         specifier: ^6.2.1
         version: 6.2.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@cloudflare/puppeteer':
         specifier: ^1.0.6
@@ -2166,18 +2172,6 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -2447,10 +2441,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -2482,9 +2472,6 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -2749,9 +2736,6 @@ packages:
   core-js@3.43.0:
     resolution: {integrity: sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==}
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
@@ -2867,10 +2851,6 @@ packages:
 
   devtools-protocol@0.0.1299070:
     resolution: {integrity: sha512-+qtL3eX50qsJ7c+qVyagqi7AWMoQCBGNfoyJZMwm/NSXVqLYbuitrWEEIzxfUmTNy7//Xe8yhMmQ+elj3uAqSg==}
-
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -3136,6 +3116,12 @@ packages:
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
 
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-unicorn@63.0.0:
     resolution: {integrity: sha512-Iqecl9118uQEXYh7adylgEmGfkn5es3/mlQTLLkd4pXkIk9CTGrAbeUux+YljSa2ohXCBmQQ0+Ej1kZaFgcfkA==}
     engines: {node: ^20.10.0 || >=21.0.0}
@@ -3380,6 +3366,12 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
@@ -3713,9 +3705,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
@@ -4494,20 +4483,6 @@ packages:
     peerDependencies:
       typescript: '>=4.0.0'
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
@@ -4634,9 +4609,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
@@ -4897,10 +4869,6 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4917,6 +4885,12 @@ packages:
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -6573,14 +6547,6 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@tsconfig/node10@1.0.12': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -6878,10 +6844,6 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
@@ -6904,8 +6866,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
-
-  arg@4.1.3: {}
 
   arg@5.0.2: {}
 
@@ -7159,8 +7119,6 @@ snapshots:
 
   core-js@3.43.0: {}
 
-  create-require@1.1.1: {}
-
   cross-fetch@4.1.0:
     dependencies:
       node-fetch: 2.7.0
@@ -7259,8 +7217,6 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   devtools-protocol@0.0.1299070: {}
-
-  diff@4.0.4: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -7510,6 +7466,17 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.0.3(jiti@2.6.1))
       eslint: 10.0.3(jiti@2.6.1)
+
+  eslint-plugin-react-hooks@7.1.1(eslint@10.0.3(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
+      eslint: 10.0.3(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-unicorn@63.0.0(eslint@10.0.3(jiti@2.6.1)):
     dependencies:
@@ -7772,6 +7739,12 @@ snapshots:
   has-flag@4.0.0: {}
 
   headers-polyfill@4.0.3: {}
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hex-rgb@4.3.0: {}
 
@@ -8066,8 +8039,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
-
-  make-error@1.3.6: {}
 
   mark.js@8.11.1: {}
 
@@ -8960,24 +8931,6 @@ snapshots:
       picomatch: 4.0.3
       typescript: 5.9.3
 
-  ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.4.0
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -9105,8 +9058,6 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
-
-  v8-compile-cache-lib@3.0.1: {}
 
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
@@ -9343,8 +9294,6 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
-  yn@3.1.1: {}
-
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
@@ -9363,5 +9312,9 @@ snapshots:
       '@speed-highlight/core': 1.2.14
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod-validation-error@4.0.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.3.6: {}

--- a/scripts/check-missing-tmdb-ids.ts
+++ b/scripts/check-missing-tmdb-ids.ts
@@ -7,7 +7,7 @@ import {movies} from '@shine/database/schema/movies';
 config({path: '.dev.vars'});
 
 async function checkMissingTmdbIds() {
-  const db = getDatabase({
+  const database = getDatabase({
     TURSO_DATABASE_URL: process.env.TURSO_DATABASE_URL!,
     TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN!,
     TMDB_API_KEY: process.env.TMDB_API_KEY!,
@@ -15,7 +15,7 @@ async function checkMissingTmdbIds() {
     OMDB_API_KEY: process.env.OMDB_API_KEY!,
   });
 
-  const moviesWithImdbButNoTmdb = await db
+  const moviesWithImdbButNoTmdb = await database
     .select({
       uid: movies.uid,
       imdbId: movies.imdbId,
@@ -33,7 +33,7 @@ async function checkMissingTmdbIds() {
     console.log(`- ${movie.uid}: IMDb ${movie.imdbId}, Year ${movie.year}`);
   }
 
-  const duplicateTmdbIds = await db
+  const duplicateTmdbIds = await database
     .select({
       tmdbId: movies.tmdbId,
       count: count(movies.uid),

--- a/scripts/clean-duplicate-tmdb-ids.ts
+++ b/scripts/clean-duplicate-tmdb-ids.ts
@@ -6,7 +6,7 @@ import {movies} from '@shine/database/schema/movies';
 config({path: '.dev.vars'});
 
 async function cleanDuplicateTmdbIds() {
-  const db = getDatabase({
+  const database = getDatabase({
     TURSO_DATABASE_URL: process.env.TURSO_DATABASE_URL!,
     TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN!,
     TMDB_API_KEY: process.env.TMDB_API_KEY!,
@@ -16,7 +16,7 @@ async function cleanDuplicateTmdbIds() {
 
   console.log('Finding duplicate TMDb IDs...');
 
-  const duplicates = await db
+  const duplicates = await database
     .select({
       tmdbId: movies.tmdbId,
       count: count(movies.uid),
@@ -31,11 +31,15 @@ async function cleanDuplicateTmdbIds() {
   let cleaned = 0;
 
   for (const duplicate of duplicates) {
+    if (duplicate.tmdbId === null) {
+      continue;
+    }
+
     console.log(
       `\nProcessing TMDb ID ${String(duplicate.tmdbId)} (${duplicate.count} movies)`,
     );
 
-    const conflictingMovies = await db
+    const conflictingMovies = await database
       .select({
         uid: movies.uid,
         imdbId: movies.imdbId,
@@ -55,8 +59,9 @@ async function cleanDuplicateTmdbIds() {
     );
 
     for (const movie of toClean) {
-      await db
+      await database
         .update(movies)
+        // eslint-disable-next-line unicorn/no-null -- undefinedだとdrizzleが列更新をスキップする
         .set({tmdbId: null})
         .where(eq(movies.uid, movie.uid));
 
@@ -70,7 +75,7 @@ async function cleanDuplicateTmdbIds() {
   console.log(`\n✅ Cleaned up ${cleaned} duplicate TMDb IDs`);
 
   // 最終確認
-  const remainingDuplicates = await db
+  const remainingDuplicates = await database
     .select({
       tmdbId: movies.tmdbId,
       count: count(movies.uid),

--- a/scripts/find-duplicate-tmdb-ids.ts
+++ b/scripts/find-duplicate-tmdb-ids.ts
@@ -6,7 +6,7 @@ import {movies} from '@shine/database/schema/movies';
 config({path: '.dev.vars'});
 
 async function findDuplicateTmdbIds() {
-  const db = getDatabase({
+  const database = getDatabase({
     TURSO_DATABASE_URL: process.env.TURSO_DATABASE_URL!,
     TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN!,
     TMDB_API_KEY: process.env.TMDB_API_KEY!,
@@ -16,7 +16,7 @@ async function findDuplicateTmdbIds() {
 
   console.log('Checking for duplicate TMDb IDs...');
 
-  const duplicates = await db
+  const duplicates = await database
     .select({
       tmdbId: movies.tmdbId,
       count: count(movies.uid),
@@ -29,11 +29,15 @@ async function findDuplicateTmdbIds() {
   console.log(`Found ${duplicates.length} duplicate TMDb IDs`);
 
   for (const duplicate of duplicates) {
+    if (duplicate.tmdbId === null) {
+      continue;
+    }
+
     console.log(
       `\nTMDb ID ${duplicate.tmdbId} is used by ${duplicate.count} movies:`,
     );
 
-    const conflictingMovies = await db
+    const conflictingMovies = await database
       .select({
         uid: movies.uid,
         imdbId: movies.imdbId,

--- a/scripts/fix-japan-academy-ceremonies.ts
+++ b/scripts/fix-japan-academy-ceremonies.ts
@@ -1,13 +1,13 @@
-import {config as loadEnv} from 'dotenv';
+import {config as loadEnvironment} from 'dotenv';
 
 import {getDatabase, type Environment} from '@shine/database';
 import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
 import {awardOrganizations} from '@shine/database/schema/award-organizations';
 import {asc, eq} from 'drizzle-orm';
 
-loadEnv({path: '.dev.vars', override: true});
+loadEnvironment({path: '.dev.vars', override: true});
 if (!process.env.TURSO_DATABASE_URL || !process.env.TURSO_AUTH_TOKEN) {
-  loadEnv();
+  loadEnvironment();
 }
 
 type CeremonyRecord = {
@@ -79,7 +79,7 @@ async function main() {
   const seenYears: number[] = [];
 
   for (const ceremony of ceremonies) {
-    if (ceremony.year == null) {
+    if (ceremony.year == undefined) {
       continue;
     }
 
@@ -183,7 +183,9 @@ async function main() {
   }
 }
 
-main().catch(error => {
+try {
+  await main();
+} catch (error) {
   console.error(error);
-  process.exit(1);
-});
+  process.exitCode = 1;
+}

--- a/scripts/soft-delete-orphan-movies.ts
+++ b/scripts/soft-delete-orphan-movies.ts
@@ -7,9 +7,12 @@ import {movieSelections} from '../packages/database/src/schema/movie-selections.
 
 config({path: '.dev.vars'});
 
-const requiredEnvVars = ['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN'] as const;
+const requiredEnvironmentVariables = [
+  'TURSO_DATABASE_URL',
+  'TURSO_AUTH_TOKEN',
+] as const;
 
-for (const key of requiredEnvVars) {
+for (const key of requiredEnvironmentVariables) {
   if (!process.env[key]) {
     throw new Error(
       `${key} is required. Please add it to .dev.vars or the environment.`,
@@ -17,7 +20,7 @@ for (const key of requiredEnvVars) {
   }
 }
 
-const db = getDatabase({
+const database = getDatabase({
   TURSO_DATABASE_URL: process.env.TURSO_DATABASE_URL!,
   TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN!,
   TMDB_API_KEY: process.env.TMDB_API_KEY,
@@ -30,7 +33,7 @@ async function softDeleteOrphanMovies() {
     '🔍 Scanning for movies without nominations (and not already deleted)...',
   );
 
-  const orphanMovies = await db
+  const orphanMovies = await database
     .select({
       uid: movies.uid,
       imdbId: movies.imdbId,
@@ -51,7 +54,7 @@ async function softDeleteOrphanMovies() {
   );
   const now = Math.floor(Date.now() / 1000);
 
-  await db.transaction(async trx => {
+  await database.transaction(async trx => {
     for (const movie of orphanMovies) {
       await trx
         .update(movies)

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,13 +1,14 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "allowJs": true,
-    "checkJs": false,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "es2022",
-    "types": ["node"],
-    "noEmit": true,
-    "esModuleInterop": true
+    "composite": true,
+    "types": ["node", "@cloudflare/workers-types"]
   },
-  "include": ["./**/*.cjs"]
+  "include": [
+    "./**/*.ts",
+    "./**/*.cjs",
+    "../packages/database/src/**/*",
+    "../packages/utils/src/**/*"
+  ],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     {"path": "./apps/scrapers"},
     {"path": "./packages/database"},
     {"path": "./packages/utils"},
-    {"path": "./packages/types"}
+    {"path": "./packages/types"},
+    {"path": "./scripts"}
   ],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
- `apps/api` が未宣言のまま shamefully-hoist で偶然解決していた zod / drizzle-orm を package.json に明示
- eslint-plugin-react-hooks を導入（rules-of-hooks / exhaustive-deps、既存コードは違反ゼロ。recommended に含まれる React Compiler 系の新ルールは既存コード22箇所に触れるため今回は見送り）
- `scripts/` の .ts 5本（本番DBを触る soft-delete-orphan-movies 含む）が tsconfig の include からも eslint からも完全に外れていたのを検査対象化し、検出された null ガード漏れを修正
- 未使用の ts-node を削除

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x