### PR TITLE
front: admin系のトークン管理と401ハンドリングをadmin-fetchヘルパーに集約

### DIFF
--- a/apps/front/app/components/admin-nav.tsx
+++ b/apps/front/app/components/admin-nav.tsx
@@ -1,5 +1,6 @@
 import {useLocation} from 'react-router';
 import {Button} from '@/components/ui/button';
+import {clearAdminToken} from '@/lib/admin-fetch';
 
 const navItems = [
   {href: '/', label: 'トップページ'},
@@ -10,7 +11,7 @@ const navItems = [
 
 const handleLogout = () => {
   if (typeof globalThis !== 'undefined' && globalThis.localStorage) {
-    globalThis.localStorage.removeItem('adminToken');
+    clearAdminToken();
     globalThis.location.href = '/admin/login';
   }
 };

--- a/apps/front/app/components/article-link-manager.tsx
+++ b/apps/front/app/components/article-link-manager.tsx
@@ -1,5 +1,6 @@
 import {useState} from 'react';
 import type {Dispatch, SetStateAction} from 'react';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type ArticleLink = {
   uid: string;
@@ -50,19 +51,15 @@ export default function ArticleLinkManager<
       return;
     }
 
-    const token = globalThis.localStorage.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       return;
     }
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/article-links/${articleId}`,
         {
           method: 'DELETE',
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
         },
       );
 
@@ -85,19 +82,15 @@ export default function ArticleLinkManager<
       return;
     }
 
-    const token = globalThis.localStorage.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       return;
     }
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/article-links/${articleId}/spam`,
         {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
         },
       );
 

--- a/apps/front/app/components/molecules/admin-login.tsx
+++ b/apps/front/app/components/molecules/admin-login.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react';
 import {Button} from '@/components/ui/button.tsx';
+import {clearAdminToken, getAdminToken, setAdminToken} from '@/lib/admin-fetch';
 
 type AdminLoginProperties = {
   locale: string;
@@ -15,8 +16,7 @@ export function AdminLogin({locale, apiUrl}: AdminLoginProperties) {
 
   useEffect(() => {
     if (globalThis.window !== undefined) {
-      const token = localStorage.getItem('adminToken') ?? undefined;
-      setIsLoggedIn(Boolean(token));
+      setIsLoggedIn(Boolean(getAdminToken()));
     }
   }, []);
 
@@ -69,11 +69,10 @@ export function AdminLogin({locale, apiUrl}: AdminLoginProperties) {
 
       if (response.ok) {
         const {token} = (await response.json()) as {token: string};
-        localStorage.setItem('adminToken', token);
+        setAdminToken(token);
         setIsLoggedIn(true);
         setShowModal(false);
         setPassword('');
-        globalThis.dispatchEvent(new Event('adminLogin'));
       } else {
         setError(true);
       }
@@ -86,9 +85,8 @@ export function AdminLogin({locale, apiUrl}: AdminLoginProperties) {
   };
 
   const handleLogout = () => {
-    localStorage.removeItem('adminToken');
+    clearAdminToken();
     setIsLoggedIn(false);
-    globalThis.dispatchEvent(new Event('adminLogout'));
   };
 
   const handleOpenChange = (open: boolean) => {

--- a/apps/front/app/components/movie-info-editor.test.tsx
+++ b/apps/front/app/components/movie-info-editor.test.tsx
@@ -129,10 +129,9 @@ describe('MovieInfoEditor 外部ID検索', () => {
         }
 
         if (url.endsWith('/tmdb-id') && method === 'PUT') {
-          expect(init?.headers).toMatchObject({
-            Authorization: 'Bearer admin-token',
-            'Content-Type': 'application/json',
-          });
+          const headers = new Headers(init?.headers);
+          expect(headers.get('authorization')).toBe('Bearer admin-token');
+          expect(headers.get('content-type')).toBe('application/json');
           return Promise.resolve({
             ok: true,
             status: 200,
@@ -189,13 +188,15 @@ describe('MovieInfoEditor 外部ID検索', () => {
       );
     });
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining(
+    const searchCall = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes(
         `/admin/movies/${movieData.uid}/external-id-search`,
       ),
-      expect.objectContaining({
-        headers: {Authorization: 'Bearer admin-token'},
-      }),
+    );
+    expect(searchCall).toBeDefined();
+    const searchInit = searchCall?.[1] as RequestInit | undefined;
+    expect(new Headers(searchInit?.headers).get('authorization')).toBe(
+      'Bearer admin-token',
     );
   });
 });

--- a/apps/front/app/components/movie-info-editor.tsx
+++ b/apps/front/app/components/movie-info-editor.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import type {FormEvent} from 'react';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type MovieDetails = {
   uid: string;
@@ -195,17 +196,15 @@ export default function MovieInfoEditor({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
 
     try {
-      const response = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
+      const response = await adminFetch(`${apiUrl}/admin/movies/${movieId}`, {
         method: 'PUT',
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -214,8 +213,6 @@ export default function MovieInfoEditor({
       });
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -226,9 +223,9 @@ export default function MovieInfoEditor({
         throw new Error(errorData.error || 'Failed to update year');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -252,8 +249,7 @@ export default function MovieInfoEditor({
     imdbIdValue: string | undefined,
     options: {fetchTmdbData?: boolean} = {},
   ) => {
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return false;
     }
@@ -265,12 +261,11 @@ export default function MovieInfoEditor({
     };
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/imdb-id`,
         {
           method: 'PUT',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(body),
@@ -278,8 +273,6 @@ export default function MovieInfoEditor({
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return false;
       }
 
@@ -290,9 +283,9 @@ export default function MovieInfoEditor({
         throw new Error(errorData.error || 'Failed to update IMDb ID');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -311,8 +304,7 @@ export default function MovieInfoEditor({
     tmdbIdValue: number | undefined,
     options: {refreshData?: boolean} = {},
   ) => {
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return false;
     }
@@ -323,12 +315,11 @@ export default function MovieInfoEditor({
     };
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/tmdb-id`,
         {
           method: 'PUT',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(body),
@@ -336,8 +327,6 @@ export default function MovieInfoEditor({
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return false;
       }
 
@@ -352,9 +341,9 @@ export default function MovieInfoEditor({
         throw new Error(errorData.error || 'Failed to update TMDb ID');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -458,8 +447,7 @@ export default function MovieInfoEditor({
       parameters.set('year', String(parsedYear));
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
@@ -471,16 +459,11 @@ export default function MovieInfoEditor({
     setIdSearchUsedYear(undefined);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/external-id-search?${parameters.toString()}`,
-        {
-          headers: {Authorization: `Bearer ${token}`},
-        },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -596,8 +579,7 @@ export default function MovieInfoEditor({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
@@ -606,19 +588,14 @@ export default function MovieInfoEditor({
     setTmdbRefreshError(undefined);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/refresh-tmdb`,
         {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
         },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -629,9 +606,9 @@ export default function MovieInfoEditor({
         throw new Error(errorData.error || 'Failed to refresh TMDb data');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -655,8 +632,7 @@ export default function MovieInfoEditor({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
@@ -665,19 +641,14 @@ export default function MovieInfoEditor({
     setAutoFetchError(undefined);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/auto-fetch-tmdb`,
         {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
         },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -697,9 +668,9 @@ export default function MovieInfoEditor({
         };
       };
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -1208,8 +1179,7 @@ function MediaTypeToggle({
     if (updating) return;
 
     const newType = movieData.mediaType === 'tv' ? 'movie' : 'tv';
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
@@ -1218,18 +1188,15 @@ function MediaTypeToggle({
     setError(undefined);
 
     try {
-      const response = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
+      const response = await adminFetch(`${apiUrl}/admin/movies/${movieId}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({mediaType: newType}),
       });
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 

--- a/apps/front/app/components/nomination-manager.test.tsx
+++ b/apps/front/app/components/nomination-manager.test.tsx
@@ -110,11 +110,14 @@ describe('NominationManager', () => {
       expect(screen.getAllByRole('combobox')).toHaveLength(3);
     });
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
-      'http://localhost:8787/admin/awards',
-      expect.objectContaining({
-        headers: {Authorization: 'Bearer admin-token'},
-      }),
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const awardsCall = fetchMock.mock.calls.find(
+      ([input]) => input === 'http://localhost:8787/admin/awards',
+    );
+    expect(awardsCall).toBeDefined();
+    const awardsInit = awardsCall?.[1] as RequestInit | undefined;
+    expect(new Headers(awardsInit?.headers).get('authorization')).toBe(
+      'Bearer admin-token',
     );
   });
 });

--- a/apps/front/app/components/nomination-manager.tsx
+++ b/apps/front/app/components/nomination-manager.tsx
@@ -2,6 +2,7 @@ import {useEffect, useMemo, useState} from 'react';
 import {Link} from 'react-router';
 import type {ChangeEvent, FormEvent} from 'react';
 import type {MovieDetails, Nomination} from '../routes/admin.movies.$id';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type NominationManagerProperties = {
   movieId: string;
@@ -39,7 +40,7 @@ type AwardsData = {
 };
 
 const ensureToken = () => {
-  const token = globalThis.localStorage?.getItem('adminToken');
+  const token = getAdminToken();
   if (!token) {
     globalThis.location.href = '/admin/login';
     return;
@@ -136,8 +137,7 @@ export default function NominationManager({
         return;
       }
 
-      const token = globalThis.localStorage?.getItem('adminToken');
-      if (!token) {
+      if (!getAdminToken()) {
         globalThis.location.href = '/admin/login';
         return;
       }
@@ -146,13 +146,9 @@ export default function NominationManager({
       setAwardsError(undefined);
 
       try {
-        const response = await fetch(`${apiUrl}/admin/awards`, {
-          headers: {Authorization: `Bearer ${token}`},
-        });
+        const response = await adminFetch(`${apiUrl}/admin/awards`);
 
         if (response.status === 401) {
-          globalThis.localStorage?.removeItem('adminToken');
-          globalThis.location.href = '/admin/login';
           return;
         }
 
@@ -215,10 +211,8 @@ export default function NominationManager({
     setNominationError(undefined);
   };
 
-  const refreshMovieData = async (token: string) => {
-    const response = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-      headers: {Authorization: `Bearer ${token}`},
-    });
+  const refreshMovieData = async () => {
+    const response = await adminFetch(`${apiUrl}/admin/movies/${movieId}`);
 
     if (response.ok) {
       const movie = (await response.json()) as MovieDetails;
@@ -250,20 +244,18 @@ export default function NominationManager({
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
     setIsAdding(true);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/nominations`,
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
@@ -279,8 +271,6 @@ export default function NominationManager({
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -291,7 +281,7 @@ export default function NominationManager({
         throw new Error(errorData.error || 'ノミネートの追加に失敗しました');
       }
 
-      await refreshMovieData(token);
+      await refreshMovieData();
       resetAddForm();
       setShowAddForm(false);
       globalThis.alert?.('ノミネートを追加しました');
@@ -322,8 +312,7 @@ export default function NominationManager({
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
@@ -331,12 +320,11 @@ export default function NominationManager({
     setNominationError(undefined);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/nominations/${editingNominationId}`,
         {
           method: 'PUT',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
@@ -350,8 +338,6 @@ export default function NominationManager({
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -362,7 +348,7 @@ export default function NominationManager({
         throw new Error(errorData.error || 'ノミネートの更新に失敗しました');
       }
 
-      await refreshMovieData(token);
+      await refreshMovieData();
       setEditingNominationId(undefined);
       globalThis.alert?.('ノミネートを更新しました');
     } catch (error) {
@@ -386,8 +372,7 @@ export default function NominationManager({
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
@@ -395,17 +380,14 @@ export default function NominationManager({
     setNominationError(undefined);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/nominations/${nomination.uid}`,
         {
           method: 'DELETE',
-          headers: {Authorization: `Bearer ${token}`},
         },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -416,7 +398,7 @@ export default function NominationManager({
         throw new Error(errorData.error || 'ノミネートの削除に失敗しました');
       }
 
-      await refreshMovieData(token);
+      await refreshMovieData();
       globalThis.alert?.('ノミネートを削除しました');
     } catch (error) {
       const message =

--- a/apps/front/app/components/poster-manager.tsx
+++ b/apps/front/app/components/poster-manager.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type PosterUrl = {
   uid: string;
@@ -63,19 +64,17 @@ export default function PosterManager({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/posters`,
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
@@ -94,8 +93,6 @@ export default function PosterManager({
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -106,9 +103,9 @@ export default function PosterManager({
         throw new Error(errorData.error || 'Failed to add poster');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -140,26 +137,20 @@ export default function PosterManager({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${movieId}/posters/${posterId}`,
         {
           method: 'DELETE',
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
         },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -170,9 +161,9 @@ export default function PosterManager({
         throw new Error(errorData.error || 'Failed to delete poster');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;

--- a/apps/front/app/components/translation-manager.tsx
+++ b/apps/front/app/components/translation-manager.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type Translation = {
   uid: string;
@@ -65,29 +66,28 @@ export default function TranslationManager({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
 
     try {
-      const response = await fetch(`${apiUrl}/movies/${movieId}/translations`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
+      const response = await adminFetch(
+        `${apiUrl}/movies/${movieId}/translations`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            languageCode: newTranslation.languageCode.trim(),
+            content: newTranslation.content.trim(),
+            isDefault: newTranslation.isDefault,
+          }),
         },
-        body: JSON.stringify({
-          languageCode: newTranslation.languageCode.trim(),
-          content: newTranslation.content.trim(),
-          isDefault: newTranslation.isDefault,
-        }),
-      });
+      );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -98,9 +98,9 @@ export default function TranslationManager({
         throw new Error(errorData.error || 'Failed to add translation');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -130,29 +130,28 @@ export default function TranslationManager({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
 
     try {
-      const response = await fetch(`${apiUrl}/movies/${movieId}/translations`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
+      const response = await adminFetch(
+        `${apiUrl}/movies/${movieId}/translations`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            languageCode: languageCode.trim(),
+            content: content.trim(),
+            isDefault,
+          }),
         },
-        body: JSON.stringify({
-          languageCode: languageCode.trim(),
-          content: content.trim(),
-          isDefault,
-        }),
-      });
+      );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -163,9 +162,9 @@ export default function TranslationManager({
         throw new Error(errorData.error || 'Failed to update translation');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;
@@ -189,26 +188,20 @@ export default function TranslationManager({
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/movies/${movieId}/translations/${languageCode}`,
         {
           method: 'DELETE',
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
         },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -219,9 +212,9 @@ export default function TranslationManager({
         throw new Error(errorData.error || 'Failed to delete translation');
       }
 
-      const movieResponse = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const movieResponse = await adminFetch(
+        `${apiUrl}/admin/movies/${movieId}`,
+      );
 
       if (movieResponse.ok) {
         const data = (await movieResponse.json()) as MovieDetails;

--- a/apps/front/app/lib/admin-fetch.test.ts
+++ b/apps/front/app/lib/admin-fetch.test.ts
@@ -1,0 +1,158 @@
+import {beforeEach, describe, expect, it, vi, type Mock} from 'vitest';
+import {
+  adminFetch,
+  clearAdminToken,
+  getAdminToken,
+  setAdminToken,
+} from './admin-fetch';
+
+const fetchMock = globalThis.fetch as Mock;
+
+const lastFetchHeaders = () => {
+  const [, init] = fetchMock.mock.calls.at(-1) as [unknown, RequestInit];
+  return new Headers(init.headers);
+};
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+  fetchMock.mockReset();
+  globalThis.location.href = 'http://localhost:3000/';
+});
+
+describe('getAdminToken', () => {
+  it('localStorageのadminTokenを返す', () => {
+    globalThis.localStorage.setItem('adminToken', 'token-123');
+
+    expect(getAdminToken()).toBe('token-123');
+  });
+
+  it('トークンが無ければundefinedを返す', () => {
+    expect(getAdminToken()).toBeUndefined();
+  });
+});
+
+describe('setAdminToken', () => {
+  it('localStorageにトークンを保存する', () => {
+    setAdminToken('token-abc');
+
+    expect(globalThis.localStorage.getItem('adminToken')).toBe('token-abc');
+  });
+
+  it('adminLoginイベントをdispatchする', () => {
+    const listener = vi.fn();
+    globalThis.addEventListener('adminLogin', listener);
+
+    setAdminToken('token-abc');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    globalThis.removeEventListener('adminLogin', listener);
+  });
+});
+
+describe('clearAdminToken', () => {
+  it('localStorageからトークンを削除する', () => {
+    globalThis.localStorage.setItem('adminToken', 'token-abc');
+
+    clearAdminToken();
+
+    expect(globalThis.localStorage.getItem('adminToken')).toBeNull();
+  });
+
+  it('adminLogoutイベントをdispatchする', () => {
+    const listener = vi.fn();
+    globalThis.addEventListener('adminLogout', listener);
+
+    clearAdminToken();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    globalThis.removeEventListener('adminLogout', listener);
+  });
+});
+
+describe('adminFetch', () => {
+  it('Authorizationヘッダを自動付与する', async () => {
+    globalThis.localStorage.setItem('adminToken', 'token-xyz');
+    fetchMock.mockResolvedValue(new Response('{}', {status: 200}));
+
+    await adminFetch('https://api.example.com/admin/movies');
+
+    expect(lastFetchHeaders().get('authorization')).toBe('Bearer token-xyz');
+  });
+
+  it('トークンが無ければAuthorizationヘッダを付与しない', async () => {
+    fetchMock.mockResolvedValue(new Response('{}', {status: 200}));
+
+    await adminFetch('https://api.example.com/admin/movies');
+
+    expect(lastFetchHeaders().get('authorization')).toBeNull();
+  });
+
+  it('initのmethodや既存ヘッダを引き継ぐ', async () => {
+    globalThis.localStorage.setItem('adminToken', 'token-xyz');
+    fetchMock.mockResolvedValue(new Response('{}', {status: 200}));
+
+    await adminFetch('https://api.example.com/admin/movies', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: '{}',
+    });
+
+    const [, init] = fetchMock.mock.calls.at(-1) as [unknown, RequestInit];
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('{}');
+    expect(lastFetchHeaders().get('content-type')).toBe('application/json');
+    expect(lastFetchHeaders().get('authorization')).toBe('Bearer token-xyz');
+  });
+
+  it('成功レスポンスをそのまま返す', async () => {
+    globalThis.localStorage.setItem('adminToken', 'token-xyz');
+    fetchMock.mockResolvedValue(new Response('{"ok":true}', {status: 200}));
+
+    const response = await adminFetch('https://api.example.com/admin/movies');
+
+    expect(response.status).toBe(200);
+    expect(globalThis.localStorage.getItem('adminToken')).toBe('token-xyz');
+    expect(globalThis.location.href).toBe('http://localhost:3000/');
+  });
+
+  it('401ならトークンを削除して/admin/loginへリダイレクトする', async () => {
+    globalThis.localStorage.setItem('adminToken', 'token-xyz');
+    fetchMock.mockResolvedValue(new Response('Unauthorized', {status: 401}));
+
+    await adminFetch('https://api.example.com/admin/movies');
+
+    expect(globalThis.localStorage.getItem('adminToken')).toBeNull();
+    expect(globalThis.location.href).toBe('/admin/login');
+  });
+
+  it('401時にadminLogoutイベントをdispatchする', async () => {
+    globalThis.localStorage.setItem('adminToken', 'token-xyz');
+    fetchMock.mockResolvedValue(new Response('Unauthorized', {status: 401}));
+    const listener = vi.fn();
+    globalThis.addEventListener('adminLogout', listener);
+
+    await adminFetch('https://api.example.com/admin/movies');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    globalThis.removeEventListener('adminLogout', listener);
+  });
+
+  it('401でもそのResponseを返す', async () => {
+    fetchMock.mockResolvedValue(new Response('Unauthorized', {status: 401}));
+
+    const response = await adminFetch('https://api.example.com/admin/movies');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('401以外のエラーではリダイレクトしない', async () => {
+    globalThis.localStorage.setItem('adminToken', 'token-xyz');
+    fetchMock.mockResolvedValue(new Response('Server Error', {status: 500}));
+
+    const response = await adminFetch('https://api.example.com/admin/movies');
+
+    expect(response.status).toBe(500);
+    expect(globalThis.localStorage.getItem('adminToken')).toBe('token-xyz');
+    expect(globalThis.location.href).toBe('http://localhost:3000/');
+  });
+});

--- a/apps/front/app/lib/admin-fetch.ts
+++ b/apps/front/app/lib/admin-fetch.ts
@@ -1,0 +1,35 @@
+const tokenKey = 'adminToken';
+
+export function getAdminToken(): string | undefined {
+  return globalThis.localStorage?.getItem(tokenKey) ?? undefined;
+}
+
+export function setAdminToken(token: string): void {
+  globalThis.localStorage?.setItem(tokenKey, token);
+  globalThis.dispatchEvent(new Event('adminLogin'));
+}
+
+export function clearAdminToken(): void {
+  globalThis.localStorage?.removeItem(tokenKey);
+  globalThis.dispatchEvent(new Event('adminLogout'));
+}
+
+export async function adminFetch(
+  input: string | URL | Request,
+  init: RequestInit = {},
+): Promise<Response> {
+  const token = getAdminToken();
+  const headers = new Headers(init.headers);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const response = await fetch(input, {...init, headers});
+
+  if (response.status === 401) {
+    clearAdminToken();
+    globalThis.location.href = '/admin/login';
+  }
+
+  return response;
+}

--- a/apps/front/app/routes/admin.ceremonies.$uid.tsx
+++ b/apps/front/app/routes/admin.ceremonies.$uid.tsx
@@ -5,6 +5,7 @@ import {Button} from '@/components/ui/button';
 import {Input} from '@/components/ui/input';
 import {Textarea} from '@/components/ui/textarea';
 import type {Route} from './+types/admin.ceremonies.$uid';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type LoaderData = {
   apiUrl: string;
@@ -141,7 +142,7 @@ const ensureToken = () => {
     return;
   }
 
-  const token = globalThis.localStorage?.getItem('adminToken');
+  const token = getAdminToken();
   if (!token) {
     globalThis.location.href = '/admin/login';
     return;
@@ -387,8 +388,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
   const isSyncButtonDisabled = isSyncingFromImdb || !canSyncFromImdb;
 
   const fetchAwardsData = useCallback(async () => {
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
@@ -396,13 +396,9 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
     setAwardsError(undefined);
 
     try {
-      const response = await fetch(`${apiUrl}/admin/awards`, {
-        headers: {Authorization: `Bearer ${token}`},
-      });
+      const response = await adminFetch(`${apiUrl}/admin/awards`);
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -428,10 +424,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
   }, [apiUrl]);
 
   const fetchCeremony = useCallback(
-    async (
-      token: string,
-      options?: {syncForm?: boolean; showSpinner?: boolean},
-    ) => {
+    async (options?: {syncForm?: boolean; showSpinner?: boolean}) => {
       const {syncForm = true, showSpinner = true} = options ?? {};
 
       if (showSpinner) {
@@ -440,16 +433,11 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       setDetailError(undefined);
 
       try {
-        const response = await fetch(
+        const response = await adminFetch(
           `${apiUrl}/admin/ceremonies/${ceremonyUid}`,
-          {
-            headers: {Authorization: `Bearer ${token}`},
-          },
         );
 
         if (response.status === 401) {
-          globalThis.localStorage?.removeItem('adminToken');
-          globalThis.location.href = '/admin/login';
           return;
         }
 
@@ -502,12 +490,11 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
-    void fetchCeremony(token, {syncForm: true, showSpinner: true});
+    void fetchCeremony({syncForm: true, showSpinner: true});
   }, [fetchCeremony, isNew]);
 
   useEffect(() => {
@@ -574,8 +561,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
@@ -598,14 +584,13 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
             : formState.imdbEventUrl,
       };
 
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/ceremonies${
           isNew ? '' : `/${ceremonyDetail?.ceremony.uid ?? ceremonyUid}`
         }`,
         {
           method: isNew ? 'POST' : 'PUT',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(payload),
@@ -613,8 +598,6 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -681,8 +664,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       }
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
@@ -690,17 +672,14 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
     setDeleteError(undefined);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/ceremonies/${ceremonyDetail.ceremony.uid}`,
         {
           method: 'DELETE',
-          headers: {Authorization: `Bearer ${token}`},
         },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -735,22 +714,18 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
     setIsSearchingMovies(true);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies?limit=10&search=${encodeURIComponent(trimmedQuery)}`,
-        {headers: {Authorization: `Bearer ${token}`}},
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -795,20 +770,18 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
     setIsAddingNomination(true);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/movies/${selectedMovie.uid}/nominations`,
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
@@ -824,8 +797,6 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -836,12 +807,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
         throw new Error(data.error || '映画の追加に失敗しました。');
       }
 
-      const tokenAfter = ensureToken();
-      if (!tokenAfter) {
-        return;
-      }
-
-      await fetchCeremony(tokenAfter, {syncForm: false, showSpinner: true});
+      await fetchCeremony({syncForm: false, showSpinner: true});
       setNominationMessage('映画を追加しました。');
       setSelectedMovie(undefined);
       setMovieSearchQuery('');
@@ -868,23 +834,19 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       }
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/nominations/${nominationUid}`,
         {
           method: 'DELETE',
-          headers: {Authorization: `Bearer ${token}`},
         },
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -895,12 +857,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
         throw new Error(data.error || '紐付けの削除に失敗しました。');
       }
 
-      const tokenAfter = ensureToken();
-      if (!tokenAfter) {
-        return;
-      }
-
-      await fetchCeremony(tokenAfter, {syncForm: false, showSpinner: false});
+      await fetchCeremony({syncForm: false, showSpinner: false});
     } catch (error) {
       const message =
         error instanceof Error ? error.message : '紐付けの削除に失敗しました。';
@@ -925,8 +882,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       return;
     }
 
-    const token = ensureToken();
-    if (!token) {
+    if (!ensureToken()) {
       return;
     }
 
@@ -934,12 +890,11 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
     setNominationMessage(undefined);
 
     try {
-      const response = await fetch(
+      const response = await adminFetch(
         `${apiUrl}/admin/ceremonies/${ceremonyDetail.ceremony.uid}/sync-imdb`,
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({categoryUid: selectedSyncCategory.uid}),
@@ -947,8 +902,6 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
       );
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 
@@ -971,12 +924,7 @@ export default function AdminCeremonyEdit({loaderData}: Route.ComponentProps) {
         throw new Error(data.error || 'IMDbリストとの同期に失敗しました。');
       }
 
-      const tokenAfter = ensureToken();
-      if (!tokenAfter) {
-        return;
-      }
-
-      await fetchCeremony(tokenAfter, {syncForm: false, showSpinner: true});
+      await fetchCeremony({syncForm: false, showSpinner: true});
 
       if (data.stats) {
         const {

--- a/apps/front/app/routes/admin.ceremonies.tsx
+++ b/apps/front/app/routes/admin.ceremonies.tsx
@@ -11,6 +11,7 @@ import {
 import {Input} from '@/components/ui/input';
 import {Label} from '@/components/ui/label';
 import type {Route} from './+types/admin.ceremonies';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type CeremonyListItem = {
   uid: string;
@@ -144,9 +145,7 @@ export default function AdminCeremonies({loaderData}: Route.ComponentProps) {
         return;
       }
 
-      const token = globalThis.localStorage?.getItem('adminToken');
-
-      if (!token) {
+      if (!getAdminToken()) {
         globalThis.location.href = '/admin/login';
         return;
       }
@@ -155,13 +154,9 @@ export default function AdminCeremonies({loaderData}: Route.ComponentProps) {
       setError(undefined);
 
       try {
-        const response = await fetch(`${apiUrl}/admin/ceremonies`, {
-          headers: {Authorization: `Bearer ${token}`},
-        });
+        const response = await adminFetch(`${apiUrl}/admin/ceremonies`);
 
         if (response.status === 401) {
-          globalThis.localStorage?.removeItem('adminToken');
-          globalThis.location.href = '/admin/login';
           return;
         }
 

--- a/apps/front/app/routes/admin.login.tsx
+++ b/apps/front/app/routes/admin.login.tsx
@@ -2,6 +2,7 @@ import {useEffect} from 'react';
 import {useNavigate} from 'react-router';
 import type {Route} from './+types/admin.login';
 import {Button} from '@/components/ui/button';
+import {getAdminToken, setAdminToken} from '@/lib/admin-fetch';
 
 export function meta(): Route.MetaDescriptors {
   return [
@@ -53,11 +54,8 @@ export default function AdminLogin({actionData}: Route.ComponentProps) {
 
   // ログイン済みかチェック
   useEffect(() => {
-    if (globalThis.window !== undefined) {
-      const existingToken = localStorage.getItem('adminToken');
-      if (existingToken) {
-        navigate('/admin/movies', {replace: true});
-      }
+    if (globalThis.window !== undefined && getAdminToken()) {
+      navigate('/admin/movies', {replace: true});
     }
   }, [navigate]);
 
@@ -68,11 +66,8 @@ export default function AdminLogin({actionData}: Route.ComponentProps) {
       actionData?.token &&
       globalThis.window !== undefined
     ) {
-      localStorage.setItem('adminToken', actionData.token);
+      setAdminToken(actionData.token);
       console.log('Token saved, redirecting to /admin/movies');
-
-      // イベント発火でother componentsに通知
-      globalThis.dispatchEvent(new Event('adminLogin'));
 
       navigate('/admin/movies', {replace: true});
     }

--- a/apps/front/app/routes/admin.movies.$id.tsx
+++ b/apps/front/app/routes/admin.movies.$id.tsx
@@ -6,6 +6,7 @@ import MovieInfoEditor from '../components/movie-info-editor';
 import NominationManager from '../components/nomination-manager';
 import ArticleLinkManager from '../components/article-link-manager';
 import type {Route} from './+types/admin.movies.$id';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 export type Translation = {
   uid: string;
@@ -105,8 +106,7 @@ export default function AdminMovieEdit({loaderData}: Route.ComponentProps) {
         return;
       }
 
-      const token = globalThis.localStorage.getItem('adminToken');
-      if (!token) {
+      if (!getAdminToken()) {
         globalThis.location.href = '/admin/login';
         return;
       }
@@ -115,13 +115,9 @@ export default function AdminMovieEdit({loaderData}: Route.ComponentProps) {
       setError(undefined);
 
       try {
-        const response = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
-          headers: {Authorization: `Bearer ${token}`},
-        });
+        const response = await adminFetch(`${apiUrl}/admin/movies/${movieId}`);
 
         if (response.status === 401) {
-          globalThis.localStorage.removeItem('adminToken');
-          globalThis.location.href = '/admin/login';
           return;
         }
 

--- a/apps/front/app/routes/admin.movies.selections.tsx
+++ b/apps/front/app/routes/admin.movies.selections.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/card';
 import {Input} from '@/components/ui/input';
 import type {Route} from './+types/admin.movies.selections';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type SelectionData = {
   date: string;
@@ -158,7 +159,7 @@ export default function AdminMovieSelections({
         return;
       }
 
-      const token = globalThis.localStorage.getItem('adminToken');
+      const token = getAdminToken();
       if (!token) {
         globalThis.location.href = '/admin/login';
         return;
@@ -169,16 +170,11 @@ export default function AdminMovieSelections({
       setError(undefined);
 
       try {
-        const response = await fetch(
+        const response = await adminFetch(
           `${apiUrl}/admin/preview-selections?locale=${locale}`,
-          {
-            headers: {Authorization: `Bearer ${token}`},
-          },
         );
 
         if (response.status === 401) {
-          globalThis.localStorage.removeItem('adminToken');
-          globalThis.location.href = '/admin/login';
           return;
         }
 
@@ -209,10 +205,8 @@ export default function AdminMovieSelections({
     const timeoutId = setTimeout(async () => {
       setSearchLoading(true);
       try {
-        const token = globalThis.localStorage.getItem('adminToken');
-        const response = await fetch(
+        const response = await adminFetch(
           `${apiUrl}/admin/movies?search=${encodeURIComponent(searchQuery)}&limit=20`,
-          {headers: {Authorization: `Bearer ${token}`}},
         );
 
         if (response.ok) {
@@ -238,19 +232,20 @@ export default function AdminMovieSelections({
   const generateRandomMovie = async () => {
     setRandomLoading(true);
     try {
-      const token = globalThis.localStorage.getItem('adminToken');
-      const response = await fetch(`${apiUrl}/admin/random-movie-preview`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
+      const response = await adminFetch(
+        `${apiUrl}/admin/random-movie-preview`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            type: overrideType,
+            date: getSelectionDate(),
+            locale,
+          }),
         },
-        body: JSON.stringify({
-          type: overrideType,
-          date: getSelectionDate(),
-          locale,
-        }),
-      });
+      );
 
       if (response.ok) {
         const data = (await response.json()) as SearchMovie;
@@ -269,12 +264,10 @@ export default function AdminMovieSelections({
     }
 
     try {
-      const token = globalThis.localStorage.getItem('adminToken');
-      const response = await fetch(`${apiUrl}/admin/override-selection`, {
+      const response = await adminFetch(`${apiUrl}/admin/override-selection`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           type: overrideType,

--- a/apps/front/app/routes/admin.movies.tsx
+++ b/apps/front/app/routes/admin.movies.tsx
@@ -12,6 +12,7 @@ import {
 import {Input} from '@/components/ui/input';
 import {Label} from '@/components/ui/label';
 import type {Route} from './+types/admin.movies';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 
 type Movie = {
   uid: string;
@@ -122,8 +123,7 @@ const MoviesList = memo(({apiUrl}: {apiUrl: string}) => {
         return;
       }
 
-      const token = globalThis.localStorage.getItem('adminToken');
-      if (!token) {
+      if (!getAdminToken()) {
         globalThis.location.href = '/admin/login';
         return;
       }
@@ -135,16 +135,11 @@ const MoviesList = memo(({apiUrl}: {apiUrl: string}) => {
         const searchParameter = search
           ? `&search=${encodeURIComponent(search)}`
           : '';
-        const response = await fetch(
+        const response = await adminFetch(
           `${apiUrl}/admin/movies?page=${page}&limit=${limit}${searchParameter}`,
-          {
-            headers: {Authorization: `Bearer ${token}`},
-          },
         );
 
         if (response.status === 401) {
-          globalThis.localStorage.removeItem('adminToken');
-          globalThis.location.href = '/admin/login';
           return;
         }
 
@@ -373,22 +368,16 @@ const deleteMovie = async (
     return false;
   }
 
-  const token = globalThis.localStorage?.getItem('adminToken');
-  if (!token) {
+  if (!getAdminToken()) {
     return false;
   }
 
   try {
-    const response = await fetch(`${apiUrl}/admin/movies/${movieId}`, {
+    const response = await adminFetch(`${apiUrl}/admin/movies/${movieId}`, {
       method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (response.status === 401) {
-      globalThis.localStorage?.removeItem('adminToken');
-      globalThis.location.href = '/admin/login';
       return false;
     }
 
@@ -435,18 +424,16 @@ const mergeMovies = async (
   sourceTitle: string,
   apiUrl: string,
 ) => {
-  const token = globalThis.localStorage?.getItem('adminToken');
-  if (!token) {
+  if (!getAdminToken()) {
     return false;
   }
 
   try {
-    const response = await fetch(
+    const response = await adminFetch(
       `${apiUrl}/admin/movies/${sourceId}/merge/${targetId}`,
       {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
       },
@@ -528,8 +515,7 @@ export default function AdminMovies({loaderData}: Route.ComponentProps) {
       return;
     }
 
-    const token = globalThis.localStorage?.getItem('adminToken');
-    if (!token) {
+    if (!getAdminToken()) {
       globalThis.location.href = '/admin/login';
       return;
     }
@@ -539,10 +525,9 @@ export default function AdminMovies({loaderData}: Route.ComponentProps) {
     setCreateSuccess(undefined);
 
     try {
-      const response = await fetch(`${apiUrl}/admin/movies`, {
+      const response = await adminFetch(`${apiUrl}/admin/movies`, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
@@ -552,8 +537,6 @@ export default function AdminMovies({loaderData}: Route.ComponentProps) {
       });
 
       if (response.status === 401) {
-        globalThis.localStorage?.removeItem('adminToken');
-        globalThis.location.href = '/admin/login';
         return;
       }
 

--- a/apps/front/app/routes/home.tsx
+++ b/apps/front/app/routes/home.tsx
@@ -5,6 +5,7 @@ import {Button} from '@/components/ui/button';
 import {AdminLogin} from '@/components/molecules/admin-login';
 import {Masthead} from '@/components/editorial/masthead';
 import {SiteFooter} from '@/components/editorial/site-footer';
+import {adminFetch, getAdminToken} from '@/lib/admin-fetch';
 import {DEFAULT_LOCALE, getLocaleFromRequest} from '@/lib/locale';
 import {SITE_URL, buildSocialMeta} from '@/lib/meta';
 import {FilmCard} from '@/components/editorial/film-card';
@@ -183,10 +184,10 @@ export default function Home({loaderData}: Route.ComponentProps) {
 
   useEffect(() => {
     if (globalThis.window !== undefined) {
-      setAdminToken(localStorage.getItem('adminToken') || undefined);
+      setAdminToken(getAdminToken());
 
       const handleAdminLogin = () => {
-        setAdminToken(localStorage.getItem('adminToken') || undefined);
+        setAdminToken(getAdminToken());
       };
 
       const handleAdminLogout = () => {
@@ -297,7 +298,6 @@ function ManualSelectionPanel({
   period,
   locale,
   apiUrl,
-  adminToken,
   onClose,
   onOverrideSuccess,
   onOverrideLoadingChange,
@@ -306,7 +306,6 @@ function ManualSelectionPanel({
   period: PeriodType;
   locale: string;
   apiUrl: string;
-  adminToken: string;
   onClose: () => void;
   onOverrideSuccess: () => Promise<void> | void;
   onOverrideLoadingChange: (value: boolean) => void;
@@ -332,9 +331,8 @@ function ManualSelectionPanel({
 
     const timeoutId = setTimeout(async () => {
       try {
-        const response = await fetch(
+        const response = await adminFetch(
           `${apiUrl}/admin/movies?search=${encodeURIComponent(query)}&limit=20`,
-          {headers: {Authorization: `Bearer ${adminToken}`}},
         );
 
         if (!response.ok) {
@@ -365,7 +363,7 @@ function ManualSelectionPanel({
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [query, apiUrl, adminToken, locale]);
+  }, [query, apiUrl, locale]);
 
   const processingLabel = locale === 'ja' ? '処理中...' : 'Processing...';
   const searchPlaceholder =
@@ -394,11 +392,10 @@ function ManualSelectionPanel({
     setError(undefined);
 
     try {
-      const response = await fetch(`${apiUrl}/admin/override-selection`, {
+      const response = await adminFetch(`${apiUrl}/admin/override-selection`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${adminToken}`,
         },
         body: JSON.stringify({
           type: period,
@@ -574,11 +571,10 @@ function Movies({
       setActionLoading(previous => ({...previous, [type]: true}));
 
       try {
-        const response = await fetch(`${apiUrl}/reselect`, {
+        const response = await adminFetch(`${apiUrl}/reselect`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${adminToken}`,
           },
           body: JSON.stringify({
             type,
@@ -739,7 +735,6 @@ function Movies({
                     period={period}
                     locale={locale}
                     apiUrl={apiUrl}
-                    adminToken={adminToken}
                     onClose={() => {
                       setSearchOpen(previous => ({
                         ...previous,


### PR DESCRIPTION
apps/front のadmin系画面に約50箇所手書きされていた「localStorageからadminToken取得 → Authorizationヘッダ付与 → 401なら removeItem してログイン画面へ」の定型を、新設の `app/lib/admin-fetch.ts` に集約した。

- `getAdminToken` / `setAdminToken` / `clearAdminToken`: localStorage読み書きと `adminLogin` / `adminLogout` イベント発火を一元化
- `adminFetch`: Authorizationヘッダの自動付与と、401時のトークン削除 + `/admin/login` リダイレクトを共通処理化(TDD、テスト14件)
- movie-info-editor / nomination-manager / translation-manager / poster-manager / article-link-manager / admin.movies / admin.movies.$id / admin.ceremonies / admin.ceremonies.$uid / admin.movies.selections / home の計32箇所のfetchを置換
- ログイン2系統(molecules/admin-login.tsx と routes/admin.login.tsx)のトークン保存・イベント発火を setAdminToken に一本化。リダイレクト先やイベント名は現状維持

lint / typecheck / vitest(644件)すべて通過。

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x