### PR TITLE
docs: CLAUDE.md/AGENTS.md/README/OpenAPIを実装に追従

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Test
         run: pnpm run test
 
+      - name: Validate OpenAPI spec
+        run: pnpm run docs:validate
+
       - name: Build - API
         run: pnpm --filter @shine/api run build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,43 +2,41 @@
 
 ## Project Structure & Module Organization
 
-- The repo is a pnpm workspace with `api`, `front`, and `scrapers` packages alongside shared `src/` database logic.
-- `src/` hosts Drizzle ORM schema, migrations, and shared utilities; database setup scripts live in `scripts/`.
-- Cloudflare Worker code sits in `apps/api/src` with route files under `routes/` and middleware/services folders; tests reside in `apps/api/tests` and `apps/api/src/__tests__`.
-- The Remix front end lives in `front/app` (routes named with Remix dot-segments), static assets in `front/public`, and worker builds in `front/build`.
+- The repo is a pnpm workspace: `apps/api`, `apps/front`, `apps/scrapers`, plus shared packages `packages/database` (Drizzle schema, migrations, seeds), `packages/utils`, and `packages/types`. One-off DB scripts live in `scripts/`.
+- Cloudflare Worker code sits in `apps/api/src` with route files under `routes/` and middleware/services folders; tests reside in `apps/api/src/__tests__`.
+- The React Router v7 front end lives in `apps/front/app` (routes named with dot-segments), static assets in `apps/front/public`, and worker builds in `apps/front/build`.
 - Scraper CLIs are in `apps/scrapers/src` with per-festival directories and matching `__tests__`; run outputs to `data/` and `tmp/`.
 
 ## Build, Test, and Development Commands
 
-- Use `pnpm install` to sync workspaces (Node >=18).
-- `pnpm dev` boots API (`wrangler`) and front dev server concurrently; run package-specific dev with `pnpm api:dev` or `pnpm --filter front run dev`.
-- Execute `pnpm front:build` for production Remix assets, and `pnpm api:deploy:dev` / `pnpm front:deploy:dev` for Cloudflare previews.
-- Run `pnpm test` for the Vitest suite, or scoped variants: `pnpm test:api`, `pnpm test:front`, `pnpm test:scrapers`; append `--watch` locally.
-- Database migrations rely on `pnpm db:generate` and `pnpm db:migrate`; studio launches via `pnpm db:studio`.
+- Use `pnpm install` to sync workspaces (Node 22, see `.tool-versions`).
+- `pnpm dev` boots API (`wrangler`) and front dev server concurrently; run package-specific dev with `pnpm api:dev` or `pnpm front:dev`. Note: `pnpm --filter @shine/api run dev` skips the DB environment setup that the root scripts perform — prefer the root scripts.
+- Execute `pnpm front:build` for production assets, and `pnpm api:deploy:prod` / `pnpm front:deploy:prod` to deploy (production only; the dev environment is not used).
+- Run `pnpm test` for the Vitest suite, or scoped variants: `pnpm test:api`, `pnpm test:front`, `pnpm test:scrapers`.
+- Database migrations rely on `pnpm db:generate` and `pnpm db:migrate` (`:prod` variants for production); studio launches via `pnpm db:studio`.
 
 ## Coding Style & Naming Conventions
 
-- TypeScript modules use ESLint (flat config) + Prettier; format before pushing with `pnpm lint` or `pnpm lint:fix`.
-- Prefer tabs for indentation (existing codebase style) and single quotes; keep files ESM (`type: module`).
-- Follow domain-driven naming: PascalCase for React components/services, camelCase for helpers, dot-separated Remix route filenames (e.g. `admin.movies.$id.tsx`).
-- Shared types live in `packages/types` and feature-specific folders; co-locate tests as `.test.ts`/`.test.tsx`.
+- TypeScript modules use ESLint (flat config) + Prettier; format before pushing with `pnpm lint:fix` (runs eslint --fix and prettier --write).
+- Indentation is 2 spaces (Prettier default) with single quotes; keep files ESM (`type: module`).
+- Follow domain-driven naming: PascalCase for React components/services, camelCase for helpers, dot-separated route filenames (e.g. `admin.movies.$id.tsx`).
+- Shared types live in `packages/types`; co-locate tests as `.test.ts`/`.test.tsx`.
 
 ## Testing Guidelines
 
-- Vitest is configured via `vitest.config.ts` and `vitest.front.config.ts`; front-end tests rely on JSDOM/MSW, API tests run against Cloudflare Workers shim.
-- Use descriptive `*.test.ts(x)` names mirroring source folders; integration tests for routes belong in `front/app/routes` alongside page files.
-- Collect coverage with `pnpm test -- --coverage`; review reports under `coverage/` and `test-results/`.
-- For data pipelines, add fixture seeds under `scrapers/src/__tests__/fixtures` and validate idempotency.
+- Vitest is configured via `vitest.config.ts` (node + jsdom projects); CI runs `pnpm test`.
+- Use descriptive `*.test.ts(x)` names mirroring source folders; route tests live in `apps/front/app/routes` alongside page files.
+- API tests that need a real database use a libsql `file:` URL with `migrate()` (see `apps/api/src/__tests__/reselect-exclude.test.ts` for the pattern).
+- For data pipelines, add fixture seeds under `apps/scrapers/src/__tests__` and validate idempotency.
 
 ## Commit & Pull Request Guidelines
 
 - Commit history follows Conventional Commits (`feat`, `fix`, `chore`, optional scope like `fix(api): …`); keep summaries imperative and ≤72 chars.
 - Reference issues in the body (`Refs #123`) and detail database or schema updates explicitly.
-- Pull requests should summarize scope, list test commands executed, and include screenshots or cURL examples for UI/API changes.
-- Ensure schema or OpenAPI adjustments update `api/openapi.yml` and regenerate artifacts (`pnpm docs:bundle`) before review.
+- Pull requests should summarize scope concisely (no boilerplate Summary/Test Plan sections).
+- Ensure schema or OpenAPI adjustments update `apps/api/openapi.yml` and pass `pnpm docs:validate` before review.
 
 ## Environment & Configuration Notes
 
-- Cloudflare credentials and LibSQL URLs are loaded via `.env` variables consumed by `scripts/setup-database-environment.cjs`; never commit secrets.
+- Turso credentials and API keys are loaded from `.dev.vars` at the repo root via `scripts/setup-database-environment.cjs` (API/DB) and `apps/scrapers/src/common/environment.ts` (scraper CLIs); never commit secrets.
 - When using the scrapers, populate `tmp/` instead of `data/` until outputs are vetted, and clean transient artifacts before submitting PRs.
-- Always use context7 when I need code generation, setup or configuration steps, or library/API documentation. This means you should automatically use the Context7 MCP tools to resolve library id and get library docs without me having to explicitly ask.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,569 +4,123 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-SHINE is a comprehensive movie database project designed to be the world's most organized movie database. It collects and organizes movie information, awards, nominations, and multilingual translations. The project is built on Cloudflare Workers with Turso (libSQL) database and uses a modular architecture with separate packages for API, scrapers, database, and frontend.
+SHINE is a comprehensive movie database project designed to be the world's most organized movie database. It collects and organizes movie information, awards, nominations, and multilingual translations. The project is built on Cloudflare Workers with Turso (libSQL) database.
 
 ## Architecture
 
-The project uses a simplified monorepo structure with pnpm workspaces:
+pnpm workspace monorepo:
 
-- **api/** - Hono-based REST API running on Cloudflare Workers
-- **scrapers/** - CLI-based data collection tools (Wikipedia, TMDb, Cannes Film Festival, Academy Awards)
-- **front/** - React Router v7-based frontend (Cloudflare Workers)
-- **src/** - Shared database schemas, migrations, and utilities
+- **apps/api/** – Hono-based REST API on Cloudflare Workers
+- **apps/front/** – React Router v7 frontend with SSR on Cloudflare Workers (Tailwind CSS v4)
+- **apps/scrapers/** – CLI-based data collection tools (Wikipedia, TMDb, Cannes, Academy Awards, Japan Academy Awards, availability checks)
+- **packages/database/** – Drizzle ORM schema, migrations, seeds, shared DB helpers
+- **packages/types/** – Shared domain types
+- **packages/utils/** – Cross-application utilities
+- **scripts/** – One-off DB maintenance scripts (run with tsx; type-checked and linted)
 
 Key design patterns:
 
-- Date-seeded movie selection (daily/weekly/monthly) with deterministic hash-based randomization, persisted in database
-- Multilingual support through a flexible translations table
-- Comprehensive awards and nominations tracking system
-- UUID-based primary keys with snake_case database naming
-- Database: Turso (libSQL) - a SQLite-compatible edge database
+- Date-seeded movie selection (daily/weekly/monthly) with deterministic hash-based randomization, persisted in `movie_selections`
+- Multilingual support through the `translations` table
+- Awards / nominations tracking (organizations → ceremonies → categories → nominations)
+- UUID primary keys; camelCase in schema mapped to snake_case in the database (`casing: 'snake_case'`)
+- Soft delete on movies via `deleted_at` — every movie lookup (API and scrapers) must filter or skip soft-deleted rows
 
 ## Common Commands
 
-### Development
-
 ```bash
-# Start both API and React Router v7 frontend development servers
-pnpm run dev
+pnpm run dev              # API + front dev servers
+pnpm run api:dev          # API only (wrangler, loads .dev.vars)
+pnpm run front:dev        # front only
 
-# Start API development server with local DB persistence
-pnpm run api:dev
-
-# Start React Router v7 frontend development server
-pnpm run front:dev
-
-# Run scrapers (CLI tools)
+# Scrapers (CLI, run locally)
 pnpm run scrapers:academy-awards
-pnpm run scrapers:cannes-film-festival [year]  # Optional year parameter
+pnpm run scrapers:cannes-film-festival [--year YYYY] [--winners-only]
 pnpm run scrapers:japanese-translations
-pnpm run scrapers:japan-academy-awards
+pnpm run scrapers:japan-academy-awards [--year YYYY] [--dry-run] [--seed]
 pnpm run scrapers:movie-import
 pnpm run scrapers:availability-check
-```
 
-### Database Operations
+# Database (dev / prod)
+pnpm run db:studio / db:generate / db:migrate / db:push
+pnpm run db:studio:prod / db:generate:prod / db:migrate:prod / db:push:prod
 
-```bash
-# Development database commands
-pnpm run db:studio
-pnpm run db:generate
-pnpm run db:migrate
-pnpm run db:push
+# Quality gates — run before every commit
+pnpm lint:fix && pnpm check   # eslint --fix + prettier --write, then lint + tsc build
+pnpm run test                 # vitest (node + jsdom projects)
+pnpm run test:api / test:front / test:scrapers / test:database
 
-# Production database commands
-pnpm run db:studio:prod
-pnpm run db:generate:prod
-pnpm run db:migrate:prod
-pnpm run db:push:prod
-```
-
-### Deployment
-
-```bash
-# Deploy API to development environment
-pnpm run api:deploy:dev
-
-# Deploy API to production environment
+# Deploy (production only — dev environment is not used)
 pnpm run api:deploy:prod
-
-# Deploy React Router v7 frontend to development environment
-pnpm run front:deploy:dev
-
-# Deploy React Router v7 frontend to production environment
 pnpm run front:deploy:prod
 
-# Note: Scrapers run locally as CLI tools and are not deployed
-```
-
-### API Documentation
-
-```bash
-# Validate OpenAPI specification
-pnpm run docs:validate
-
-# Build static documentation
-pnpm run docs:build
-
-# Preview documentation locally
+# API docs
+pnpm run docs:validate   # redocly lint apps/api/openapi.yml (keep it green)
 pnpm run docs:serve
-
-# Bundle OpenAPI spec to JSON
-pnpm run docs:bundle
-
-# Access interactive documentation (when API is running)
-# Swagger UI: http://localhost:8787/docs
-# ReDoc: http://localhost:8787/docs/redoc
-# OpenAPI spec: http://localhost:8787/docs/openapi.yml
 ```
-
-### Utilities
-
-```bash
-# Lint code
-npx eslint .
-
-# Format code
-npx prettier --write .
-
-# Run React Router v7 frontend tests
-pnpm run test:front
-```
-
-## React Router v7 Frontend
-
-SHINE project uses a modern React Router v7-based frontend built with Test-Driven Development (TDD). This implementation runs on Cloudflare Workers and provides server-side rendering (SSR) with full TypeScript support.
-
-### Architecture
-
-- **Framework**: React Router v7 with TypeScript
-- **Runtime**: Cloudflare Workers with SSR
-- **Styling**: Tailwind CSS v4
-- **Testing**: Vitest with React Testing Library
-- **Type Safety**: Full TypeScript coverage with Cloudflare Workers types
-
-### TDD Implementation Features
-
-All features have been implemented using Test-Driven Development with comprehensive test coverage:
-
-**Pages & Routes:**
-
-- **Home Page (`/`)**: Date-seeded movie selections (daily/weekly/monthly)
-- **Movie Details (`/movies/:id`)**: Individual movie information and nominations
-- **Search (`/search`)**: Movie search functionality with filters
-- **Admin Login (`/admin/login`)**: JWT-based authentication
-- **Admin Movies (`/admin/movies`)**: Movie management interface
-
-**Core Features:**
-
-- Responsive design with mobile-first approach
-- JWT authentication with localStorage persistence
-- Error handling and loading states
-- Accessibility-compliant components
-- SEO-optimized meta tags
-
-### Test Coverage
-
-Complete test suite with **51 tests passing** across all components:
-
-```bash
-✓ front/app/routes/admin.movies.test.tsx (12 tests)
-✓ front/app/routes/movies.$id.test.tsx (10 tests)
-✓ front/app/routes/home.test.tsx (8 tests)
-✓ front/app/routes/admin.login.test.tsx (10 tests)
-✓ front/app/routes/search.test.tsx (11 tests)
-```
-
-**Test Categories:**
-
-- Loader functions (API data fetching)
-- Component rendering and interactions
-- Error state handling
-- Form submissions and validation
-- Authentication flows
-- Meta tag generation
-
-### Authentication System
-
-- **Method**: JWT tokens stored in localStorage
-- **Admin Login**: Password-based authentication with the API
-- **Route Protection**: Client-side auth checks for admin routes
-- **Session Management**: Automatic token validation and renewal
-
-### API Integration
-
-Seamlessly integrates with the Hono-based API:
-
-- Environment-aware API URL configuration
-- Comprehensive error handling for network failures
-- Type-safe API response interfaces
-- Optimistic UI updates for better user experience
-
-### Development Workflow
-
-```bash
-# Start development server
-pnpm run front:dev
-
-# Run tests
-pnpm run test:front
-
-# Build for production
-pnpm run front:build
-
-# Deploy to development
-pnpm run front:deploy:dev
-
-# Deploy to production
-pnpm run front:deploy:prod
-```
-
-### Key Files
-
-- `front/app/routes/` - Page components with loaders and tests
-- `front/app/root.tsx` - Root application component
-- `front/workers/app.ts` - Cloudflare Workers entry point
-- `front/react-router.config.ts` - React Router configuration
-- `front/wrangler.jsonc` - Cloudflare Workers deployment configuration
 
 ## Database Schema
-
-The core entities follow this relationship structure:
 
 ```
 movies ←→ translations (movie titles/descriptions)
   ↓ 1:N     ↓ 1:N
 nominations  movie_selections (daily/weekly/monthly picks)
   ↓ N:1         ↓ 1:N
-award_categories  poster_urls
-  ↓ N:1
-award_organizations
-  ↓ 1:N
-award_ceremonies
+award_categories  poster_urls, reference_urls, article_links,
+  ↓ N:1           movie_availability_checks
+award_organizations → award_ceremonies
 ```
 
-Important schema details:
+Important schema rules:
 
-- All tables use UUID primary keys generated by `generateUUID()` utility
-- **`translations` table structure**:
-  - `resourceType` must be `"movie_title"` for movie titles (NOT `"movie"`)
-  - `content` field contains the raw title text directly (NOT formatted like `"title:Movie Name"`)
-  - Composite unique constraint on `(resourceType, resourceUid, languageCode)`
-  - Movie titles are NOT stored in the movies table itself - they must be in translations
-- Database uses snake_case naming convention (configured in drizzle.config.ts)
-- Date-seeded movie selection uses deterministic hash-based algorithms with persistence in `movie_selections` table
+- All tables use UUID primary keys via `generateUUID()`
+- **`translations`**: `resourceType` is an enum of `'movie_title' | 'movie_description'`; `content` holds the raw text (never `"title:..."` prefixed). Composite unique on `(resourceType, resourceUid, languageCode)`. Movie titles live ONLY here, not on `movies`
+- `movies.deletedAt` implements soft delete; unique constraints on `imdbId`/`tmdbId` still include deleted rows, so dedup checks must NOT filter them out (skip instead of re-creating)
+- Schema fields are camelCase (`createdAt`) but map to snake_case columns; always reference schema fields in queries, never hardcoded column names
 
-## Database Configuration
+## Environment Configuration
 
-The project uses Turso (libSQL) as the database with separate databases for development and production. Configuration requires:
+Local development reads `.dev.vars` at the repo root (loaded by `scripts/setup-database-environment.cjs` and `apps/scrapers/src/common/environment.ts`):
 
-**Development Environment:**
+- `TURSO_DATABASE_URL` / `TURSO_AUTH_TOKEN`
+- `ADMIN_PASSWORD`, `JWT_SECRET` (admin auth; JWT expires after 7 days)
+- `TMDB_API_KEY`, `TMDB_LEAD_ACCESS_TOKEN`, `OMDB_API_KEY`
+- `TURNSTILE_SECRET_KEY` / `PUBLIC_TURNSTILE_SITE_KEY`
 
-- `TURSO_DATABASE_URL`: Your development Turso database URL
-- `TURSO_AUTH_TOKEN`: Your development Turso authentication token
-
-**Production Environment:**
-
-- `TURSO_DATABASE_URL_PROD`: Your production Turso database URL
-- `TURSO_AUTH_TOKEN_PROD`: Your production Turso authentication token
-
-**Admin Authentication:**
-
-- `ADMIN_PASSWORD`: Admin password for login
-- `JWT_SECRET`: Secret key for JWT token generation (uses `jose` library)
-
-**External APIs (for scrapers):**
-
-- `TMDB_API_KEY`: TMDb API key for movie data
-- `TMDB_LEAD_ACCESS_TOKEN`: TMDb access token
-- `OMDB_API_KEY`: OMDb API key for additional movie data
-
-For local development with Cloudflare Workers:
-
-1. Copy `.dev.vars.example` to `.dev.vars` in the root directory
-2. Add your Turso credentials and API keys
-3. The `.dev.vars` file is automatically symlinked to `api/` and `scrapers/` directories
-4. Environment variables are loaded automatically by wrangler during development
-
-For production deployment, set secrets using:
-
-```bash
-wrangler secret put TURSO_AUTH_TOKEN_PROD --env production
-wrangler secret put ADMIN_PASSWORD --env production
-wrangler secret put JWT_SECRET --env production
-```
-
-## Data Collection Strategy
-
-Scrapers are CLI-based tools that run locally and follow this priority order:
-
-1. Wikipedia (primary source for basic info and awards)
-2. TMDb (The Movie Database - for Japanese translations and poster URLs)
-3. Cannes Film Festival (official selections and awards)
-4. Academy Awards (Oscar nominations and wins)
-5. OMDb (planned for additional movie data)
-
-Scraping features:
-
-- Cheerio for HTML parsing with error handling and retry logic
-- Command-line arguments support (e.g., specific year for Cannes scraper)
-- Incremental updates to avoid duplicate data
-- Integration with TMDb API for enriched movie data
-- Automatic poster URL and translation fetching
+Cloudflare Workers: non-secret vars go in `wrangler.jsonc`/`wrangler.toml` `vars`; secrets via `wrangler secret put`. React Router v7 reads env via loader context (`resolveApiUrl(context)` in `apps/front/app/lib/api.ts`).
 
 ## API Design
 
-The main API endpoint (`/`) returns date-seeded movie selections:
+- `GET /` – date-seeded selections (daily / weekly starting Friday / monthly), locale-aware
+- `GET /movies/:id` – movie details with translations
+- `POST /auth/login` – admin login (rate-limited per IP)
+- `POST /fetch-url-title` – URL title fetch (SSRF-guarded via `utils/url-safety.ts`)
+- `/admin/*` – JWT-protected admin CRUD (movies, ceremonies, nominations, posters, translations, TMDb sync, selection overrides). See `apps/api/openapi.yml` for the full list — keep it in sync with implementations
+- Edge caching via `EdgeCache` (`apps/api/src/utils/cache.ts`): cache keys include locale; writes use `set()`, reads use `get()`. When invalidating movie caches use `getMovieCacheKeysForAllLocales()`
 
-- Daily: Changes every day
-- Weekly: Changes every Friday (week starts Friday)
-- Monthly: Changes every month
+## Frontend (React Router v7)
 
-Movie selection features:
-
-- Hash-based seeding ensures deterministic but varied results
-- Selections are persisted in the `movie_selections` table
-- Existing selections are reused to maintain consistency
-- Fallback to hash-based selection if no movies match criteria
-
-### Public API Endpoints
-
-- `GET /` - Get date-seeded movie selections (daily/weekly/monthly)
-- `GET /movies/:id` - Get movie details with all translations
-
-### Admin API Endpoints
-
-Authentication is handled via JWT tokens (using `jose` library) stored in localStorage (client-side only):
-
-- `POST /auth/login` - Login with admin password
-- `GET /admin/movies` - List all movies (paginated)
-- `POST /movies/:id/translations` - Add or update movie translation
-- `DELETE /movies/:id/translations/:lang` - Delete movie translation
-- `DELETE /admin/movies/:id` - Delete movie and all related data (nominations, translations, posters, selections)
-- `PUT /admin/movies/:id/imdb-id` - Update IMDb ID with optional TMDb data refresh
-- `POST /admin/movies/:id/posters` - Add poster URL to movie
-- `DELETE /admin/movies/:movieId/posters/:posterId` - Delete poster from movie
-- `POST /reselect` - Force new movie selection for a specific period
-
-### Admin Frontend Routes
-
-Admin interface pages (authentication required via localStorage token):
-
-- `/admin/login` - Admin login page
-- `/admin/movies` - Movies list with pagination
-- `/admin/movies/:id` - Edit movie details and translations
-
-Note: Authentication uses localStorage, not cookies, ensuring client-side auth management.
+- Public: `/` (selections), `/movies/:id`, `/search`, sitemaps, OG images (`/og/*`)
+- Admin (localStorage JWT): `/admin/login`, `/admin/movies`, `/admin/movies/:id`, `/admin/movies/selections`, `/admin/ceremonies`, `/admin/ceremonies/:uid`
+- API URL resolution: always `resolveApiUrl(context)` from `@/lib/api` — never hand-cast `context.cloudflare`
+- Tests: Vitest + React Testing Library, co-located `*.test.tsx`
 
 ## Code Style and Conventions
 
-- TypeScript with strict configuration
-- ESLint with recommended + strict + unicorn rules
-- Prettier for formatting with import organization
+- TypeScript strict; ESLint flat config (js/ts recommended + unicorn + react-hooks) with `--max-warnings 0`; Prettier for formatting
+- Run `pnpm lint:fix && pnpm check` before every commit
 - No comments in code unless explicitly requested
-- Follow existing patterns for database queries and API responses
-- Use existing utilities and libraries (Hono, Drizzle, Cheerio)
+- API URL convention: base URLs without trailing slash, paths start with `/`
+- Follow existing patterns for DB queries (Drizzle) and API responses (Hono)
 
-## Important Files
+## Development Guidelines
 
-- `packages/database/src/schema/index.ts` - Database schema definitions
-- `apps/api/src/index.ts` - Main API implementation with date-seeding logic
-- `drizzle.config.ts` - Database configuration for Turso
-- `.dev.vars.example` - Environment variable template
-- `.dev.vars` - Local development variables (symlinked to `api/` and `scrapers/`)
-- `packages/database/src/schema/movie-selections.ts` - Movie selection persistence schema
-- `apps/scrapers/src/japanese-translations/` - TMDb integration for translations
-- `apps/scrapers/src/cannes-film-festival.ts` - Cannes scraper with year parameter support
-
-## Recent Changes Log
-
-Track recent changes and updates to keep CLAUDE.md synchronized with the codebase.
-
-### 2025-01-10
-
-- Updated CLAUDE.md to reflect current project state
-- Added movie_selections table documentation
-- Updated scraper commands (TMDb, Cannes Film Festival integration)
-- Fixed environment variable names (removed \_DEV suffix)
-- Added missing API endpoints documentation
-- Updated file paths to match current structure
-- Added `pnpm run dev` command to start both API and frontend concurrently
-
-### 2025-06-10
-
-- Improved `/admin/movies` page with better sorting and poster display:
-  - Changed default sort order to `created_at DESC` (newest movies first)
-  - Modified poster display to show only one poster per movie instead of multiple
-- Added movie deletion functionality:
-  - New `DELETE /admin/movies/:id` API endpoint with cascading delete of all related data
-  - Added delete button with confirmation dialog in admin movies list
-  - Proper cleanup of movie_selections, nominations, translations, and poster_urls
-- Fixed `/admin/movies` API endpoint bug:
-  - Corrected SQL ORDER BY clause to use proper camelCase column name `createdAt` instead of snake_case `created_at`
-  - Used SQL template with schema field reference: `sql`${movies.createdAt} DESC`` at apps/api/src/index.ts:581
-
-### 2025-06-10 (Updated)
-
-- Fixed API URL handling inconsistency:
-  - Standardized all API URL construction to NOT include trailing slash in base URL
-  - All API paths must start with leading slash (e.g., `/auth/login`, `/reselect`)
-  - Fixed API URL construction in frontend and `wrangler.jsonc` to follow this pattern
-  - This prevents URL construction errors like `http://localhost:8787reselect`
-- Fixed `/reselect` endpoint:
-  - The endpoint expects `type` parameter, not `period`
-  - Request body should include both `type` and `locale`
-- Fixed movie import script (`movie-import-from-list.ts`):
-  - Corrected `resourceType` to use `"movie_title"` instead of `"movie"`
-  - Fixed `content` field to store raw title text instead of formatted strings
-  - Resolved all ESLint errors (non-null assertions, null vs undefined, unused variables)
-
-### 2025-06-11
-
-- Fixed Cloudflare deployment environment variable issues:
-  - Environment variables in Cloudflare Workers must be set in `wrangler.jsonc` under `vars` section, not as secrets
-  - React Router v7 components access environment variables via loader context
-  - Secrets and vars cannot coexist with the same name - delete secrets if using vars
-- Fixed movie import nomination assignment bug:
-  - Movie import scripts were incorrectly assigning all nominations to Cannes Film Festival
-  - Root cause: Database lookups for categories and ceremonies didn't filter by `organizationUid`
-  - Fixed `apps/scrapers/src/movie-import-from-list.ts` and `apps/scrapers/src/academy-awards.ts` to use compound WHERE clauses
-  - Now properly filters by both identifying field AND `organizationUid` using `and()` condition
-  - This ensures nominations are assigned to the correct award organization
-
-### 2025-06-11 (Article Links Feature)
-
-- Added article links feature for user-submitted movie-related articles:
-  - New `article_links` table with spam/flagging support and rate limiting
-  - Public submission API with IP-based rate limiting (10 submissions per hour per IP)
-  - Article links displayed in MovieCard components (top 3 by submission date)
-  - Dedicated movie detail pages (`/movies/[id]`) for article submission
-  - Admin spam flagging functionality via `POST /admin/article-links/:id/spam`
-- Implemented mobile-responsive collapsible content:
-  - Nominations, article links, and add article button are collapsible on mobile (≤768px)
-  - Always expanded on desktop (>768px)
-  - Smooth animations with toggle button and icons
-- **Removed view counting feature completely**:
-  - Removed `viewCount` column from `article_links` table
-  - Removed `/article-links/:id/view` API endpoint
-  - Articles now sorted by `submittedAt DESC` instead of view count
-  - Cleaner UI without view count displays
-
-### 2025-06-11 (Dependabot Setup)
-
-- Added Dependabot configuration (`.github/dependabot.yml`) for automated dependency updates:
-  - Monitors all workspace packages: root, api, scrapers, front
-  - Weekly updates on Monday 9:00 AM
-  - Scoped commit message prefixes: `deps(api)`, `deps(scrapers)`, `deps(front)`, `deps`
-  - Rate-limited PRs: 5 per package, 3 for GitHub Actions
-  - Includes GitHub Actions monitoring for CI/CD workflow updates
-
-### 2025-06-11 (Cannes Winner Update Enhancement)
-
-- Added `--winners-only` option to Cannes Film Festival scraper for lightweight winner status updates:
-  - **Lightweight mode**: Skips TMDb API calls, poster downloads, and new movie creation
-  - **Winner detection improvement**: Enhanced `findPalmeDOrWinner` function with better Wikipedia parsing
-  - **CLI support**: Added `--winners-only` flag to `cannes-film-festival-cli.ts`
-  - **Database efficiency**: Only updates `isWinner` flag in existing nominations
-- **Usage**:
-  - `pnpm run scrapers:cannes-film-festival --winners-only` (all years)
-  - `pnpm run scrapers:cannes-film-festival --year 2024 --winners-only` (specific year)
-- **Key Files**:
-  - `apps/scrapers/src/cannes-film-festival.ts`: Added `updateAllCannesWinnersOnly()` and `updateCannesWinnersOnly(year)` functions
-  - `apps/scrapers/src/cannes-film-festival-cli.ts`: Added CLI argument parsing for `--winners-only` flag
-
-### 2025-06-13 (Admin Movie Management Enhancement)
-
-- **IMDb ID Manual Update with TMDb Integration**:
-  - Added `PUT /admin/movies/:id/imdb-id` API endpoint with optional TMDb data refresh
-  - Includes TMDb ID auto-detection, poster fetching, and Japanese translation retrieval
-  - Frontend modal with checkbox for "TMDb から追加データを取得" option
-  - Comprehensive validation: IMDb ID format, duplicate prevention, API error handling
-  - Fixed missing `tmdbId` field in movie details API response (`/movies/:id`)
-- **Poster Management System**:
-  - Added `POST /admin/movies/:id/posters` and `DELETE /admin/movies/:movieId/posters/:posterId` endpoints
-  - Complete poster CRUD operations with primary poster designation
-  - Frontend grid-based poster display with thumbnails, metadata, and delete functionality
-  - Support for manual poster addition with URL, dimensions, language, and source tracking
-  - Enhanced movie details API to include complete poster information array
-- **Key Features**:
-  - Manual IMDb ID updates trigger optional TMDb data synchronization
-  - Poster management with visual grid interface and primary designation
-  - Comprehensive form validation and error handling across all new features
-  - Real-time UI updates after all operations
-
-### 2025-06-11 (Japan Academy Awards Scraper Implementation)
-
-- Successfully implemented Japan Academy Awards scraper from consolidated Wikipedia page:
-  - **Source**: Uses `https://ja.wikipedia.org/wiki/日本アカデミー賞作品賞` (consolidated awards page)
-  - **Coverage**: Extracts 159 movies across years 1978-2024 (missing: 1979, 1989, 1999, 2009, 2019)
-  - **Year detection**: Multi-pattern approach (`YYYY年（第X回）`, `第X回`, `YYYY年`) with ceremony calculation `1976 + X = year`
-  - **Duplicate prevention**: Implemented `processedYears` Set to avoid processing same year multiple times
-  - **2024 special handling**: Extracts movies from text format rather than table (5 nominees: 侍タイムスリッパー, キングダム 大将軍の帰還, 正体, 夜明けのすべて, ラストマイル)
-- **CLI Integration**: Full support for `--year`, `--dry-run`, `--seed` options
-- **Code Quality**: ESLint compliant, proper TypeScript types, clean production-ready code
-- **Key Files**:
-  - `apps/scrapers/src/japan-academy-awards.ts`: Main scraper implementation
-  - `apps/scrapers/src/japan-academy-awards-cli.ts`: CLI interface
-  - `packages/database/seeds/japan-academy-awards.ts`: Database seeding
-- **Usage**:
-  - `pnpm run scrapers:japan-academy-awards` (all years)
-  - `pnpm run scrapers:japan-academy-awards --year 2024` (specific year)
-  - `pnpm run scrapers:japan-academy-awards --dry-run` (safe testing)
-
-### 2025-06-11 (Movie Deletion Foreign Key Fix)
-
-- Fixed critical foreign key constraint error in movie deletion API:
-  - **Root cause**: `reference_urls` table deletion was missing from cascading delete logic
-  - **Solution**: Added `referenceUrls` deletion to movie delete endpoint at `apps/api/src/index.ts:665-668`
-  - **Complete deletion order**: article_links → movie_selections → nominations → reference_urls → translations → poster_urls → movies
-  - **Prevention**: Added comprehensive guidelines for foreign key constraint handling in Development Guidelines
-- **Lesson learned**: Always verify ALL foreign key references across entire schema when implementing delete operations
-- **Key insight**: Most tables lack `onDelete: 'cascade'` configuration, requiring manual cascading delete implementation
-
-### 2025-06-27 (React Router v7 Frontend Implementation)
-
-- Successfully implemented React Router v7-based frontend using Test-Driven Development (TDD):
-  - **Complete TDD Implementation**: All 51 tests passing across 5 test files
-  - **Modern Architecture**: React Router v7 with Cloudflare Workers SSR and Tailwind CSS v4
-  - **Pages Implemented**: Home (`/`), Movie Details (`/movies/:id`), Search (`/search`), Admin Login (`/admin/login`), Admin Movies (`/admin/movies`)
-  - **Authentication**: JWT-based localStorage authentication matching API design
-  - **Comprehensive Testing**: Loader functions, component rendering, error handling, form validation, and authentication flows
-- **Added to CLAUDE.md**: Complete React Router v7 Frontend section with architecture, features, test coverage, and deployment commands
-- **Updated Commands**: Added front deployment and testing commands to relevant sections
-- **Production-ready**: Full-featured frontend with comprehensive test coverage and modern architecture
-
-### 2025-07-01 (Complete Migration to React Router v7)
-
-- Completed full migration from Astro to React Router v7:
-  - **Removed Legacy Frontend**: Deleted entire `front/` directory containing Astro-based implementation
-  - **Updated Build Scripts**: Renamed front commands throughout package.json
-  - **Simplified Architecture**: React Router v7 is now the sole frontend implementation
-  - **Updated Documentation**: Removed all references to legacy Astro frontend and dual-frontend setup
-- **Migration Details**:
-  - All functionality from Astro frontend has been reimplemented in React Router v7
-  - Maintained feature parity including movie selections, admin interface, and article links
-  - Improved performance with Cloudflare Workers SSR instead of static site generation
-- **Benefits**:
-  - Unified frontend codebase with consistent patterns
-  - Better type safety with full TypeScript coverage
-  - Comprehensive test coverage (51+ tests)
-  - Modern development experience with React Router v7
-
-### Development Guidelines
-
-- TS エラーと Lint エラーをを絶対に無視するな
-- Database column names in schema use camelCase (e.g., `createdAt`, `updatedAt`) but are mapped to snake_case in the actual database
-- When writing SQL queries, use the schema field references directly instead of hardcoding column names
-- **API URL Convention**: Base URLs should NOT have trailing slashes, paths should start with leading slash
-- **Cloudflare Workers Environment Variables**: Use `vars` in wrangler.jsonc, access via loader context in React Router v7 components
-- **API URL Handling**: Environment-aware API URL configuration in React Router v7 loaders
-- **Mobile Responsiveness**: Consider mobile-first design with collapsible content for dense information
-- **Security**: Always implement rate limiting for public submission endpoints
-- **TailwindCSS**: Use utility-first approach, preserve custom CSS only for complex animations/interactions
-- **Component Styling**: Follow responsive patterns like `text-xl md:text-2xl` and `p-5 md:p-6`
-- **Favicon Management**: `apps/front/public/favicon.svg` is the master; `favicon.ico` (16/32/48 frames) and `apple-touch-icon.png` (opaque 180x180) are rasterized from it
-- **Database Foreign Key Constraints and Cascading Deletes**:
-  - **Critical**: When implementing delete operations for core entities (movies, awards, etc.), always verify ALL foreign key references across the entire schema
-  - Most tables do NOT have `onDelete: 'cascade'` configured, requiring manual deletion of related data
-  - **Movie deletion order**: article_links → movie_selections → nominations → reference_urls → translations → poster_urls → movies
-  - Use `Task` tool to search all schema files for foreign key references when implementing new delete operations
-  - Test delete operations in development to catch missing cascading delete logic before production
-- **Wikipedia Scraping Best Practices**:
-  - Use duplicate prevention logic (`Set<T>`) when processing tables to avoid year/data duplication
-  - Implement multiple year detection patterns for robustness (`YYYY年（第X回）`, `第X回`, `YYYY年`)
-  - Handle special cases where data appears in text format rather than tables (e.g., 2024 Japan Academy Awards)
-  - Always include comprehensive error handling and skip logic for malformed/irrelevant tables
-  - Remove debug output before production; keep only essential operational logs
-- **Admin Interface Development**:
-  - Always include proper TypeScript types for API responses to avoid runtime errors
-  - Use modal-based UI patterns for complex form interactions (IMDb ID, poster management)
-  - Implement comprehensive form validation both client and server-side
-  - Provide immediate user feedback for all operations (success/error messages)
-  - Use grid layouts for visual content management (poster thumbnails)
-  - Implement confirmation dialogs for destructive operations (delete)
-- **TMDb API Integration Best Practices**:
-  - Always use existing TMDb utility functions from `apps/scrapers/src/common/tmdb-utilities.ts`
-  - Implement graceful fallbacks when TMDb data is unavailable
-  - Log essential operations but remove debug output for production
-  - Use consistent error handling patterns across TMDb API calls
+- TSエラーとLintエラーを絶対に無視するな
+- **Foreign keys / cascading deletes**: most tables lack `onDelete: 'cascade'`. Movie deletion order: article_links → movie_selections → nominations → reference_urls → translations → poster_urls → movies. When adding delete operations, grep the whole schema for FK references first
+- **Soft delete**: scrapers must skip soft-deleted movies when attaching data (see `isNull(movies.deletedAt)` filters and skip guards); do not "resurrect" them
+- **TMDb integration**: use the utilities in `apps/scrapers/src/common/tmdb-utilities.ts`; don't re-implement search/save logic per scraper
+- **Scraper CLIs**: load env via `loadScraperEnvironment()` / `loadEnvironmentFiles()` from `common/environment.ts` (never `config({path: '../.dev.vars'})` — cwd-relative paths escape the repo root); always check `Response.ok` when calling worker-style handlers from CLIs
+- **Rate limiting / security**: public submission endpoints need rate limiting; external URL fetches must go through `validateExternalUrl()`
+- **Wikipedia scraping**: use duplicate-prevention `Set`s, multiple year-detection patterns, and handle text-format special cases (e.g. 2024 Japan Academy Awards)
+- **Favicon**: `apps/front/public/favicon.svg` is the master; `favicon.ico` and `apple-touch-icon.png` are rasterized from it
+- **Testing DB code**: prefer real libsql `file:` databases with `migrate()` over deep drizzle mocks

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Monorepo Layout
 
 - `apps/api` – Cloudflare Worker API (Hono)
-- `apps/front` – Remix-based admin frontend
+- `apps/front` – React Router v7 frontend (public pages + admin, Cloudflare Workers SSR)
 - `apps/scrapers` – CLI scrapers and automation jobs
 - `packages/database` – Drizzle ORM schema, migrations, seeds, shared DB helpers
 - `packages/utils` – Cross-application utility helpers

--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -368,6 +368,8 @@ paths:
                     description: JWT token (valid for 24 hours)
         '401':
           $ref: '#/components/responses/UnauthorizedError'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -417,7 +419,107 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+    post:
+      summary: Create movie from IMDb ID (admin)
+      description: Create a new movie from an IMDb ID, optionally importing TMDb data (posters and translations)
+      operationId: adminCreateMovie
+      tags:
+        - Admin - Movies
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MovieCreateRequest'
+      responses:
+        '201':
+          description: Movie successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MovieCreateResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /admin/movies/{id}:
+    get:
+      summary: Get movie details (admin)
+      description: Retrieve movie details for admin including all translations, posters, and nominations
+      operationId: adminGetMovie
+      tags:
+        - Admin - Movies
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Movie unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successfully retrieved movie details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminMovieDetails'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    put:
+      summary: Update movie basic info (admin)
+      description: Update movie year, original language, and media type
+      operationId: adminUpdateMovie
+      tags:
+        - Admin - Movies
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Movie unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MovieUpdateRequest'
+      responses:
+        '200':
+          description: Movie successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
     delete:
       summary: Delete movie (admin)
       description: Delete a movie and all related data (cascading delete)
@@ -667,6 +769,681 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /admin/movies/{id}/external-id-search:
+    get:
+      summary: Search external movie IDs (admin)
+      description: Search TMDb for candidate external IDs (TMDb/IMDb) matching a movie
+      operationId: adminSearchExternalMovieIds
+      tags:
+        - Admin - Movies
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Movie unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: query
+          in: query
+          description: Search query (defaults to the movie's stored title)
+          required: false
+          schema:
+            type: string
+        - name: language
+          in: query
+          description: Search language (ja or en prefixed values)
+          required: false
+          schema:
+            type: string
+        - name: year
+          in: query
+          description: Release year to bias search results
+          required: false
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Maximum number of results
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Successfully retrieved external ID candidates
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExternalIdSearchResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          description: TMDb API key is not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/movies/{id}/auto-fetch-tmdb:
+    post:
+      summary: Auto-fetch TMDb data using IMDb ID (admin)
+      description: Detect the TMDb ID from the movie's IMDb ID, then import posters and translations from TMDb
+      operationId: adminAutoFetchTmdb
+      tags:
+        - Admin - Movies
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Movie unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: TMDb data successfully fetched
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutoFetchTmdbResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/movies/{id}/refresh-tmdb:
+    post:
+      summary: Refresh TMDb data (admin)
+      description: Re-import posters and translations from TMDb using the movie's stored TMDb ID
+      operationId: adminRefreshTmdb
+      tags:
+        - Admin - Movies
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Movie unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: TMDb data successfully refreshed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TmdbIdUpdateResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/movies/{sourceId}/merge/{targetId}:
+    post:
+      summary: Merge movies (admin)
+      description: Merge the source movie's data (nominations, translations, posters, article links) into the target movie and delete the source movie
+      operationId: adminMergeMovies
+      tags:
+        - Admin - Movies
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: sourceId
+          in: path
+          description: Source movie unique identifier (deleted after merge)
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: targetId
+          in: path
+          description: Target movie unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Movies successfully merged
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MergeMoviesResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/movies/{movieId}/nominations:
+    post:
+      summary: Add nomination to movie (admin)
+      description: Add an award nomination for a movie
+      operationId: adminAddNomination
+      tags:
+        - Admin - Nominations
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: movieId
+          in: path
+          description: Movie unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NominationCreateRequest'
+      responses:
+        '200':
+          description: Nomination successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NominationRecord'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/nominations/{nominationId}:
+    put:
+      summary: Update nomination (admin)
+      description: Update the winner flag and special mention of a nomination
+      operationId: adminUpdateNomination
+      tags:
+        - Admin - Nominations
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: nominationId
+          in: path
+          description: Nomination unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NominationUpdateRequest'
+      responses:
+        '200':
+          description: Nomination successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    delete:
+      summary: Delete nomination (admin)
+      description: Delete an award nomination
+      operationId: adminDeleteNomination
+      tags:
+        - Admin - Nominations
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: nominationId
+          in: path
+          description: Nomination unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Nomination successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/article-links/{id}:
+    delete:
+      summary: Delete article link (admin)
+      description: Permanently delete an article link
+      operationId: adminDeleteArticleLink
+      tags:
+        - Admin - Articles
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          description: Article link unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Article link successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/ceremonies:
+    get:
+      summary: List award ceremonies (admin)
+      description: Retrieve all award ceremonies with organization info and nominated movie counts
+      operationId: adminListCeremonies
+      tags:
+        - Admin - Awards
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Successfully retrieved ceremonies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CeremoniesListResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    post:
+      summary: Create award ceremony (admin)
+      description: Create a new award ceremony for an organization
+      operationId: adminCreateCeremony
+      tags:
+        - Admin - Awards
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CeremonyRequest'
+      responses:
+        '201':
+          description: Ceremony successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CeremonyDetail'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/ceremonies/{ceremonyUid}:
+    get:
+      summary: Get award ceremony detail (admin)
+      description: Retrieve a ceremony with its nominations
+      operationId: adminGetCeremony
+      tags:
+        - Admin - Awards
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: ceremonyUid
+          in: path
+          description: Ceremony unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successfully retrieved ceremony detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CeremonyDetail'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    put:
+      summary: Update award ceremony (admin)
+      description: Update an award ceremony
+      operationId: adminUpdateCeremony
+      tags:
+        - Admin - Awards
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: ceremonyUid
+          in: path
+          description: Ceremony unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CeremonyRequest'
+      responses:
+        '200':
+          description: Ceremony successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CeremonyDetail'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+    delete:
+      summary: Delete award ceremony (admin)
+      description: Delete a ceremony and all of its nominations
+      operationId: adminDeleteCeremony
+      tags:
+        - Admin - Awards
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: ceremonyUid
+          in: path
+          description: Ceremony unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Ceremony successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/ceremonies/{ceremonyUid}/sync-imdb:
+    post:
+      summary: Sync ceremony nominations from IMDb (admin)
+      description: Import nominations for a ceremony category from its configured IMDb event page
+      operationId: adminSyncCeremonyFromImdb
+      tags:
+        - Admin - Awards
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: ceremonyUid
+          in: path
+          description: Ceremony unique identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - categoryUid
+              properties:
+                categoryUid:
+                  type: string
+                  format: uuid
+                  description: Award category to sync nominations into
+      responses:
+        '200':
+          description: Nominations successfully synced from IMDb
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Operation success status
+                  ceremony:
+                    $ref: '#/components/schemas/CeremonyDetail'
+                  stats:
+                    type: object
+                    description: Sync statistics (created/updated/skipped counts)
+                required:
+                  - success
+                  - ceremony
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: IMDb event page could not be parsed or matched to movies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '502':
+          description: Failed to fetch the IMDb event page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/awards:
+    get:
+      summary: Get awards data for nomination editing (admin)
+      description: Retrieve all award organizations, ceremonies, and categories
+      operationId: adminGetAwardsData
+      tags:
+        - Admin - Awards
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Successfully retrieved awards data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AwardsDataResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/preview-selections:
+    get:
+      summary: Preview next period selections (admin)
+      description: Preview the movies that will be selected for the next daily, weekly, and monthly periods
+      operationId: adminPreviewSelections
+      tags:
+        - Admin - Selections
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: locale
+          in: query
+          description: Language preference for movie titles
+          required: false
+          schema:
+            type: string
+            enum: [en, ja]
+            default: en
+      responses:
+        '200':
+          description: Successfully retrieved selection previews
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreviewSelectionsResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/override-selection:
+    post:
+      summary: Override movie selection (admin)
+      description: Set a specific movie as the selection for a given date and period type
+      operationId: adminOverrideSelection
+      tags:
+        - Admin - Selections
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OverrideSelectionRequest'
+      responses:
+        '200':
+          description: Selection successfully overridden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/cleanup-future-selections:
+    delete:
+      summary: Clean up future selections (admin)
+      description: Delete movie selections scheduled for future dates
+      operationId: adminCleanupFutureSelections
+      tags:
+        - Admin - Selections
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Future selections successfully deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CleanupFutureSelectionsResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /admin/random-movie-preview:
+    post:
+      summary: Generate random movie preview (admin)
+      description: Generate a random movie preview for a specific date and period type without writing a selection
+      operationId: adminRandomMoviePreview
+      tags:
+        - Admin - Selections
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RandomMoviePreviewRequest'
+      responses:
+        '200':
+          description: Successfully generated movie preview
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MovieWithDetails'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
 components:
   securitySchemes:
     BearerAuth:
@@ -693,27 +1470,23 @@ components:
           pattern: '^[a-z]{2}$'
           description: ISO 639-1 language code
         imdbId:
-          type: string
+          type: [string, 'null']
           pattern: '^tt\d{7,8}$'
-          nullable: true
           description: IMDb identifier (tt format)
         tmdbId:
-          type: integer
+          type: [integer, 'null']
           minimum: 1
-          nullable: true
           description: TMDb identifier
         title:
           type: string
           description: Movie title (localized)
         posterUrl:
-          type: string
+          type: [string, 'null']
           format: uri
-          nullable: true
           description: Primary poster image URL
         imdbUrl:
-          type: string
+          type: [string, 'null']
           format: uri
-          nullable: true
           description: IMDb page URL
         hasAwards:
           type: boolean
@@ -757,19 +1530,16 @@ components:
           format: uri
           description: Poster image URL
         width:
-          type: integer
+          type: [integer, 'null']
           minimum: 1
-          nullable: true
           description: Image width in pixels
         height:
-          type: integer
+          type: [integer, 'null']
           minimum: 1
-          nullable: true
           description: Image height in pixels
         languageCode:
-          type: string
+          type: [string, 'null']
           pattern: '^[a-z]{2}$'
-          nullable: true
           description: Language-specific poster
         sourceType:
           type: string
@@ -813,8 +1583,7 @@ components:
           type: boolean
           description: Whether this nomination won the award
         specialMention:
-          type: string
-          nullable: true
+          type: [string, 'null']
           description: Special mention or note about the nomination
         category:
           $ref: '#/components/schemas/AwardCategory'
@@ -875,8 +1644,7 @@ components:
           type: string
           description: Organization full name
         shortName:
-          type: string
-          nullable: true
+          type: [string, 'null']
           description: Organization short name or abbreviation
       required:
         - uid
@@ -897,8 +1665,7 @@ components:
           type: string
           description: Article title
         description:
-          type: string
-          nullable: true
+          type: [string, 'null']
           description: Article description
         submittedAt:
           type: string
@@ -1028,20 +1795,16 @@ components:
       type: object
       properties:
         query:
-          type: string
-          nullable: true
+          type: [string, 'null']
           description: Applied search query
         year:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
           description: Applied year filter
         language:
-          type: string
-          nullable: true
+          type: [string, 'null']
           description: Applied language filter
         hasAwards:
-          type: boolean
-          nullable: true
+          type: [boolean, 'null']
           description: Applied awards filter
 
     ArticleLinkSubmission:
@@ -1056,9 +1819,8 @@ components:
           maxLength: 200
           description: Article title
         description:
-          type: string
+          type: [string, 'null']
           maxLength: 500
-          nullable: true
           description: Article description
         captchaToken:
           type: string
@@ -1118,12 +1880,10 @@ components:
           type: boolean
           description: Operation success status
         refreshResults:
-          type: object
-          nullable: true
+          type: [object, 'null']
           properties:
             tmdbId:
-              type: integer
-              nullable: true
+              type: [integer, 'null']
               description: Auto-detected TMDb ID
             postersAdded:
               type: integer
@@ -1156,8 +1916,7 @@ components:
           type: boolean
           description: Operation success status
         refreshResults:
-          type: object
-          nullable: true
+          type: [object, 'null']
           properties:
             postersAdded:
               type: integer
@@ -1177,19 +1936,16 @@ components:
           format: uri
           description: Poster image URL
         width:
-          type: integer
+          type: [integer, 'null']
           minimum: 1
-          nullable: true
           description: Image width in pixels
         height:
-          type: integer
+          type: [integer, 'null']
           minimum: 1
-          nullable: true
           description: Image height in pixels
         languageCode:
-          type: string
+          type: [string, 'null']
           pattern: '^[a-z]{2}$'
-          nullable: true
           description: Language-specific poster
         isPrimary:
           type: boolean
@@ -1226,6 +1982,16 @@ components:
           enum: [en, ja]
           default: en
           description: Language preference
+        date:
+          type: string
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: Target date for the reselection (YYYY-MM-DD, defaults to today)
+        excludeMovieUids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Movie UIDs to exclude from the reselection
       required:
         - type
 
@@ -1240,6 +2006,627 @@ components:
       required:
         - type
         - movie
+
+    MovieCreateRequest:
+      type: object
+      properties:
+        imdbId:
+          type: string
+          pattern: '^tt\d{7,8}$'
+          description: IMDb identifier in tt format
+        refreshData:
+          type: boolean
+          default: true
+          description: Whether to import posters and translations from TMDb
+      required:
+        - imdbId
+
+    MovieCreateResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Operation success status
+        movie:
+          type: object
+          properties:
+            uid:
+              type: string
+              format: uuid
+              description: Unique identifier for the created movie
+            imdbId:
+              type: string
+              description: IMDb identifier
+            tmdbId:
+              type: integer
+              description: TMDb identifier
+            year:
+              type: integer
+              description: Release year
+            originalLanguage:
+              type: string
+              description: ISO 639-1 language code
+          required:
+            - uid
+        imports:
+          type: object
+          properties:
+            translationsAdded:
+              type: integer
+              description: Number of translations imported
+            postersAdded:
+              type: integer
+              description: Number of posters imported
+      required:
+        - success
+        - movie
+
+    MovieUpdateRequest:
+      type: object
+      properties:
+        year:
+          type: integer
+          minimum: 1888
+          maximum: 2100
+          description: Release year
+        originalLanguage:
+          type: string
+          pattern: '^[a-z]{2}$'
+          description: ISO 639-1 language code
+        mediaType:
+          type: string
+          enum: [movie, tv]
+          description: Media type
+
+    AdminMovieDetails:
+      type: object
+      properties:
+        uid:
+          type: string
+          format: uuid
+          description: Unique identifier for the movie
+        year:
+          type: [integer, 'null']
+          description: Release year
+        originalLanguage:
+          type: string
+          description: ISO 639-1 language code
+        imdbId:
+          type: [string, 'null']
+          description: IMDb identifier (tt format)
+        tmdbId:
+          type: [integer, 'null']
+          description: TMDb identifier
+        mediaType:
+          type: string
+          enum: [movie, tv]
+          description: Media type
+        translations:
+          type: array
+          items:
+            type: object
+            properties:
+              uid:
+                type: string
+                format: uuid
+              languageCode:
+                type: string
+              content:
+                type: string
+              isDefault:
+                type: integer
+                description: 1 if this is the default translation
+          description: All movie title translations
+        posters:
+          type: array
+          items:
+            $ref: '#/components/schemas/Poster'
+          description: All poster images for the movie
+        nominations:
+          type: array
+          items:
+            type: object
+            properties:
+              uid:
+                type: string
+                format: uuid
+              isWinner:
+                type: integer
+              specialMention:
+                type: [string, 'null']
+              categoryUid:
+                type: string
+                format: uuid
+              categoryName:
+                type: string
+              ceremonyUid:
+                type: string
+                format: uuid
+              ceremonyNumber:
+                type: [integer, 'null']
+              ceremonyYear:
+                type: integer
+              organizationUid:
+                type: string
+                format: uuid
+              organizationName:
+                type: string
+              organizationShortName:
+                type: [string, 'null']
+          description: Awards and nominations with full details
+      required:
+        - uid
+        - originalLanguage
+
+    ExternalIdSearchResponse:
+      type: object
+      properties:
+        usedQuery:
+          type: string
+          description: Query used for the TMDb search
+        usedYear:
+          type: integer
+          description: Year used to bias search results
+        results:
+          type: array
+          items:
+            type: object
+            properties:
+              tmdbId:
+                type: integer
+                description: TMDb identifier
+              imdbId:
+                type: string
+                description: IMDb identifier
+              title:
+                type: string
+                description: Localized title
+              originalTitle:
+                type: string
+                description: Original title
+              releaseDate:
+                type: string
+                description: Release date (YYYY-MM-DD)
+              overview:
+                type: string
+                description: Movie overview
+              originalLanguage:
+                type: string
+                description: ISO 639-1 language code
+              posterPath:
+                type: string
+                description: TMDb poster path
+              popularity:
+                type: number
+                description: TMDb popularity score
+              voteAverage:
+                type: number
+                description: TMDb vote average
+              voteCount:
+                type: integer
+                description: TMDb vote count
+              yearDifference:
+                type: integer
+                description: Absolute difference from the movie's stored year
+            required:
+              - tmdbId
+              - title
+          description: Candidate matches from TMDb
+      required:
+        - usedQuery
+        - results
+
+    AutoFetchTmdbResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Operation success status
+        fetchResults:
+          type: object
+          properties:
+            tmdbIdSet:
+              type: boolean
+              description: Whether a TMDb ID was newly detected and saved
+            postersAdded:
+              type: integer
+              description: Number of posters added
+            translationsAdded:
+              type: integer
+              description: Number of translations added
+      required:
+        - success
+        - fetchResults
+
+    MergeMoviesResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Operation success status
+        message:
+          type: string
+          description: Merge result message
+      required:
+        - success
+        - message
+
+    NominationCreateRequest:
+      type: object
+      properties:
+        ceremonyUid:
+          type: string
+          format: uuid
+          description: Award ceremony identifier
+        categoryUid:
+          type: string
+          format: uuid
+          description: Award category identifier
+        isWinner:
+          type: boolean
+          default: false
+          description: Whether the nomination won the award
+        specialMention:
+          type: string
+          description: Special mention or note about the nomination
+      required:
+        - ceremonyUid
+        - categoryUid
+
+    NominationUpdateRequest:
+      type: object
+      properties:
+        isWinner:
+          type: boolean
+          description: Whether the nomination won the award
+        specialMention:
+          type: string
+          description: Special mention or note about the nomination
+
+    NominationRecord:
+      type: object
+      properties:
+        uid:
+          type: string
+          format: uuid
+          description: Unique identifier for the nomination
+        movieUid:
+          type: string
+          format: uuid
+          description: Associated movie identifier
+        ceremonyUid:
+          type: string
+          format: uuid
+          description: Award ceremony identifier
+        categoryUid:
+          type: string
+          format: uuid
+          description: Award category identifier
+        isWinner:
+          type: integer
+          description: 1 if the nomination won the award
+        specialMention:
+          type: [string, 'null']
+          description: Special mention or note about the nomination
+        createdAt:
+          type: integer
+          description: Creation timestamp (unix seconds)
+        updatedAt:
+          type: integer
+          description: Last update timestamp (unix seconds)
+      required:
+        - uid
+        - movieUid
+        - ceremonyUid
+        - categoryUid
+        - isWinner
+
+    CeremonyRequest:
+      type: object
+      properties:
+        organizationUid:
+          type: string
+          format: uuid
+          description: Award organization identifier
+        year:
+          type: integer
+          minimum: 1880
+          maximum: 9999
+          description: Ceremony year
+        ceremonyNumber:
+          type: integer
+          description: Ceremony number (e.g., 95th Academy Awards)
+        startDate:
+          type: integer
+          description: Start date (unix seconds)
+        endDate:
+          type: integer
+          description: End date (unix seconds)
+        location:
+          type: string
+          description: Ceremony location
+        description:
+          type: string
+          description: Ceremony description
+        imdbEventUrl:
+          type: string
+          format: uri
+          description: IMDb event page URL used for nomination sync
+      required:
+        - organizationUid
+        - year
+
+    CeremonySummary:
+      type: object
+      properties:
+        uid:
+          type: string
+          format: uuid
+          description: Unique identifier for the ceremony
+        organizationUid:
+          type: string
+          format: uuid
+          description: Award organization identifier
+        organizationName:
+          type: string
+          description: Organization name
+        organizationCountry:
+          type: [string, 'null']
+          description: Organization country
+        year:
+          type: integer
+          description: Ceremony year
+        ceremonyNumber:
+          type: [integer, 'null']
+          description: Ceremony number
+        startDate:
+          type: [integer, 'null']
+          description: Start date (unix seconds)
+        endDate:
+          type: [integer, 'null']
+          description: End date (unix seconds)
+        location:
+          type: [string, 'null']
+          description: Ceremony location
+        description:
+          type: [string, 'null']
+          description: Ceremony description
+        imdbEventUrl:
+          type: [string, 'null']
+          description: IMDb event page URL
+        createdAt:
+          type: integer
+          description: Creation timestamp (unix seconds)
+        updatedAt:
+          type: integer
+          description: Last update timestamp (unix seconds)
+      required:
+        - uid
+        - organizationUid
+        - organizationName
+        - year
+
+    CeremoniesListResponse:
+      type: object
+      properties:
+        ceremonies:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/CeremonySummary'
+              - type: object
+                properties:
+                  movieCount:
+                    type: integer
+                    description: Number of distinct nominated movies
+          description: Award ceremonies
+      required:
+        - ceremonies
+
+    CeremonyDetail:
+      allOf:
+        - $ref: '#/components/schemas/CeremonySummary'
+        - type: object
+          properties:
+            nominations:
+              type: array
+              items:
+                type: object
+                properties:
+                  uid:
+                    type: string
+                    format: uuid
+                  movieUid:
+                    type: string
+                    format: uuid
+                  movieTitle:
+                    type: string
+                  movieYear:
+                    type: [integer, 'null']
+                  movieOriginalLanguage:
+                    type: string
+                  categoryUid:
+                    type: string
+                    format: uuid
+                  categoryName:
+                    type: string
+                  isWinner:
+                    type: integer
+                  specialMention:
+                    type: [string, 'null']
+              description: Nominations for the ceremony
+
+    AwardsDataResponse:
+      type: object
+      properties:
+        organizations:
+          type: array
+          items:
+            type: object
+            properties:
+              uid:
+                type: string
+                format: uuid
+              name:
+                type: string
+              country:
+                type: [string, 'null']
+            required:
+              - uid
+              - name
+          description: Award organizations
+        ceremonies:
+          type: array
+          items:
+            type: object
+            properties:
+              uid:
+                type: string
+                format: uuid
+              organizationUid:
+                type: string
+                format: uuid
+              year:
+                type: integer
+              ceremonyNumber:
+                type: [integer, 'null']
+              organizationName:
+                type: string
+              imdbEventUrl:
+                type: [string, 'null']
+            required:
+              - uid
+              - organizationUid
+              - year
+              - organizationName
+          description: Award ceremonies
+        categories:
+          type: array
+          items:
+            type: object
+            properties:
+              uid:
+                type: string
+                format: uuid
+              organizationUid:
+                type: string
+                format: uuid
+              name:
+                type: string
+              organizationName:
+                type: string
+            required:
+              - uid
+              - organizationUid
+              - name
+              - organizationName
+          description: Award categories
+      required:
+        - organizations
+        - ceremonies
+        - categories
+
+    PreviewSelectionsResponse:
+      type: object
+      properties:
+        nextDaily:
+          $ref: '#/components/schemas/SelectionPreview'
+        nextWeekly:
+          $ref: '#/components/schemas/SelectionPreview'
+        nextMonthly:
+          $ref: '#/components/schemas/SelectionPreview'
+      required:
+        - nextDaily
+        - nextWeekly
+        - nextMonthly
+
+    SelectionPreview:
+      type: object
+      properties:
+        date:
+          type: string
+          description: Selection date (YYYY-MM-DD)
+        movie:
+          $ref: '#/components/schemas/MovieWithDetails'
+      required:
+        - date
+
+    OverrideSelectionRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [daily, weekly, monthly]
+          description: Selection period type
+        date:
+          type: string
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: Target selection date (YYYY-MM-DD)
+        movieId:
+          type: string
+          format: uuid
+          description: Movie to set as the selection
+      required:
+        - type
+        - date
+        - movieId
+
+    CleanupFutureSelectionsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Operation success status
+        currentDates:
+          type: object
+          properties:
+            daily:
+              type: string
+              description: Current daily selection date
+            weekly:
+              type: string
+              description: Current weekly selection date
+            monthly:
+              type: string
+              description: Current monthly selection date
+          description: Current selection dates per period
+        deletedCount:
+          type: object
+          properties:
+            daily:
+              type: integer
+              description: Deleted future daily selections
+            weekly:
+              type: integer
+              description: Deleted future weekly selections
+            monthly:
+              type: integer
+              description: Deleted future monthly selections
+          description: Number of deleted selections per period
+      required:
+        - success
+        - currentDates
+        - deletedCount
+
+    RandomMoviePreviewRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [daily, weekly, monthly]
+          description: Selection period type
+        date:
+          type: string
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: Target date (YYYY-MM-DD)
+        locale:
+          type: string
+          enum: [en, ja]
+          default: en
+          description: Language preference
+      required:
+        - type
+        - date
 
     SuccessResponse:
       type: object
@@ -1260,8 +2647,7 @@ components:
           type: string
           description: Error code
         details:
-          type: object
-          nullable: true
+          type: [object, 'null']
           description: Additional error details
       required:
         - error
@@ -1353,3 +2739,7 @@ tags:
     description: Admin operations for article link management
   - name: Admin - Selections
     description: Admin operations for movie selection management
+  - name: Admin - Nominations
+    description: Admin operations for nomination management
+  - name: Admin - Awards
+    description: Admin operations for award organizations, ceremonies, and categories


### PR DESCRIPTION
- CLAUDE.md / AGENTS.md / README のモノレポ再編前の記述（api/・front/・src/・Remix・タブインデント等）を現行構成に修正。CLAUDE.mdの174行の古いChanges Logを削除し、今回確立した規約（soft delete・キャッシュ・env読込・実DBテスト）を反映
- openapi.yml: redocly lintのエラー22件（3.1で無効なnullable）を解消し、未文書だった管理系22オペレーションを実装から起こして追加。`docs:validate` をCIに組み込み

base は #221（CI変更の上に積んでいるため）。#221マージ後にmainへ自動リターゲットされます。

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x