### PR TITLE
scrapers: fetchWithRetryの強化とTMDb fetchの共通化

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -10,6 +10,7 @@
     "../../packages/database/src/**/*",
     "../../packages/types/src/**/*",
     "../../packages/utils/src/**/*",
+    "../scrapers/src/common/fetch-utilities.ts",
     "../scrapers/src/common/tmdb-utilities.ts"
   ],
   "exclude": ["node_modules", "dist"]

--- a/apps/scrapers/src/__tests__/fetch-utilities.test.ts
+++ b/apps/scrapers/src/__tests__/fetch-utilities.test.ts
@@ -1,5 +1,9 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {buildUrl, fetchWithRetry} from '../common/fetch-utilities';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  buildUrl,
+  fetchJsonWithRetry,
+  fetchWithRetry,
+} from '../common/fetch-utilities';
 
 // Mock fetch globally
 globalThis.fetch = vi.fn();
@@ -7,6 +11,10 @@ globalThis.fetch = vi.fn();
 describe('Fetch Utilities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('fetchWithRetry', () => {
@@ -24,6 +32,7 @@ describe('Fetch Utilities', () => {
           'User-Agent':
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
         },
+        signal: expect.any(AbortSignal) as AbortSignal,
       });
       expect(result).toBe('success');
     });
@@ -45,10 +54,11 @@ describe('Fetch Utilities', () => {
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
           'Custom-Header': 'custom-value',
         },
+        signal: expect.any(AbortSignal) as AbortSignal,
       });
     });
 
-    it('should retry on HTTP error', async () => {
+    it('should retry on HTTP 5xx error', async () => {
       const mockErrorResponse = {
         ok: false,
         status: 500,
@@ -120,6 +130,166 @@ describe('Fetch Utilities', () => {
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 150); // 100 * 1.5
 
       setTimeoutSpy.mockRestore();
+    });
+
+    it('should not retry on 4xx errors other than 429', async () => {
+      const mockErrorResponse = {
+        ok: false,
+        status: 404,
+      };
+      vi.mocked(fetch).mockResolvedValue(
+        mockErrorResponse as unknown as Response,
+      );
+
+      await expect(
+        fetchWithRetry('https://example.com', {}, 3, 10),
+      ).rejects.toThrow('HTTP error! Status: 404');
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should respect Retry-After header (seconds) on 429', async () => {
+      vi.useFakeTimers();
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers({'retry-after': '2'}),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          text: vi.fn().mockResolvedValue('success'),
+        } as unknown as Response);
+
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      const promise = fetchWithRetry('https://example.com', {}, 3, 10);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toBe('success');
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
+
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('should fall back to backoff delay on 429 without Retry-After', async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers(),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          text: vi.fn().mockResolvedValue('success'),
+        } as unknown as Response);
+
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      const result = await fetchWithRetry('https://example.com', {}, 3, 10);
+
+      expect(result).toBe('success');
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10);
+
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('should throw on 429 after exhausting retries', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: new Headers({'retry-after': '0'}),
+      } as unknown as Response);
+
+      await expect(
+        fetchWithRetry('https://example.com', {}, 1, 10),
+      ).rejects.toThrow('HTTP error! Status: 429');
+
+      expect(fetch).toHaveBeenCalledTimes(2); // Initial + 1 retry
+    });
+
+    it('should abort the request when the timeout elapses', async () => {
+      vi.mocked(fetch).mockImplementation(
+        async (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => {
+              reject(init.signal?.reason as Error);
+            });
+          }),
+      );
+
+      await expect(
+        fetchWithRetry('https://example.com', {}, 0, 10, 50),
+      ).rejects.toMatchObject({name: 'TimeoutError'});
+    });
+
+    it('should use the caller-provided signal instead of the timeout signal', async () => {
+      const mockResponse = {
+        ok: true,
+        text: vi.fn().mockResolvedValue('success'),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      const controller = new AbortController();
+      await fetchWithRetry('https://example.com', {signal: controller.signal});
+
+      const init = vi.mocked(fetch).mock.calls[0][1];
+      expect(init?.signal).toBe(controller.signal);
+    });
+  });
+
+  describe('fetchJsonWithRetry', () => {
+    it('should parse the response body as JSON', async () => {
+      const mockResponse = {
+        ok: true,
+        text: vi.fn().mockResolvedValue('{"id":1,"title":"Movie"}'),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      const result = await fetchJsonWithRetry<{id: number; title: string}>(
+        'https://example.com',
+      );
+
+      expect(result).toEqual({id: 1, title: 'Movie'});
+    });
+
+    it('should retry on HTTP 5xx error', async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          text: vi.fn().mockResolvedValue('{"ok":true}'),
+        } as unknown as Response);
+
+      const result = await fetchJsonWithRetry<{ok: boolean}>(
+        'https://example.com',
+        {},
+        2,
+        10,
+      );
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ok: true});
+    });
+
+    it('should not retry on 4xx errors other than 429', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+      } as unknown as Response);
+
+      await expect(
+        fetchJsonWithRetry('https://example.com', {}, 3, 10),
+      ).rejects.toThrow('HTTP error! Status: 401');
+
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/scrapers/src/__tests__/tmdb-utilities.test.ts
+++ b/apps/scrapers/src/__tests__/tmdb-utilities.test.ts
@@ -1,0 +1,173 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  fetchTMDBMovieDetails,
+  fetchTMDBMovieTranslations,
+  findTMDBByImdbId,
+  searchTMDBMovie,
+} from '../common/tmdb-utilities';
+
+globalThis.fetch = vi.fn();
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('TMDb Utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchTMDBMovieDetails', () => {
+    it('should return movie details', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        jsonResponse({
+          id: 123,
+          title: 'Test Movie',
+          original_title: 'Test Movie',
+          release_date: '2020-01-01',
+        }),
+      );
+
+      const result = await fetchTMDBMovieDetails(123, 'api-key');
+
+      expect(result?.id).toBe(123);
+      expect(result?.title).toBe('Test Movie');
+      const requestedUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(requestedUrl).toContain('/movie/123');
+      expect(requestedUrl).toContain('api_key=api-key');
+    });
+
+    it('should retry on transient 5xx errors', async () => {
+      vi.useFakeTimers();
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+        } as unknown as Response)
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: 123,
+            title: 'Test Movie',
+            original_title: 'Test Movie',
+            release_date: '2020-01-01',
+          }),
+        );
+
+      const promise = fetchTMDBMovieDetails(123, 'api-key');
+      await vi.runAllTimersAsync();
+      const result = await promise;
+      vi.useRealTimers();
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(result?.id).toBe(123);
+    });
+
+    it('should return undefined on non-retryable errors', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 404,
+      } as unknown as Response);
+
+      const result = await fetchTMDBMovieDetails(123, 'api-key');
+
+      expect(result).toBeUndefined();
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fetchTMDBMovieTranslations', () => {
+    it('should return translations', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        jsonResponse({
+          id: 123,
+          translations: [
+            {
+              iso_3166_1: 'JP',
+              iso_639_1: 'ja',
+              name: '日本語',
+              english_name: 'Japanese',
+              data: {title: 'テスト映画'},
+            },
+          ],
+        }),
+      );
+
+      const result = await fetchTMDBMovieTranslations(123, 'api-key');
+
+      expect(result?.translations[0].data.title).toBe('テスト映画');
+      const requestedUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(requestedUrl).toContain('/movie/123/translations');
+    });
+  });
+
+  describe('searchTMDBMovie', () => {
+    it('should return the matched movie id', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        jsonResponse({
+          results: [{id: 42, title: 'Test Movie', release_date: '2020-05-01'}],
+        }),
+      );
+
+      const result = await searchTMDBMovie('Test Movie', 2020, 'api-key');
+
+      expect(result).toBe(42);
+    });
+
+    it('should return undefined when no results match', async () => {
+      vi.mocked(fetch).mockResolvedValue(jsonResponse({results: []}));
+
+      const result = await searchTMDBMovie('Unknown', 2020, 'api-key');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('findTMDBByImdbId', () => {
+    it('should return movie result', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        jsonResponse({
+          movie_results: [
+            {
+              id: 99,
+              title: 'Found Movie',
+              original_title: 'Found Movie',
+              release_date: '2019-01-01',
+            },
+          ],
+          tv_results: [],
+        }),
+      );
+
+      const result = await findTMDBByImdbId('tt1234567', 'api-key');
+
+      expect(result).toEqual({tmdbId: 99, mediaType: 'movie'});
+      const requestedUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(requestedUrl).toContain('/find/tt1234567');
+      expect(requestedUrl).toContain('external_source=imdb_id');
+    });
+
+    it('should return tv result when no movie matches', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        jsonResponse({
+          movie_results: [],
+          tv_results: [
+            {
+              id: 55,
+              name: 'Found Show',
+              original_name: 'Found Show',
+              first_air_date: '2018-01-01',
+            },
+          ],
+        }),
+      );
+
+      const result = await findTMDBByImdbId('tt7654321', 'api-key');
+
+      expect(result).toEqual({tmdbId: 55, mediaType: 'tv'});
+    });
+  });
+});

--- a/apps/scrapers/src/cannes-film-festival.ts
+++ b/apps/scrapers/src/cannes-film-festival.ts
@@ -10,6 +10,7 @@ import {nominations} from '@shine/database/schema/nominations';
 import {posterUrls} from '@shine/database/schema/poster-urls';
 import {referenceUrls} from '@shine/database/schema/reference-urls';
 import {translations} from '@shine/database/schema/translations';
+import {saveJapaneseTranslation} from './common/tmdb-utilities';
 
 const WIKIPEDIA_BASE_URL = 'https://en.wikipedia.org';
 const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
@@ -1386,7 +1387,7 @@ function appendJapaneseTitle(
     resourceUid: movieUid,
     languageCode: 'ja',
     content: movieDetails.japaneseTitle,
-    isDefault: 0,
+    isDefault: 1,
   });
 }
 
@@ -1438,33 +1439,6 @@ async function saveTranslations(
     .insert(translations)
     .values(translationsBatch)
     .onConflictDoNothing();
-}
-
-async function upsertJapaneseTitleTranslation(
-  database: DatabaseClient,
-  movieUid: string,
-  japaneseTitle: string,
-) {
-  await database
-    .insert(translations)
-    .values({
-      resourceType: 'movie_title',
-      resourceUid: movieUid,
-      languageCode: 'ja',
-      content: japaneseTitle,
-      isDefault: 0,
-    })
-    .onConflictDoUpdate({
-      target: [
-        translations.resourceType,
-        translations.resourceUid,
-        translations.languageCode,
-      ],
-      set: {
-        content: japaneseTitle,
-        updatedAt: Math.floor(Date.now() / 1000),
-      },
-    });
 }
 
 async function saveReferenceUrl(
@@ -1660,10 +1634,10 @@ async function processMovie(
     await saveTranslations(database, movieResolution.translations);
 
     if (movieDetails.japaneseTitle) {
-      await upsertJapaneseTitleTranslation(
-        database,
+      await saveJapaneseTranslation(
         movieResolution.movieUid,
         movieDetails.japaneseTitle,
+        environment_,
       );
     }
 

--- a/apps/scrapers/src/common/fetch-utilities.ts
+++ b/apps/scrapers/src/common/fetch-utilities.ts
@@ -2,12 +2,39 @@
  * HTTPリクエスト関連のユーティリティ関数
  */
 
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1000);
+  }
+
+  const dateMs = Date.parse(value) - Date.now();
+  return Number.isNaN(dateMs) ? undefined : Math.max(0, dateMs);
+}
+
 /**
  * リトライ機能付きのfetch
+ * - タイムアウト: AbortSignal.timeoutで打ち切り(デフォルト15秒)
+ * - 429: Retry-Afterヘッダを尊重して待機しリトライ
+ * - 5xx・ネットワークエラー: 指数バックオフでリトライ
+ * - 429以外の4xx: リトライせず即エラー
  * @param url 取得するURL
  * @param options fetchオプション
  * @param retries リトライ回数
  * @param delay リトライ間の待機時間(ms)
+ * @param timeoutMs リクエストタイムアウト(ms)
  * @returns レスポンスのテキスト
  */
 export async function fetchWithRetry(
@@ -15,36 +42,88 @@ export async function fetchWithRetry(
   options: RequestInit = {},
   retries = 3,
   delay = 1000,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
 ): Promise<string> {
-  try {
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
-        ...options.headers,
-      },
-    });
+  let retriesLeft = retries;
+  let currentDelay = delay;
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
+  for (;;) {
+    let response: Response;
+
+    try {
+      response = await fetch(url, {
+        ...options,
+        signal: options.signal ?? AbortSignal.timeout(timeoutMs),
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+          ...options.headers,
+        },
+      });
+    } catch (error) {
+      if (retriesLeft <= 0) {
+        throw error;
+      }
+
+      console.warn(
+        `Fetch failed, retrying in ${currentDelay}ms... (${retriesLeft} retries left)`,
+      );
+      await sleep(currentDelay);
+      retriesLeft--;
+      currentDelay *= 1.5;
+      continue;
     }
 
-    return await response.text();
-  } catch (error) {
-    if (retries <= 0) {
-      throw error;
+    if (response.ok) {
+      return response.text();
     }
 
-    console.warn(
-      `Fetch failed, retrying in ${delay}ms... (${retries} retries left)`,
-    );
-    await new Promise(resolve => {
-      setTimeout(resolve, delay);
-    });
+    const {status} = response;
 
-    return fetchWithRetry(url, options, retries - 1, delay * 1.5);
+    if (status === 429 && retriesLeft > 0) {
+      const waitMs =
+        parseRetryAfter(response.headers.get('retry-after')) ?? currentDelay;
+      console.warn(
+        `Rate limited (429), retrying in ${waitMs}ms... (${retriesLeft} retries left)`,
+      );
+      await sleep(waitMs);
+      retriesLeft--;
+      currentDelay *= 1.5;
+      continue;
+    }
+
+    if (status >= 500 && retriesLeft > 0) {
+      console.warn(
+        `Fetch failed with status ${status}, retrying in ${currentDelay}ms... (${retriesLeft} retries left)`,
+      );
+      await sleep(currentDelay);
+      retriesLeft--;
+      currentDelay *= 1.5;
+      continue;
+    }
+
+    throw new Error(`HTTP error! Status: ${status}`);
   }
+}
+
+/**
+ * リトライ機能付きのfetch(JSONレスポンス用)
+ * @param url 取得するURL
+ * @param options fetchオプション
+ * @param retries リトライ回数
+ * @param delay リトライ間の待機時間(ms)
+ * @param timeoutMs リクエストタイムアウト(ms)
+ * @returns パース済みのJSON
+ */
+export async function fetchJsonWithRetry<T>(
+  url: string,
+  options: RequestInit = {},
+  retries = 3,
+  delay = 1000,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<T> {
+  const text = await fetchWithRetry(url, options, retries, delay, timeoutMs);
+  return JSON.parse(text) as T;
 }
 
 /**

--- a/apps/scrapers/src/common/tmdb-utilities.ts
+++ b/apps/scrapers/src/common/tmdb-utilities.ts
@@ -6,6 +6,7 @@ import {getDatabase, type Environment} from '@shine/database';
 import {movies} from '@shine/database/schema/movies';
 import {posterUrls} from '@shine/database/schema/poster-urls';
 import {translations} from '@shine/database/schema/translations';
+import {fetchJsonWithRetry} from './fetch-utilities';
 
 const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
 
@@ -104,12 +105,9 @@ export async function fetchTMDBMovieTranslations(
     );
     translationsUrl.searchParams.append('api_key', tmdbApiKey);
 
-    const response = await fetch(translationsUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDb API error: ${response.statusText}`);
-    }
-
-    const data: TMDBTranslationsResponse = await response.json();
+    const data = await fetchJsonWithRetry<TMDBTranslationsResponse>(
+      translationsUrl.toString(),
+    );
     return data;
   } catch (error) {
     console.error(
@@ -136,12 +134,9 @@ export async function searchTMDBMovie(
     searchUrlWithYear.searchParams.append('year', year.toString());
     searchUrlWithYear.searchParams.append('language', 'en-US');
 
-    const responseWithYear = await fetch(searchUrlWithYear.toString());
-    if (!responseWithYear.ok) {
-      throw new Error(`TMDb API error: ${responseWithYear.statusText}`);
-    }
-
-    const dataWithYear: TMDBSearchResponse = await responseWithYear.json();
+    const dataWithYear = await fetchJsonWithRetry<TMDBSearchResponse>(
+      searchUrlWithYear.toString(),
+    );
 
     // 年パラメータ付きで結果があった場合
     if (dataWithYear.results.length > 0) {
@@ -161,12 +156,9 @@ export async function searchTMDBMovie(
     searchUrlNoYear.searchParams.append('query', title);
     searchUrlNoYear.searchParams.append('language', 'en-US');
 
-    const responseNoYear = await fetch(searchUrlNoYear.toString());
-    if (!responseNoYear.ok) {
-      throw new Error(`TMDb API error: ${responseNoYear.statusText}`);
-    }
-
-    const dataNoYear: TMDBSearchResponse = await responseNoYear.json();
+    const dataNoYear = await fetchJsonWithRetry<TMDBSearchResponse>(
+      searchUrlNoYear.toString(),
+    );
 
     // 年パラメータなしでも結果をフィルタリング
     const matches = dataNoYear.results.filter(movie => {
@@ -204,12 +196,9 @@ export async function fetchTMDBMovieDetails(
     detailsUrl.searchParams.append('api_key', tmdbApiKey);
     detailsUrl.searchParams.append('language', language);
 
-    const response = await fetch(detailsUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDb API error: ${response.statusText}`);
-    }
-
-    const data: TMDBMovieData = await response.json();
+    const data = await fetchJsonWithRetry<TMDBMovieData>(
+      detailsUrl.toString(),
+    );
     return data;
   } catch (error) {
     console.error(
@@ -233,13 +222,9 @@ export async function fetchTMDBTvDetails(
     detailsUrl.searchParams.append('api_key', tmdbApiKey);
     detailsUrl.searchParams.append('language', language);
 
-    const response = await fetch(detailsUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDb API error: ${response.statusText}`);
-    }
-
-    const data: TMDBTvData & {translations?: TMDBMovieData['translations']} =
-      await response.json();
+    const data = await fetchJsonWithRetry<
+      TMDBTvData & {translations?: TMDBMovieData['translations']}
+    >(detailsUrl.toString());
     return {
       id: data.id,
       title: data.name,
@@ -283,12 +268,9 @@ export async function findTMDBByImdbId(
     findUrl.searchParams.append('api_key', tmdbApiKey);
     findUrl.searchParams.append('external_source', 'imdb_id');
 
-    const response = await fetch(findUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDb API error: ${response.statusText}`);
-    }
-
-    const data: TMDBFindResponse = await response.json();
+    const data = await fetchJsonWithRetry<TMDBFindResponse>(
+      findUrl.toString(),
+    );
 
     if (data.movie_results && data.movie_results.length > 0) {
       return {tmdbId: data.movie_results[0].id, mediaType: 'movie'};
@@ -395,12 +377,9 @@ export async function fetchTMDBMovieImages(
     );
     imagesUrl.searchParams.append('api_key', tmdbApiKey);
 
-    const imagesResponse = await fetch(imagesUrl.toString());
-    if (!imagesResponse.ok) {
-      throw new Error(`TMDb API error: ${imagesResponse.statusText}`);
-    }
-
-    const images: TMDBMovieImages = await imagesResponse.json();
+    const images = await fetchJsonWithRetry<TMDBMovieImages>(
+      imagesUrl.toString(),
+    );
     return {images, tmdbId, mediaType};
   } catch (error) {
     console.error(`Error fetching TMDb images for IMDb ID ${imdbId}:`, error);


### PR DESCRIPTION
- `fetchWithRetry` に AbortSignal.timeout によるタイムアウト(デフォルト15秒)、429時のRetry-Afterヘッダ尊重リトライ、5xxのみリトライ・429以外の4xxは即エラーの制御を追加。JSON用の `fetchJsonWithRetry` も追加(TDDでテスト先行)
- `common/tmdb-utilities.ts` の素のfetch 7箇所を `fetchJsonWithRetry` 経由に置換。挙動担保のテストを追加
- カンヌスクレイパーの日本語タイトル保存の `isDefault: 0` を共通実装(`saveJapaneseTranslation` = `isDefault: 1`)に統一

lint / tsc / vitest(647件)すべて通過。

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x