### PR TITLE
refactor(scrapers): TMDb実装・環境変数ロード・CLI規約の共通化

### DIFF
--- a/apps/scrapers/src/__tests__/tmdb-save-utilities.test.ts
+++ b/apps/scrapers/src/__tests__/tmdb-save-utilities.test.ts
@@ -65,7 +65,10 @@ describe('tmdb-utilities save functions (libsql integration)', () => {
       await savePosterUrls('movie-1', posters, environment);
       const savedCount = await savePosterUrls(
         'movie-1',
-        [...posters, {file_path: '/c.jpg', width: 300, height: 450, iso_639_1: 'ja'}],
+        [
+          ...posters,
+          {file_path: '/c.jpg', width: 300, height: 450, iso_639_1: 'ja'},
+        ],
         environment,
       );
 

--- a/apps/scrapers/src/__tests__/tmdb-save-utilities.test.ts
+++ b/apps/scrapers/src/__tests__/tmdb-save-utilities.test.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {eq} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {
+  saveJapaneseTranslation,
+  savePosterUrls,
+  saveTMDBId,
+} from '../common/tmdb-utilities';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+describe('tmdb-utilities save functions (libsql integration)', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-test-'));
+    environment = {
+      TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+      TURSO_AUTH_TOKEN: '',
+    };
+    const database = getDatabase(environment);
+    await migrate(database, {migrationsFolder});
+
+    await database
+      .insert(movies)
+      .values({uid: 'movie-1', year: 2020, imdbId: 'tt0000001'});
+  });
+
+  describe('savePosterUrls', () => {
+    const posters = [
+      {file_path: '/a.jpg', width: 500, height: 750, iso_639_1: 'en'},
+      {file_path: '/b.jpg', width: 500, height: 750, iso_639_1: undefined},
+    ];
+
+    it('saves posters with the first one marked primary', async () => {
+      const savedCount = await savePosterUrls('movie-1', posters, environment);
+
+      expect(savedCount).toBe(2);
+
+      const database = getDatabase(environment);
+      const rows = await database
+        .select()
+        .from(posterUrls)
+        .where(eq(posterUrls.movieUid, 'movie-1'));
+
+      expect(rows).toHaveLength(2);
+      const primary = rows.find(row => row.isPrimary === 1);
+      expect(primary?.url).toBe('https://image.tmdb.org/t/p/original/a.jpg');
+      expect(primary?.languageCode).toBe('en');
+    });
+
+    it('skips posters whose URL already exists', async () => {
+      await savePosterUrls('movie-1', posters, environment);
+      const savedCount = await savePosterUrls(
+        'movie-1',
+        [...posters, {file_path: '/c.jpg', width: 300, height: 450, iso_639_1: 'ja'}],
+        environment,
+      );
+
+      expect(savedCount).toBe(1);
+
+      const database = getDatabase(environment);
+      const rows = await database
+        .select()
+        .from(posterUrls)
+        .where(eq(posterUrls.movieUid, 'movie-1'));
+      expect(rows).toHaveLength(3);
+    });
+
+    it('returns 0 for an empty poster list', async () => {
+      const savedCount = await savePosterUrls('movie-1', [], environment);
+      expect(savedCount).toBe(0);
+    });
+  });
+
+  describe('saveJapaneseTranslation', () => {
+    it('inserts a default Japanese title translation', async () => {
+      await saveJapaneseTranslation('movie-1', 'テスト映画', environment);
+
+      const database = getDatabase(environment);
+      const rows = await database
+        .select()
+        .from(translations)
+        .where(eq(translations.resourceUid, 'movie-1'));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].resourceType).toBe('movie_title');
+      expect(rows[0].languageCode).toBe('ja');
+      expect(rows[0].content).toBe('テスト映画');
+      expect(rows[0].isDefault).toBe(1);
+    });
+
+    it('updates the content when a Japanese title already exists', async () => {
+      await saveJapaneseTranslation('movie-1', '旧タイトル', environment);
+      await saveJapaneseTranslation('movie-1', '新タイトル', environment);
+
+      const database = getDatabase(environment);
+      const rows = await database
+        .select()
+        .from(translations)
+        .where(eq(translations.resourceUid, 'movie-1'));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].content).toBe('新タイトル');
+    });
+  });
+
+  describe('saveTMDBId', () => {
+    it('saves the TMDb ID for a movie looked up by IMDb ID', async () => {
+      await saveTMDBId('tt0000001', 12_345, environment);
+
+      const database = getDatabase(environment);
+      const [movie] = await database
+        .select()
+        .from(movies)
+        .where(eq(movies.uid, 'movie-1'));
+
+      expect(movie.tmdbId).toBe(12_345);
+    });
+
+    it('does not overwrite an existing TMDb ID', async () => {
+      await saveTMDBId('tt0000001', 12_345, environment);
+      await saveTMDBId('tt0000001', 99_999, environment);
+
+      const database = getDatabase(environment);
+      const [movie] = await database
+        .select()
+        .from(movies)
+        .where(eq(movies.uid, 'movie-1'));
+
+      expect(movie.tmdbId).toBe(12_345);
+    });
+
+    it('skips saving when another movie already uses the TMDb ID', async () => {
+      const database = getDatabase(environment);
+      await database
+        .insert(movies)
+        .values({uid: 'movie-2', year: 2021, imdbId: 'tt0000002', tmdbId: 777});
+
+      await saveTMDBId('tt0000001', 777, environment);
+
+      const [movie] = await database
+        .select()
+        .from(movies)
+        .where(eq(movies.uid, 'movie-1'));
+      expect(movie.tmdbId).toBeNull();
+    });
+  });
+});

--- a/apps/scrapers/src/availability-check-cli.ts
+++ b/apps/scrapers/src/availability-check-cli.ts
@@ -21,6 +21,76 @@ const arguments_ = new Set(process.argv.slice(2));
 const isDryRun = arguments_.has('--dry-run');
 const shouldHelp = arguments_.has('--help') || arguments_.has('-h');
 
+async function main(): Promise<void> {
+  const environment = buildEnvironment(process.env);
+
+  const apiUrl =
+    process.env.SHINE_API_URL || 'https://shine-api.yuta25.workers.dev';
+  const adminPassword = environment.ADMIN_PASSWORD || '';
+  const discordWebhookUrl = process.env.DISCORD_WEBHOOK_URL || '';
+
+  if (!environment.TURSO_DATABASE_URL || !environment.TURSO_AUTH_TOKEN) {
+    console.error('TURSO_DATABASE_URL / TURSO_AUTH_TOKEN が設定されていません');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!adminPassword) {
+    console.error('ADMIN_PASSWORD が設定されていません');
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    const summaries = await runAvailabilityCheck({
+      environment,
+      apiUrl,
+      adminPassword,
+      maxAttempts: isDryRun ? 1 : 10,
+    });
+
+    const date = new Date().toISOString().slice(0, 10);
+    const message = buildDiscordMessage(summaries, date);
+
+    console.log(message.content);
+    for (const embed of message.embeds) {
+      console.log(`\n## ${embed.title}\n${embed.description}`);
+    }
+
+    if (isDryRun) {
+      console.log('\n(dry-run: 再抽選・Discord通知はスキップ)');
+    } else if (discordWebhookUrl) {
+      await sendDiscordNotification(discordWebhookUrl, message);
+    } else {
+      console.warn('DISCORD_WEBHOOK_URL 未設定のため通知をスキップ');
+    }
+
+    const exhausted = summaries.filter(summary => summary.exhausted);
+    if (exhausted.length > 0 && !isDryRun) {
+      console.error(
+        `視聴可能な映画が見つからなかったセレクション: ${exhausted
+          .map(summary => summary.type)
+          .join(', ')}`,
+      );
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error('可用性チェックが失敗しました:', error);
+    if (discordWebhookUrl && !isDryRun) {
+      try {
+        await sendDiscordNotification(discordWebhookUrl, {
+          content: `🚨 セレクション可用性チェックがエラーで停止: ${error instanceof Error ? error.message : String(error)}`,
+          embeds: [],
+        });
+      } catch {
+        // 通知自体の失敗はexit codeで拾う
+      }
+    }
+
+    process.exitCode = 1;
+  }
+}
+
 if (shouldHelp) {
   console.log(`
 Usage: availability-check-cli [options]
@@ -37,71 +107,6 @@ Environment variables:
   SHINE_API_URL          APIのURL (default: https://shine-api.yuta25.workers.dev)
   DISCORD_WEBHOOK_URL    Discord webhook URL (通知先)
 `);
-  process.exit(0);
-}
-
-const environment = buildEnvironment(process.env);
-
-const apiUrl =
-  process.env.SHINE_API_URL || 'https://shine-api.yuta25.workers.dev';
-const adminPassword = environment.ADMIN_PASSWORD || '';
-const discordWebhookUrl = process.env.DISCORD_WEBHOOK_URL || '';
-
-if (!environment.TURSO_DATABASE_URL || !environment.TURSO_AUTH_TOKEN) {
-  console.error('TURSO_DATABASE_URL / TURSO_AUTH_TOKEN が設定されていません');
-  process.exit(1);
-}
-
-if (!adminPassword) {
-  console.error('ADMIN_PASSWORD が設定されていません');
-  process.exit(1);
-}
-
-try {
-  const summaries = await runAvailabilityCheck({
-    environment,
-    apiUrl,
-    adminPassword,
-    maxAttempts: isDryRun ? 1 : 10,
-  });
-
-  const date = new Date().toISOString().slice(0, 10);
-  const message = buildDiscordMessage(summaries, date);
-
-  console.log(message.content);
-  for (const embed of message.embeds) {
-    console.log(`\n## ${embed.title}\n${embed.description}`);
-  }
-
-  if (isDryRun) {
-    console.log('\n(dry-run: 再抽選・Discord通知はスキップ)');
-  } else if (discordWebhookUrl) {
-    await sendDiscordNotification(discordWebhookUrl, message);
-  } else {
-    console.warn('DISCORD_WEBHOOK_URL 未設定のため通知をスキップ');
-  }
-
-  const exhausted = summaries.filter(summary => summary.exhausted);
-  if (exhausted.length > 0 && !isDryRun) {
-    console.error(
-      `視聴可能な映画が見つからなかったセレクション: ${exhausted
-        .map(summary => summary.type)
-        .join(', ')}`,
-    );
-    process.exit(1);
-  }
-} catch (error) {
-  console.error('可用性チェックが失敗しました:', error);
-  if (discordWebhookUrl && !isDryRun) {
-    try {
-      await sendDiscordNotification(discordWebhookUrl, {
-        content: `🚨 セレクション可用性チェックがエラーで停止: ${error instanceof Error ? error.message : String(error)}`,
-        embeds: [],
-      });
-    } catch {
-      // 通知自体の失敗はexit codeで拾う
-    }
-  }
-
-  process.exit(1);
+} else {
+  await main();
 }

--- a/apps/scrapers/src/availability-check-cli.ts
+++ b/apps/scrapers/src/availability-check-cli.ts
@@ -7,19 +7,15 @@
  * TMDb / U-NEXT / TSUTAYA DISCAS / GEO で確認し、観られなければ
  * APIの /reselect で再抽選する(上限10回)。結果はDiscordに通知する。
  */
-import path from 'node:path';
 import process from 'node:process';
-import {config} from 'dotenv';
-import {type Environment} from '@shine/database';
 import {
   buildDiscordMessage,
   sendDiscordNotification,
 } from './availability/discord';
 import {runAvailabilityCheck} from './availability/run';
+import {buildEnvironment, loadEnvironmentFiles} from './common/environment';
 
-config();
-config({path: path.resolve(process.cwd(), '.dev.vars')});
-config({path: path.resolve(process.cwd(), '../../.dev.vars')});
+loadEnvironmentFiles();
 
 const arguments_ = new Set(process.argv.slice(2));
 const isDryRun = arguments_.has('--dry-run');
@@ -44,15 +40,11 @@ Environment variables:
   process.exit(0);
 }
 
-const environment: Environment = {
-  TURSO_DATABASE_URL: process.env.TURSO_DATABASE_URL || '',
-  TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN || '',
-  TMDB_API_KEY: process.env.TMDB_API_KEY || '',
-};
+const environment = buildEnvironment(process.env);
 
 const apiUrl =
   process.env.SHINE_API_URL || 'https://shine-api.yuta25.workers.dev';
-const adminPassword = process.env.ADMIN_PASSWORD || '';
+const adminPassword = environment.ADMIN_PASSWORD || '';
 const discordWebhookUrl = process.env.DISCORD_WEBHOOK_URL || '';
 
 if (!environment.TURSO_DATABASE_URL || !environment.TURSO_AUTH_TOKEN) {

--- a/apps/scrapers/src/cannes-film-festival-cli.ts
+++ b/apps/scrapers/src/cannes-film-festival-cli.ts
@@ -1,6 +1,7 @@
 /**
  * カンヌ映画祭スクレイピングのCLIエントリーポイント
  */
+import {Command, InvalidArgumentError} from 'commander';
 import cannesFilmFestival from './cannes-film-festival';
 import {
   assertDatabaseEnvironment,
@@ -11,132 +12,115 @@ import {
 loadEnvironmentFiles();
 const environment = buildEnvironment(process.env);
 
-/**
- * カンヌ映画祭スクレイピングのメイン処理
- */
-async function main() {
-  try {
-    // コマンドライン引数を解析
-    const arguments_ = process.argv.slice(2);
-    const yearIndex = arguments_.indexOf('--year');
-    const winnersOnlyFlag = arguments_.includes('--winners-only');
-    const dryRunFlag = arguments_.includes('--dry-run');
-    let targetYear: number | undefined;
+function parseYear(value: string): number {
+  const year = Number.parseInt(value, 10);
 
-    if (yearIndex !== -1 && arguments_[yearIndex + 1]) {
-      targetYear = Number.parseInt(arguments_[yearIndex + 1], 10);
+  if (Number.isNaN(year) || year < 1946 || year > new Date().getFullYear()) {
+    throw new InvalidArgumentError(
+      '無効な年です。1946年以降の年を指定してください。',
+    );
+  }
 
-      if (
-        Number.isNaN(targetYear) ||
-        targetYear < 1946 ||
-        targetYear > new Date().getFullYear()
-      ) {
-        console.error('無効な年です。1946年以降の年を指定してください。');
-        throw new Error('Invalid year');
-      }
+  return year;
+}
 
-      if (winnersOnlyFlag) {
+const program = new Command();
+
+program
+  .name('cannes-film-festival-cli')
+  .description(
+    [
+      'Wikipediaからカンヌ国際映画祭のコンペティション参加映画情報を',
+      'スクレイピングし、データベースに保存します。',
+      "Palme d'Or（パルム・ドール）受賞作品も含まれます。",
+      '',
+      '--winners-only オプションを使用すると、既存のノミネーションの',
+      'isWinnerフラグのみを更新し、新規映画の取得やポスターの',
+      'ダウンロードはスキップされます。',
+    ].join('\n'),
+  )
+  .option('--year <year>', '特定の年のみ処理 (例: --year 2024)', parseYear)
+  .option('--winners-only', '受賞作品のisWinnerのみを更新（軽量モード）', false)
+  .option('--dry-run', '実際の書き込みは行わず、処理内容のみ表示', false)
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrapers:cannes-film-festival
+  pnpm run scrapers:cannes-film-festival --year 2024
+  pnpm run scrapers:cannes-film-festival --winners-only
+  pnpm run scrapers:cannes-film-festival --year 2024 --winners-only
+  pnpm run scrapers:cannes-film-festival --dry-run
+`,
+  )
+  .action(
+    async (options: {year?: number; winnersOnly: boolean; dryRun: boolean}) => {
+      const targetYear = options.year;
+      const winnersOnlyFlag = options.winnersOnly;
+
+      if (targetYear && winnersOnlyFlag) {
         console.log(
           `カンヌ映画祭受賞作品の更新を開始します (対象年: ${targetYear})`,
         );
-      } else {
+      } else if (targetYear) {
         console.log(
           `カンヌ映画祭スクレイピングを開始します (対象年: ${targetYear})`,
         );
-      }
-    } else if (winnersOnlyFlag) {
-      console.log('カンヌ映画祭受賞作品の更新を開始します');
-    } else {
-      console.log('カンヌ映画祭スクレイピングを開始します');
-    }
-
-    // 環境変数の確認
-    assertDatabaseEnvironment(environment);
-
-    if (!environment.TMDB_API_KEY) {
-      console.warn(
-        '警告: TMDB_API_KEY が設定されていません。IMDb ID の取得がスキップされます。',
-      );
-    }
-
-    // スクレイピング処理を実行
-    let url = 'http://localhost/';
-    const searchParameters = new URLSearchParams();
-
-    if (targetYear) {
-      searchParameters.append('year', targetYear.toString());
-    }
-
-    if (winnersOnlyFlag) {
-      searchParameters.append('winners-only', 'true');
-    }
-
-    if (dryRunFlag) {
-      searchParameters.append('dry-run', 'true');
-    }
-
-    if (searchParameters.toString()) {
-      url += `?${searchParameters.toString()}`;
-    }
-
-    const request = new Request(url);
-    const response = await cannesFilmFestival.fetch(request, environment);
-
-    if (response.status === 200) {
-      if (winnersOnlyFlag) {
-        console.log('カンヌ映画祭受賞作品の更新が正常に完了しました');
+      } else if (winnersOnlyFlag) {
+        console.log('カンヌ映画祭受賞作品の更新を開始します');
       } else {
-        console.log('カンヌ映画祭スクレイピングが正常に完了しました');
+        console.log('カンヌ映画祭スクレイピングを開始します');
       }
-    } else {
-      const errorText = await response.text();
-      console.error('スクレイピング中にエラーが発生しました:', errorText);
-      throw new Error(errorText);
-    }
-  } catch (error) {
-    console.error('スクレイピング処理中にエラーが発生しました:', error);
-    throw error;
-  }
-}
 
-// 使用方法の表示
-function showUsage() {
-  console.log('使用方法:');
-  console.log('  pnpm run scrapers:cannes-film-festival [オプション]');
-  console.log('');
-  console.log('オプション:');
-  console.log('  --year <年>      特定の年のみ処理 (例: --year 2024)');
-  console.log('  --winners-only   受賞作品のisWinnerのみを更新（軽量モード）');
-  console.log('  --dry-run        実際の書き込みは行わず、処理内容のみ表示');
-  console.log('  --help, -h       このヘルプを表示');
-  console.log('');
-  console.log('説明:');
-  console.log(
-    '  Wikipediaからカンヌ国際映画祭のコンペティション参加映画情報を',
-  );
-  console.log('  スクレイピングし、データベースに保存します。');
-  console.log("  Palme d'Or（パルム・ドール）受賞作品も含まれます。");
-  console.log('');
-  console.log(
-    '  --winners-only オプションを使用すると、既存のノミネーションの',
-  );
-  console.log('  isWinnerフラグのみを更新し、新規映画の取得やポスターの');
-  console.log('  ダウンロードはスキップされます。');
-  console.log('');
-  console.log('例:');
-  console.log('  pnpm run scrapers:cannes-film-festival');
-  console.log('  pnpm run scrapers:cannes-film-festival --year 2024');
-  console.log('  pnpm run scrapers:cannes-film-festival --winners-only');
-  console.log(
-    '  pnpm run scrapers:cannes-film-festival --year 2024 --winners-only',
-  );
-  console.log('  pnpm run scrapers:cannes-film-festival --dry-run');
-}
+      // 環境変数の確認
+      assertDatabaseEnvironment(environment);
 
-// ヘルプオプションの処理
-if (process.argv.includes('--help') || process.argv.includes('-h')) {
-  showUsage();
-} else {
-  // メイン処理を実行
-  await main();
+      if (!environment.TMDB_API_KEY) {
+        console.warn(
+          '警告: TMDB_API_KEY が設定されていません。IMDb ID の取得がスキップされます。',
+        );
+      }
+
+      // スクレイピング処理を実行
+      let url = 'http://localhost/';
+      const searchParameters = new URLSearchParams();
+
+      if (targetYear) {
+        searchParameters.append('year', targetYear.toString());
+      }
+
+      if (winnersOnlyFlag) {
+        searchParameters.append('winners-only', 'true');
+      }
+
+      if (options.dryRun) {
+        searchParameters.append('dry-run', 'true');
+      }
+
+      if (searchParameters.toString()) {
+        url += `?${searchParameters.toString()}`;
+      }
+
+      const request = new Request(url);
+      const response = await cannesFilmFestival.fetch(request, environment);
+
+      if (response.status === 200) {
+        if (winnersOnlyFlag) {
+          console.log('カンヌ映画祭受賞作品の更新が正常に完了しました');
+        } else {
+          console.log('カンヌ映画祭スクレイピングが正常に完了しました');
+        }
+      } else {
+        const errorText = await response.text();
+        console.error('スクレイピング中にエラーが発生しました:', errorText);
+        throw new Error(errorText);
+      }
+    },
+  );
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  console.error('スクレイピング処理中にエラーが発生しました:', error);
+  process.exitCode = 1;
 }

--- a/apps/scrapers/src/cannes-film-festival.ts
+++ b/apps/scrapers/src/cannes-film-festival.ts
@@ -10,10 +10,15 @@ import {nominations} from '@shine/database/schema/nominations';
 import {posterUrls} from '@shine/database/schema/poster-urls';
 import {referenceUrls} from '@shine/database/schema/reference-urls';
 import {translations} from '@shine/database/schema/translations';
-import {saveJapaneseTranslation} from './common/tmdb-utilities';
+import {
+  fetchTMDBConfiguration,
+  fetchTMDBMovieDetails,
+  saveJapaneseTranslation,
+  searchTMDBMovie,
+  type TMDBConfiguration,
+} from './common/tmdb-utilities';
 
 const WIKIPEDIA_BASE_URL = 'https://en.wikipedia.org';
-const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
 
 type MovieInfo = {
   title: string;
@@ -34,7 +39,6 @@ type MainData = {
 let mainData: MainData | undefined;
 let environment_: Environment;
 let TMDB_API_KEY: string | undefined;
-let tmdbConfiguration: TMDatabaseConfiguration | undefined;
 let isDryRun = false;
 
 export default {
@@ -1088,114 +1092,15 @@ function cleanupTitle(title: string): string {
     .trim();
 }
 
-// TMDb APIのレスポンス型
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type TMDatabaseSearchResponse = {
-  results: Array<{
-    id: number;
-    title: string;
-    original_title: string;
-    release_date: string;
-  }>;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type TMDatabaseMovieDetails = {
-  imdb_id: string;
-  title: string;
-  original_title: string;
-  release_date: string;
-  poster_path?: string;
-};
-
-type TMDatabaseConfiguration = {
-  images: {
-    base_url: string;
-    secure_base_url: string;
-    poster_sizes: string[];
-  };
-};
-
-async function fetchTMDatabaseConfiguration(): Promise<
-  TMDatabaseConfiguration | undefined
-> {
-  if (!TMDB_API_KEY) {
-    console.error('TMDb API key is not set');
-    return undefined;
-  }
-
-  if (tmdbConfiguration) {
-    return tmdbConfiguration;
-  }
-
-  try {
-    const configUrl = new URL(`${TMDB_API_BASE_URL}/configuration`);
-    configUrl.searchParams.append('api_key', TMDB_API_KEY);
-
-    const response = await fetch(configUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDb API error: ${response.statusText}`);
-    }
-
-    tmdbConfiguration = await response.json();
-    return tmdbConfiguration;
-  } catch (error) {
-    console.error('Error fetching TMDb configuration:', error);
-    return undefined;
-  }
-}
-
-async function searchTMDatabaseMovie(
-  title: string,
-  year: number,
-): Promise<number | undefined> {
-  if (!TMDB_API_KEY) {
-    console.error('TMDb API key is not set');
-    return undefined;
-  }
-
-  try {
-    const searchUrl = new URL(`${TMDB_API_BASE_URL}/search/movie`);
-    searchUrl.searchParams.append('api_key', TMDB_API_KEY);
-    searchUrl.searchParams.append('query', title);
-    searchUrl.searchParams.append('year', year.toString());
-    searchUrl.searchParams.append('language', 'en-US');
-
-    const response = await fetch(searchUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDb API error: ${response.statusText}`);
-    }
-
-    const data: {
-      results: Array<{
-        id: number;
-        title: string;
-        release_date: string;
-      }>;
-    } = await response.json();
-
-    // 結果をフィルタリング
-    const matches = data.results.filter(movie => {
-      const movieYear = new Date(movie.release_date).getFullYear();
-      return Math.abs(movieYear - year) <= 1; // 1年の誤差を許容
-    });
-
-    // 最も関連性の高い結果を返す
-    return matches.length > 0 ? matches[0].id : undefined;
-  } catch (error) {
-    console.error(`Error searching TMDb for ${title} (${year}):`, error);
-    return undefined;
-  }
-}
-
 type MovieDetailsResult = {
   imdbId?: string;
   posterPath?: string;
   japaneseTitle?: string;
 };
 
-async function fetchTMDatabaseMovieDetails(
-  movieId: number,
+async function fetchMovieDetails(
+  title: string,
+  year: number,
 ): Promise<MovieDetailsResult> {
   if (!TMDB_API_KEY) {
     console.error('TMDb API key is not set');
@@ -1203,70 +1108,29 @@ async function fetchTMDatabaseMovieDetails(
   }
 
   try {
-    // 英語版の詳細情報を取得
-    const detailsUrlEn = new URL(`${TMDB_API_BASE_URL}/movie/${movieId}`);
-    detailsUrlEn.searchParams.append('api_key', TMDB_API_KEY);
-    detailsUrlEn.searchParams.append('language', 'en-US');
-
-    const responseEn = await fetch(detailsUrlEn.toString());
-    if (!responseEn.ok) {
-      throw new Error(`TMDb API error: ${responseEn.statusText}`);
-    }
-
-    const dataEn: {
-      imdb_id?: string;
-      poster_path?: string;
-    } = await responseEn.json();
-
-    // 日本語版の詳細情報を取得
-    const detailsUrlJa = new URL(`${TMDB_API_BASE_URL}/movie/${movieId}`);
-    detailsUrlJa.searchParams.append('api_key', TMDB_API_KEY);
-    detailsUrlJa.searchParams.append('language', 'ja');
-
-    const responseJa = await fetch(detailsUrlJa.toString());
-    if (!responseJa.ok) {
-      throw new Error(`TMDb API error: ${responseJa.statusText}`);
-    }
-
-    const dataJa: {
-      title?: string;
-      original_title?: string;
-    } = await responseJa.json();
-
-    // 日本語タイトルが英語タイトルと異なる場合のみ保存
-    const japaneseTitle =
-      dataJa.title && dataJa.title !== dataJa.original_title
-        ? dataJa.title
-        : undefined;
-
-    return {
-      imdbId: dataEn.imdb_id || undefined,
-      posterPath: dataEn.poster_path || undefined,
-      japaneseTitle,
-    };
-  } catch (error) {
-    console.error(
-      `Error fetching TMDb movie details for ID ${movieId}:`,
-      error,
-    );
-    return {};
-  }
-}
-
-async function fetchMovieDetails(
-  title: string,
-  year: number,
-): Promise<MovieDetailsResult> {
-  try {
     // TMDbで映画を検索
-    const movieId = await searchTMDatabaseMovie(title, year);
+    const movieId = await searchTMDBMovie(title, year, TMDB_API_KEY);
     if (!movieId) {
       console.log(`No TMDb match found for ${title} (${year})`);
       return {};
     }
 
-    // 映画の詳細情報を取得
-    const details = await fetchTMDatabaseMovieDetails(movieId);
+    // 英語版・日本語版の詳細情報を取得
+    const dataEn = await fetchTMDBMovieDetails(movieId, TMDB_API_KEY, 'en-US');
+    const dataJa = await fetchTMDBMovieDetails(movieId, TMDB_API_KEY, 'ja');
+
+    // 日本語タイトルが英語タイトルと異なる場合のみ保存
+    const japaneseTitle =
+      dataJa?.title && dataJa.title !== dataJa.original_title
+        ? dataJa.title
+        : undefined;
+
+    const details: MovieDetailsResult = {
+      imdbId: dataEn?.imdb_id || undefined,
+      posterPath: dataEn?.poster_path || undefined,
+      japaneseTitle,
+    };
+
     if (details.imdbId) {
       console.log(`Found IMDb ID for ${title} (${year}): ${details.imdbId}`);
     }
@@ -1396,12 +1260,15 @@ async function collectPosterUrls(
   movieUid: string,
   sizes: string[] = ['w342'],
 ): Promise<Array<typeof posterUrls.$inferInsert>> {
-  if (!movieDetails.posterPath) {
+  if (!movieDetails.posterPath || !TMDB_API_KEY) {
     return [];
   }
 
-  const config = await fetchTMDatabaseConfiguration();
-  if (!config) {
+  let config: TMDBConfiguration;
+  try {
+    config = await fetchTMDBConfiguration(TMDB_API_KEY);
+  } catch (error) {
+    console.error('Error fetching TMDb configuration:', error);
     return [];
   }
 

--- a/apps/scrapers/src/common/tmdb-utilities.ts
+++ b/apps/scrapers/src/common/tmdb-utilities.ts
@@ -72,6 +72,13 @@ export type TMDBSearchResponse = {
   }>;
 };
 
+export type TMDBConfiguration = {
+  images: {
+    secure_base_url: string;
+    poster_sizes: string[];
+  };
+};
+
 export type TMDBTranslationsResponse = {
   id: number;
   translations: Array<{
@@ -89,6 +96,27 @@ export type TMDBTranslationsResponse = {
     };
   }>;
 };
+
+let cachedConfiguration: TMDBConfiguration | undefined;
+
+/**
+ * TMDb APIの画像設定を取得(プロセス内でキャッシュ)
+ */
+export async function fetchTMDBConfiguration(
+  tmdbApiKey: string,
+): Promise<TMDBConfiguration> {
+  if (cachedConfiguration) {
+    return cachedConfiguration;
+  }
+
+  const configUrl = new URL(`${TMDB_API_BASE_URL}/configuration`);
+  configUrl.searchParams.append('api_key', tmdbApiKey);
+
+  cachedConfiguration = await fetchJsonWithRetry<TMDBConfiguration>(
+    configUrl.toString(),
+  );
+  return cachedConfiguration;
+}
 
 /**
  * TMDb APIから映画の翻訳情報を取得
@@ -355,6 +383,27 @@ export async function fetchJapaneseTitleFromTMDB(
 }
 
 /**
+ * TMDb IDから画像情報を取得
+ */
+export async function fetchTMDBImages(
+  tmdbId: number,
+  mediaType: 'movie' | 'tv',
+  tmdbApiKey: string,
+): Promise<TMDBMovieImages | undefined> {
+  try {
+    const imagesUrl = new URL(
+      `${TMDB_API_BASE_URL}/${mediaType}/${tmdbId}/images`,
+    );
+    imagesUrl.searchParams.append('api_key', tmdbApiKey);
+
+    return await fetchJsonWithRetry<TMDBMovieImages>(imagesUrl.toString());
+  } catch (error) {
+    console.error(`Error fetching TMDb images for TMDb ID ${tmdbId}:`, error);
+    return undefined;
+  }
+}
+
+/**
  * TMDb APIから映画のポスター情報を取得
  */
 export async function fetchTMDBMovieImages(
@@ -364,27 +413,18 @@ export async function fetchTMDBMovieImages(
   | {images: TMDBMovieImages; tmdbId: number; mediaType: 'movie' | 'tv'}
   | undefined
 > {
-  try {
-    const findResult = await findTMDBByImdbId(imdbId, tmdbApiKey);
-    if (!findResult) {
-      return undefined;
-    }
-
-    const {tmdbId, mediaType} = findResult;
-    const endpoint = mediaType;
-    const imagesUrl = new URL(
-      `${TMDB_API_BASE_URL}/${endpoint}/${tmdbId}/images`,
-    );
-    imagesUrl.searchParams.append('api_key', tmdbApiKey);
-
-    const images = await fetchJsonWithRetry<TMDBMovieImages>(
-      imagesUrl.toString(),
-    );
-    return {images, tmdbId, mediaType};
-  } catch (error) {
-    console.error(`Error fetching TMDb images for IMDb ID ${imdbId}:`, error);
+  const findResult = await findTMDBByImdbId(imdbId, tmdbApiKey);
+  if (!findResult) {
     return undefined;
   }
+
+  const {tmdbId, mediaType} = findResult;
+  const images = await fetchTMDBImages(tmdbId, mediaType, tmdbApiKey);
+  if (!images) {
+    return undefined;
+  }
+
+  return {images, tmdbId, mediaType};
 }
 
 /**

--- a/apps/scrapers/src/common/tmdb-utilities.ts
+++ b/apps/scrapers/src/common/tmdb-utilities.ts
@@ -224,9 +224,7 @@ export async function fetchTMDBMovieDetails(
     detailsUrl.searchParams.append('api_key', tmdbApiKey);
     detailsUrl.searchParams.append('language', language);
 
-    const data = await fetchJsonWithRetry<TMDBMovieData>(
-      detailsUrl.toString(),
-    );
+    const data = await fetchJsonWithRetry<TMDBMovieData>(detailsUrl.toString());
     return data;
   } catch (error) {
     console.error(
@@ -296,9 +294,7 @@ export async function findTMDBByImdbId(
     findUrl.searchParams.append('api_key', tmdbApiKey);
     findUrl.searchParams.append('external_source', 'imdb_id');
 
-    const data = await fetchJsonWithRetry<TMDBFindResponse>(
-      findUrl.toString(),
-    );
+    const data = await fetchJsonWithRetry<TMDBFindResponse>(findUrl.toString());
 
     if (data.movie_results && data.movie_results.length > 0) {
       return {tmdbId: data.movie_results[0].id, mediaType: 'movie'};

--- a/apps/scrapers/src/import-imdb-list-cli.ts
+++ b/apps/scrapers/src/import-imdb-list-cli.ts
@@ -1,21 +1,8 @@
-import {existsSync} from 'node:fs';
-import path from 'node:path';
-import {config as loadEnvironment} from 'dotenv';
 import {Command} from 'commander';
 import {importMoviesFromCsv} from './import-imdb-list';
+import {buildEnvironment, loadEnvironmentFiles} from './common/environment';
 
-const environmentCandidates = [
-  '.env',
-  '.dev.vars',
-  '../.dev.vars',
-  '../../.dev.vars',
-];
-for (const candidate of environmentCandidates) {
-  const resolvedPath = path.resolve(process.cwd(), candidate);
-  if (existsSync(resolvedPath)) {
-    loadEnvironment({path: resolvedPath, override: false});
-  }
-}
+loadEnvironmentFiles();
 
 function finiteNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value)
@@ -76,13 +63,7 @@ program
     try {
       await importMoviesFromCsv({
         filePath: csvFile,
-        environment: {
-          TURSO_DATABASE_URL: process.env.TURSO_DATABASE_URL!,
-          TURSO_AUTH_TOKEN: process.env.TURSO_AUTH_TOKEN!,
-          TMDB_API_KEY: process.env.TMDB_API_KEY,
-          TMDB_LEAD_ACCESS_TOKEN: process.env.TMDB_LEAD_ACCESS_TOKEN,
-          OMDB_API_KEY: process.env.OMDB_API_KEY,
-        },
+        environment: buildEnvironment(process.env),
         dryRun,
         limit,
         throttleMs: throttle,

--- a/apps/scrapers/src/import-imdb-list.ts
+++ b/apps/scrapers/src/import-imdb-list.ts
@@ -12,6 +12,11 @@ import {posterUrls} from '@shine/database/schema/poster-urls';
 import {referenceUrls} from '@shine/database/schema/reference-urls';
 import {translations} from '@shine/database/schema/translations';
 import {generateUUID} from '@shine/utils';
+import {
+  fetchTMDBConfiguration,
+  findTMDBByImdbId,
+  type TMDBConfiguration,
+} from './common/tmdb-utilities';
 
 const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
 
@@ -22,13 +27,6 @@ type CsvMovieRow = {
   Year?: string;
   'Release Date'?: string;
   Description?: string;
-};
-
-type TmdbConfiguration = {
-  images: {
-    secure_base_url: string;
-    poster_sizes: string[];
-  };
 };
 
 type TmdbMovieDetails = {
@@ -83,7 +81,7 @@ type ImportOptions = {
 };
 
 let tmdbApiKey: string;
-let tmdbConfiguration: TmdbConfiguration | undefined;
+let tmdbConfiguration: TMDBConfiguration | undefined;
 let releaseDateColumnAvailable: boolean | undefined;
 type AwardContext = {
   organizationUid: string;
@@ -414,21 +412,7 @@ export async function importMoviesFromCsv({
 }
 
 async function ensureTmdbConfiguration(): Promise<void> {
-  if (tmdbConfiguration) {
-    return;
-  }
-
-  const url = new URL(`${TMDB_API_BASE_URL}/configuration`);
-  url.searchParams.set('api_key', tmdbApiKey);
-
-  const response = await fetch(url.toString());
-  if (!response.ok) {
-    throw new Error(
-      `Failed to load TMDb configuration: ${response.statusText}`,
-    );
-  }
-
-  tmdbConfiguration = (await response.json()) as TmdbConfiguration;
+  tmdbConfiguration ??= await fetchTMDBConfiguration(tmdbApiKey);
 }
 
 async function findOrCreateOrganization(
@@ -556,36 +540,21 @@ async function getAwardContext(
 async function fetchMovieByImdbId(
   imdbId: string,
 ): Promise<TmdbMovieDetails | undefined> {
-  const findUrl = new URL(`${TMDB_API_BASE_URL}/find/${imdbId}`);
-  findUrl.searchParams.set('api_key', tmdbApiKey);
-  findUrl.searchParams.set('external_source', 'imdb_id');
-  findUrl.searchParams.set('language', 'en-US');
-
-  const response = await fetch(findUrl.toString());
-  if (!response.ok) {
-    throw new Error(`TMDb find endpoint error: ${response.statusText}`);
+  const findResult = await findTMDBByImdbId(imdbId, tmdbApiKey);
+  if (!findResult) {
+    return undefined;
   }
 
-  const data = (await response.json()) as {
-    movie_results?: TmdbMovieSearchResult[];
-    tv_results?: TmdbMultiSearchResult[];
-  };
-
-  for (const baseMovie of data.movie_results ?? []) {
-    const details = await fetchMovieDetails(baseMovie.id);
-    if (details) {
-      return details;
-    }
+  if (findResult.mediaType === 'movie') {
+    return fetchMovieDetails(findResult.tmdbId);
   }
 
-  for (const baseTv of data.tv_results ?? []) {
-    const tvDetails = await fetchTvDetails(baseTv.id);
-    if (tvDetails) {
-      return {
-        ...tvDetails,
-        imdb_id: imdbId,
-      };
-    }
+  const tvDetails = await fetchTvDetails(findResult.tmdbId);
+  if (tvDetails) {
+    return {
+      ...tvDetails,
+      imdb_id: imdbId,
+    };
   }
 
   return undefined;

--- a/apps/scrapers/src/import-imdb-list.ts
+++ b/apps/scrapers/src/import-imdb-list.ts
@@ -82,7 +82,6 @@ type ImportOptions = {
 
 let tmdbApiKey: string;
 let tmdbConfiguration: TMDBConfiguration | undefined;
-let releaseDateColumnAvailable: boolean | undefined;
 type AwardContext = {
   organizationUid: string;
   ceremonyUid: string;
@@ -742,18 +741,6 @@ type ExistingMovieRecord = {
   tmdbId?: number;
 };
 
-function toSqlArguments(
-  values: Array<string | number | null | undefined>,
-): Array<string | number | null> {
-  return values.map(value => {
-    if (value === undefined) {
-      // eslint-disable-next-line unicorn/no-null
-      return null;
-    }
-    return value;
-  });
-}
-
 async function insertMovieWithTranslations({
   database,
   imdbId,
@@ -782,66 +769,17 @@ async function insertMovieWithTranslations({
 
   const mediaType = tmdbMovie.media_type === 'tv' ? 'tv' : 'movie';
 
-  const movieBaseValues: typeof movies.$inferInsert = {
+  const movieValues: typeof movies.$inferInsert = {
     uid: movieUid,
     imdbId,
     originalLanguage: tmdbMovie.original_language ?? 'en',
     year: normalizedYear,
     mediaType,
     ...(tmdbId === undefined ? {} : {tmdbId}),
+    ...(releaseDate === undefined ? {} : {releaseDate}),
   };
 
-  const baseArguments = toSqlArguments([
-    movieBaseValues.uid,
-    movieBaseValues.originalLanguage,
-    movieBaseValues.year,
-    imdbId,
-    tmdbId,
-    mediaType,
-  ]);
-
-  const isReleaseDateColumnAvailable = releaseDateColumnAvailable ?? true;
-  const shouldIncludeReleaseDate =
-    Boolean(releaseDate) && isReleaseDateColumnAvailable;
-
-  if (shouldIncludeReleaseDate) {
-    try {
-      await database.$client.execute({
-        sql: `
-          INSERT INTO movies (
-            uid, original_language, year, imdb_id, tmdb_id, media_type, release_date
-          )
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `,
-        args: [...baseArguments, releaseDate!],
-      });
-      releaseDateColumnAvailable = true;
-    } catch (error) {
-      if (isMissingReleaseDateColumnError(error)) {
-        releaseDateColumnAvailable = false;
-        console.warn(
-          "  WARN: 'release_date' column not found in movies table. Re-trying without release date.",
-        );
-        await database.$client.execute({
-          sql: `
-            INSERT INTO movies (uid, original_language, year, imdb_id, tmdb_id, media_type)
-            VALUES (?, ?, ?, ?, ?, ?)
-          `,
-          args: baseArguments,
-        });
-      } else {
-        throw error;
-      }
-    }
-  } else {
-    await database.$client.execute({
-      sql: `
-        INSERT INTO movies (uid, original_language, year, imdb_id, tmdb_id, media_type)
-        VALUES (?, ?, ?, ?, ?, ?)
-      `,
-      args: baseArguments,
-    });
-  }
+  await database.insert(movies).values(movieValues);
 
   await insertTranslations({
     database,
@@ -1087,14 +1025,4 @@ async function ensureNomination({
     console.log('  Created nomination.');
   }
   return true;
-}
-
-function isMissingReleaseDateColumnError(error: unknown): boolean {
-  const message =
-    error instanceof Error
-      ? `${error.message}\n${String((error as {cause?: unknown}).cause ?? '')}`
-      : String(error);
-  return /(no such column|has no column named)\s*:?\s*release_date/i.test(
-    message,
-  );
 }

--- a/apps/scrapers/src/japan-academy-awards-cli.ts
+++ b/apps/scrapers/src/japan-academy-awards-cli.ts
@@ -20,7 +20,10 @@ program
     'Seed the database with Japan Academy Awards organization and categories',
     false,
   )
-  .option('--year <year>', 'Scrape data for a specific year (e.g., --year 2023)')
+  .option(
+    '--year <year>',
+    'Scrape data for a specific year (e.g., --year 2023)',
+  )
   .option(
     '--dry-run',
     'Show what would be scraped without making database changes',

--- a/apps/scrapers/src/japan-academy-awards-cli.ts
+++ b/apps/scrapers/src/japan-academy-awards-cli.ts
@@ -3,32 +3,32 @@
 /**
  * 日本アカデミー賞スクレイピングのCLIエントリーポイント
  */
+import {Command} from 'commander';
 import japanAcademyAwards from './japan-academy-awards';
 import {buildEnvironment, loadEnvironmentFiles} from './common/environment';
 
 loadEnvironmentFiles();
 const environment = buildEnvironment(process.env);
 
-const arguments_ = process.argv.slice(2);
-const shouldSeed = arguments_.includes('--seed');
-const shouldHelp = arguments_.includes('--help') || arguments_.includes('-h');
-const isDryRun = arguments_.includes('--dry-run');
-const yearIndex = arguments_.indexOf('--year');
-const year =
-  yearIndex !== -1 && yearIndex + 1 < arguments_.length
-    ? arguments_[yearIndex + 1]
-    : undefined;
+const program = new Command();
 
-if (shouldHelp) {
-  console.log(`
-Usage: japan-academy-awards-cli [options]
-
-Options:
-  --seed         Seed the database with Japan Academy Awards organization and categories
-  --year YEAR    Scrape data for a specific year (e.g., --year 2023)
-  --dry-run      Show what would be scraped without making database changes
-  --help         Show this help message
-
+program
+  .name('japan-academy-awards-cli')
+  .description('Scrape Japan Academy Awards data from Wikipedia')
+  .option(
+    '--seed',
+    'Seed the database with Japan Academy Awards organization and categories',
+    false,
+  )
+  .option('--year <year>', 'Scrape data for a specific year (e.g., --year 2023)')
+  .option(
+    '--dry-run',
+    'Show what would be scraped without making database changes',
+    false,
+  )
+  .addHelpText(
+    'after',
+    `
 Examples:
   # Scrape Japan Academy Awards data for all years
   japan-academy-awards-cli
@@ -41,41 +41,43 @@ Examples:
 
   # Seed database first, then scrape specific year
   japan-academy-awards-cli --seed --year 2023
-`);
-  process.exit(0);
-}
+`,
+  )
+  .action(async (options: {seed: boolean; year?: string; dryRun: boolean}) => {
+    if (options.dryRun) {
+      console.log('🔍 DRY RUN MODE - No database changes will be made');
+    }
+
+    if (options.seed) {
+      console.log('Seeding Japan Academy Awards...');
+      const seedUrl = options.dryRun
+        ? 'http://localhost/seed?dry-run=true'
+        : 'http://localhost/seed';
+      const seedRequest = new Request(seedUrl);
+      await japanAcademyAwards.fetch(seedRequest, environment);
+      console.log('Seeding completed successfully');
+    }
+
+    console.log('Starting Japan Academy Awards scraping...');
+    const baseUrl = 'http://localhost/';
+    const searchParameters = new URLSearchParams();
+    if (options.year) {
+      searchParameters.append('year', options.year);
+    }
+
+    if (options.dryRun) {
+      searchParameters.append('dry-run', 'true');
+    }
+
+    const url = `${baseUrl}?${searchParameters.toString()}`;
+    const request = new Request(url);
+    await japanAcademyAwards.fetch(request, environment);
+    console.log('Scraping completed successfully');
+  });
 
 try {
-  if (isDryRun) {
-    console.log('🔍 DRY RUN MODE - No database changes will be made');
-  }
-
-  if (shouldSeed) {
-    console.log('Seeding Japan Academy Awards...');
-    const seedUrl = isDryRun
-      ? 'http://localhost/seed?dry-run=true'
-      : 'http://localhost/seed';
-    const seedRequest = new Request(seedUrl);
-    await japanAcademyAwards.fetch(seedRequest, environment);
-    console.log('Seeding completed successfully');
-  }
-
-  console.log('Starting Japan Academy Awards scraping...');
-  const baseUrl = 'http://localhost/';
-  const searchParameters = new URLSearchParams();
-  if (year) {
-    searchParameters.append('year', year);
-  }
-
-  if (isDryRun) {
-    searchParameters.append('dry-run', 'true');
-  }
-
-  const url = `${baseUrl}?${searchParameters.toString()}`;
-  const request = new Request(url);
-  await japanAcademyAwards.fetch(request, environment);
-  console.log('Scraping completed successfully');
+  await program.parseAsync(process.argv);
 } catch (error) {
   console.error('Error:', error);
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/apps/scrapers/src/japanese-translations-cli.ts
+++ b/apps/scrapers/src/japanese-translations-cli.ts
@@ -1,6 +1,7 @@
 /**
  * 日本語翻訳スクレイピングのCLIエントリーポイント
  */
+import {Command, InvalidArgumentError} from 'commander';
 import {getDatabase} from '@shine/database';
 import {
   getMoviesWithoutJapaneseTranslation,
@@ -20,174 +21,177 @@ const environment = buildEnvironment(process.env);
 // 処理するバッチサイズ（デフォルト）
 const DEFAULT_BATCH_SIZE = 20;
 
+function parseLimit(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError(
+      '無効なバッチサイズです。正の整数を指定してください。',
+    );
+  }
+
+  return parsed;
+}
+
 /**
  * 日本語翻訳スクレイピングのメイン処理
  */
-async function main() {
-  try {
-    // コマンドライン引数を解析
-    const arguments_ = process.argv.slice(2);
-    const limitIndex = arguments_.indexOf('--limit');
-    const isAllMode = arguments_.includes('--all');
-    const includeNonJapanese = arguments_.includes('--include-non-japanese');
+async function main(options: {
+  limit?: number;
+  all: boolean;
+  includeNonJapanese: boolean;
+}): Promise<void> {
+  const {all: isAllMode, includeNonJapanese} = options;
 
-    let batchSize = DEFAULT_BATCH_SIZE;
+  let batchSize = options.limit ?? DEFAULT_BATCH_SIZE;
 
-    if (isAllMode) {
-      batchSize = 0; // 全件処理
-      console.log('日本語翻訳スクレイピングを開始します (全件処理モード)');
-    } else if (limitIndex !== -1 && arguments_[limitIndex + 1]) {
-      batchSize = Number.parseInt(arguments_[limitIndex + 1], 10);
+  if (isAllMode) {
+    batchSize = 0; // 全件処理
+    console.log('日本語翻訳スクレイピングを開始します (全件処理モード)');
+  } else {
+    console.log(
+      `日本語翻訳スクレイピングを開始します (バッチサイズ: ${batchSize})`,
+    );
+  }
 
-      if (Number.isNaN(batchSize) || batchSize <= 0) {
-        console.error('無効なバッチサイズです。正の整数を指定してください。');
-        throw new Error('Invalid batch size');
+  // 環境変数の確認
+  assertDatabaseEnvironment(environment);
+
+  // データベース接続
+  const database = getDatabase(environment);
+
+  // 日本語翻訳が未登録の映画データを取得
+  console.log(
+    includeNonJapanese
+      ? '日本語翻訳が未登録、または原題のまま保存されている映画を検索中...'
+      : '日本語翻訳が未登録の映画を検索中...',
+  );
+  const movies = await getMoviesWithoutJapaneseTranslation(
+    database,
+    batchSize,
+    includeNonJapanese,
+  );
+
+  if (movies.length === 0) {
+    console.log('日本語翻訳が必要な映画が見つかりませんでした。');
+    return;
+  }
+
+  console.log(
+    `${movies.length}件の映画が見つかりました。スクレイピングを開始します。`,
+  );
+  console.log('─'.repeat(80));
+
+  let successCount = 0;
+  let notFoundCount = 0;
+  let errorCount = 0;
+
+  // 各映画に対して処理を実行
+  for (let index = 0; index < movies.length; index++) {
+    const movie = movies[index];
+    const progress = `[${index + 1}/${movies.length}]`;
+
+    try {
+      console.log(
+        `${progress} 処理中: ${movie.englishTitle} (${
+          movie.year || '年不明'
+        }) - IMDb: ${movie.imdbId}`,
+      );
+
+      // TMDBから日本語タイトルを取得
+      let japaneseTitle = await fetchJapaneseTitleFromTMDB(
+        movie.imdbId,
+        movie.tmdbId,
+        environment,
+      );
+
+      // TMDBで見つからなかった場合はWikipediaで検索（フォールバック）
+      if (!japaneseTitle) {
+        console.log('  TMDBで見つからなかったため、Wikipediaで検索中...');
+        japaneseTitle = await scrapeJapaneseTitleFromWikipedia(movie.imdbId);
       }
 
-      console.log(
-        `日本語翻訳スクレイピングを開始します (バッチサイズ: ${batchSize})`,
-      );
-    } else {
-      console.log(
-        `日本語翻訳スクレイピングを開始します (バッチサイズ: ${batchSize})`,
-      );
-    }
-
-    // 環境変数の確認
-    assertDatabaseEnvironment(environment);
-
-    // データベース接続
-    const database = getDatabase(environment);
-
-    // 日本語翻訳が未登録の映画データを取得
-    console.log(
-      includeNonJapanese
-        ? '日本語翻訳が未登録、または原題のまま保存されている映画を検索中...'
-        : '日本語翻訳が未登録の映画を検索中...',
-    );
-    const movies = await getMoviesWithoutJapaneseTranslation(
-      database,
-      batchSize,
-      includeNonJapanese,
-    );
-
-    if (movies.length === 0) {
-      console.log('日本語翻訳が必要な映画が見つかりませんでした。');
-      return;
-    }
-
-    console.log(
-      `${movies.length}件の映画が見つかりました。スクレイピングを開始します。`,
-    );
-    console.log('─'.repeat(80));
-
-    let successCount = 0;
-    let notFoundCount = 0;
-    let errorCount = 0;
-
-    // 各映画に対して処理を実行
-    for (let index = 0; index < movies.length; index++) {
-      const movie = movies[index];
-      const progress = `[${index + 1}/${movies.length}]`;
-
-      try {
-        console.log(
-          `${progress} 処理中: ${movie.englishTitle} (${
-            movie.year || '年不明'
-          }) - IMDb: ${movie.imdbId}`,
-        );
-
-        // TMDBから日本語タイトルを取得
-        let japaneseTitle = await fetchJapaneseTitleFromTMDB(
-          movie.imdbId,
-          movie.tmdbId,
-          environment,
-        );
-
-        // TMDBで見つからなかった場合はWikipediaで検索（フォールバック）
-        if (!japaneseTitle) {
-          console.log('  TMDBで見つからなかったため、Wikipediaで検索中...');
-          japaneseTitle = await scrapeJapaneseTitleFromWikipedia(movie.imdbId);
-        }
-
-        if (japaneseTitle) {
-          // 日本語翻訳をデータベースに保存
-          await saveJapaneseTranslation(database, {
-            resourceType: 'movie_title',
-            resourceUid: movie.uid,
-            languageCode: 'ja',
-            content: japaneseTitle,
-          });
-
-          console.log(
-            `✅ ${progress} 成功: ${movie.englishTitle} → ${japaneseTitle}`,
-          );
-          successCount++;
-        } else {
-          console.log(`❌ ${progress} 見つからず: ${movie.englishTitle}`);
-          notFoundCount++;
-        }
-      } catch (error) {
-        console.error(
-          `💥 ${progress} エラー: ${movie.englishTitle} - ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-        errorCount++;
-      }
-
-      // 連続リクエストを避けるための待機（最後の処理以外）
-      if (index < movies.length - 1) {
-        await new Promise(resolve => {
-          setTimeout(resolve, 1000);
+      if (japaneseTitle) {
+        // 日本語翻訳をデータベースに保存
+        await saveJapaneseTranslation(database, {
+          resourceType: 'movie_title',
+          resourceUid: movie.uid,
+          languageCode: 'ja',
+          content: japaneseTitle,
         });
+
+        console.log(
+          `✅ ${progress} 成功: ${movie.englishTitle} → ${japaneseTitle}`,
+        );
+        successCount++;
+      } else {
+        console.log(`❌ ${progress} 見つからず: ${movie.englishTitle}`);
+        notFoundCount++;
       }
-    }
-
-    // 結果の表示
-    console.log('─'.repeat(80));
-    console.log('スクレイピング完了');
-    console.log(`✅ 成功: ${successCount}件`);
-    console.log(`❌ 見つからず: ${notFoundCount}件`);
-    console.log(`💥 エラー: ${errorCount}件`);
-    console.log(`📊 合計: ${movies.length}件`);
-
-    if (successCount > 0) {
-      console.log(
-        `\n${successCount}件の日本語翻訳をデータベースに保存しました。`,
+    } catch (error) {
+      console.error(
+        `💥 ${progress} エラー: ${movie.englishTitle} - ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
+      errorCount++;
     }
-  } catch (error) {
-    console.error('スクレイピング処理中にエラーが発生しました:', error);
-    throw error;
+
+    // 連続リクエストを避けるための待機（最後の処理以外）
+    if (index < movies.length - 1) {
+      await new Promise(resolve => {
+        setTimeout(resolve, 1000);
+      });
+    }
+  }
+
+  // 結果の表示
+  console.log('─'.repeat(80));
+  console.log('スクレイピング完了');
+  console.log(`✅ 成功: ${successCount}件`);
+  console.log(`❌ 見つからず: ${notFoundCount}件`);
+  console.log(`💥 エラー: ${errorCount}件`);
+  console.log(`📊 合計: ${movies.length}件`);
+
+  if (successCount > 0) {
+    console.log(`\n${successCount}件の日本語翻訳をデータベースに保存しました。`);
   }
 }
 
-// 使用方法の表示
-function showUsage() {
-  console.log('使用方法:');
-  console.log('  pnpm run scrape:japanese-translations [オプション]');
-  console.log('');
-  console.log('オプション:');
-  console.log('  --limit <数値>  処理する映画の件数を指定 (デフォルト: 20)');
-  console.log(
-    '  --all           全件処理モード（日本語翻訳がないすべての映画を処理）',
-  );
-  console.log(
-    '  --include-non-japanese  原題がそのまま ja として保存されている映画も取得し直す',
-  );
-  console.log('  --help, -h      このヘルプを表示');
-  console.log('');
-  console.log('例:');
-  console.log('  pnpm run scrape:japanese-translations');
-  console.log('  pnpm run scrape:japanese-translations --limit 50');
-  console.log('  pnpm run scrape:japanese-translations --all');
-}
+const program = new Command();
 
-// ヘルプオプションの処理
-if (process.argv.includes('--help') || process.argv.includes('-h')) {
-  showUsage();
-} else {
-  // メイン処理を実行
-  await main();
+program
+  .name('japanese-translations-cli')
+  .description('日本語翻訳が未登録の映画にTMDB/Wikipediaから日本語タイトルを取得して保存します')
+  .option(
+    '--limit <number>',
+    '処理する映画の件数を指定 (デフォルト: 20)',
+    parseLimit,
+  )
+  .option(
+    '--all',
+    '全件処理モード（日本語翻訳がないすべての映画を処理）',
+    false,
+  )
+  .option(
+    '--include-non-japanese',
+    '原題がそのまま ja として保存されている映画も取得し直す',
+    false,
+  )
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrape:japanese-translations
+  pnpm run scrape:japanese-translations --limit 50
+  pnpm run scrape:japanese-translations --all
+`,
+  )
+  .action(main);
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  console.error('スクレイピング処理中にエラーが発生しました:', error);
+  process.exitCode = 1;
 }

--- a/apps/scrapers/src/japanese-translations-cli.ts
+++ b/apps/scrapers/src/japanese-translations-cli.ts
@@ -154,7 +154,9 @@ async function main(options: {
   console.log(`📊 合計: ${movies.length}件`);
 
   if (successCount > 0) {
-    console.log(`\n${successCount}件の日本語翻訳をデータベースに保存しました。`);
+    console.log(
+      `\n${successCount}件の日本語翻訳をデータベースに保存しました。`,
+    );
   }
 }
 
@@ -162,7 +164,9 @@ const program = new Command();
 
 program
   .name('japanese-translations-cli')
-  .description('日本語翻訳が未登録の映画にTMDB/Wikipediaから日本語タイトルを取得して保存します')
+  .description(
+    '日本語翻訳が未登録の映画にTMDB/Wikipediaから日本語タイトルを取得して保存します',
+  )
   .option(
     '--limit <number>',
     '処理する映画の件数を指定 (デフォルト: 20)',

--- a/apps/scrapers/src/movie-import-from-list-cli.ts
+++ b/apps/scrapers/src/movie-import-from-list-cli.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-import {config} from 'dotenv';
 import {importMoviesFromList} from './movie-import-from-list';
+import {buildEnvironment, loadEnvironmentFiles} from './common/environment';
 
-// .envファイルを読み込み
-config({path: '../.dev.vars'});
+loadEnvironmentFiles();
 
 async function main(): Promise<void> {
   const arguments_ = process.argv.slice(2);
@@ -57,13 +56,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const environment = {
-    TURSO_DATABASE_URL: tursoUrl,
-    TURSO_AUTH_TOKEN: tursoToken,
-    TMDB_API_KEY: tmdbKey,
-    TMDB_LEAD_ACCESS_TOKEN: process.env.TMDB_LEAD_ACCESS_TOKEN || '',
-    OMDB_API_KEY: process.env.OMDB_API_KEY || '',
-  };
+  const environment = buildEnvironment(process.env);
 
   try {
     console.log(`Starting import from: ${filePath}`);

--- a/apps/scrapers/src/movie-import-from-list-cli.ts
+++ b/apps/scrapers/src/movie-import-from-list-cli.ts
@@ -28,7 +28,8 @@ async function main(): Promise<void> {
     console.log(
       'Example: movie-import-from-list-cli ./tmp/1000_movies.json "Best 1000 Movies" --dry-run',
     );
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const filePath = arguments_[0];
@@ -43,17 +44,20 @@ async function main(): Promise<void> {
   // 必要な環境変数をチェック
   if (!tursoUrl) {
     console.error('Error: TURSO_DATABASE_URL environment variable is required');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (!tursoToken) {
     console.error('Error: TURSO_AUTH_TOKEN environment variable is required');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (!tmdbKey) {
     console.error('Error: TMDB_API_KEY environment variable is required');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const environment = buildEnvironment(process.env);
@@ -80,7 +84,8 @@ async function main(): Promise<void> {
     console.log('Import completed successfully!');
   } catch (error) {
     console.error('Import failed:', error);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 }
 

--- a/apps/scrapers/src/movie-import-from-list.ts
+++ b/apps/scrapers/src/movie-import-from-list.ts
@@ -9,6 +9,11 @@ import {nominations} from '@shine/database/schema/nominations';
 import {posterUrls} from '@shine/database/schema/poster-urls';
 import {translations} from '@shine/database/schema/translations';
 import {generateUUID} from '@shine/utils';
+import {fetchJsonWithRetry} from './common/fetch-utilities';
+import {
+  fetchTMDBConfiguration,
+  type TMDBConfiguration,
+} from './common/tmdb-utilities';
 
 const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
 
@@ -37,13 +42,6 @@ type TMDBSearchResponse = {
   total_results: number;
 };
 
-type TMDBConfiguration = {
-  images: {
-    secure_base_url: string;
-    poster_sizes: string[];
-  };
-};
-
 let environment_: Environment;
 let TMDB_API_KEY: string;
 let tmdbConfiguration: TMDBConfiguration | undefined;
@@ -69,7 +67,8 @@ export async function importMoviesFromList(
   }
 
   // TMDB設定を取得
-  await fetchTMDBConfiguration();
+  tmdbConfiguration = await fetchTMDBConfiguration(TMDB_API_KEY);
+  console.log('TMDB configuration loaded');
 
   // JSONファイルを読み込み
   const fileContent = readFileSync(filePath, 'utf8');
@@ -387,12 +386,9 @@ async function searchMovieOnTMDB(
     searchUrl.searchParams.append('query', title);
     searchUrl.searchParams.append('language', 'ja');
 
-    const response = await fetch(searchUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDB API error: ${response.statusText}`);
-    }
-
-    const data: TMDBSearchResponse = await response.json();
+    const data = await fetchJsonWithRetry<TMDBSearchResponse>(
+      searchUrl.toString(),
+    );
 
     if (data.results.length === 0) {
       return undefined;
@@ -545,26 +541,5 @@ async function updateExistingMovie(
         sourceType: 'tmdb',
       });
     }
-  }
-}
-
-/**
- * TMDB設定を取得
- */
-async function fetchTMDBConfiguration(): Promise<void> {
-  try {
-    const configUrl = new URL(`${TMDB_API_BASE_URL}/configuration`);
-    configUrl.searchParams.append('api_key', TMDB_API_KEY);
-
-    const response = await fetch(configUrl.toString());
-    if (!response.ok) {
-      throw new Error(`TMDB configuration API error: ${response.statusText}`);
-    }
-
-    tmdbConfiguration = await response.json();
-    console.log('TMDB configuration loaded');
-  } catch (error) {
-    console.error('Error fetching TMDB configuration:', error);
-    throw error;
   }
 }

--- a/apps/scrapers/src/movie-posters.ts
+++ b/apps/scrapers/src/movie-posters.ts
@@ -2,18 +2,12 @@ import {eq, sql} from 'drizzle-orm';
 import {getDatabase, type Environment} from '@shine/database';
 import {movies} from '@shine/database/schema/movies';
 import {posterUrls} from '@shine/database/schema/poster-urls';
-
-const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
-
-type TMDBMovieImages = {
-  id: number;
-  posters: Array<{
-    file_path: string;
-    width: number;
-    height: number;
-    iso_639_1: string | undefined;
-  }>;
-};
+import {
+  fetchTMDBImages,
+  fetchTMDBMovieImages,
+  savePosterUrls,
+  saveTMDBId,
+} from './common/tmdb-utilities';
 
 type MovieWithImdbId = {
   uid: string;
@@ -127,146 +121,6 @@ async function getMoviesWithImdbId(limit = 10): Promise<MovieWithImdbId[]> {
   return filterMoviesWithImdbId(normalizeMovies(moviesWithImdbIdNoTmdb));
 }
 
-async function fetchMovieImages(
-  imdbId: string,
-): Promise<{images: TMDBMovieImages; tmdbId: number} | undefined> {
-  if (!TMDB_API_KEY) {
-    console.error('TMDb API key is not set');
-    return undefined;
-  }
-
-  try {
-    const findUrl = new URL(`${TMDB_API_BASE_URL}/find/${imdbId}`);
-    findUrl.searchParams.append('api_key', TMDB_API_KEY);
-    findUrl.searchParams.append('external_source', 'imdb_id');
-
-    const findResponse = await fetch(findUrl.toString());
-    if (!findResponse.ok) {
-      throw new Error(`TMDb API error: ${findResponse.statusText}`);
-    }
-
-    const findData: {
-      movie_results?: Array<{id: number}>;
-    } = await findResponse.json();
-    const movieResults = findData.movie_results;
-
-    if (!movieResults || movieResults.length === 0) {
-      console.log(`No TMDb match found for IMDb ID: ${imdbId}`);
-      return undefined;
-    }
-
-    const tmdbId = movieResults[0].id;
-
-    const imagesUrl = new URL(`${TMDB_API_BASE_URL}/movie/${tmdbId}/images`);
-    imagesUrl.searchParams.append('api_key', TMDB_API_KEY);
-
-    const imagesResponse = await fetch(imagesUrl.toString());
-    if (!imagesResponse.ok) {
-      throw new Error(`TMDb API error: ${imagesResponse.statusText}`);
-    }
-
-    const images: TMDBMovieImages = await imagesResponse.json();
-    return {images, tmdbId};
-  } catch (error) {
-    console.error(`Error fetching TMDb images for IMDb ID ${imdbId}:`, error);
-    return undefined;
-  }
-}
-
-async function saveTMDBId(movieUid: string, tmdbId: number): Promise<void> {
-  const database = getDatabase(environment_);
-
-  try {
-    // 既存のTMDB IDをチェック（この映画に対して）
-    const existingMovie = await database
-      .select({tmdbId: movies.tmdbId})
-      .from(movies)
-      .where(eq(movies.uid, movieUid))
-      .limit(1);
-
-    // 既にTMDB IDが設定されている場合は何もしない（差分チェック）
-    if (existingMovie.length > 0 && existingMovie[0].tmdbId === tmdbId) {
-      console.log(`  ! TMDB ID は既に存在します: ${existingMovie[0].tmdbId}`);
-      return;
-    }
-
-    // 他の映画で同じTMDB IDが使用されていないかチェック
-    const duplicateMovie = await database
-      .select({uid: movies.uid, tmdbId: movies.tmdbId})
-      .from(movies)
-      .where(eq(movies.tmdbId, tmdbId))
-      .limit(1);
-
-    if (duplicateMovie.length > 0) {
-      console.log(
-        `  ! TMDB ID ${tmdbId} は他の映画で既に使用されています (${duplicateMovie[0].uid})`,
-      );
-      return;
-    }
-
-    // TMDB IDを更新（実際に更新が必要な場合のみ）
-    await database.update(movies).set({tmdbId}).where(eq(movies.uid, movieUid));
-
-    console.log(`  ✓ TMDB ID を保存しました: ${tmdbId}`);
-  } catch (error) {
-    console.error(`Error saving TMDB ID for movie ${movieUid}:`, error);
-  }
-}
-
-async function savePosterUrls(
-  movieUid: string,
-  posters: TMDBMovieImages['posters'],
-): Promise<number> {
-  if (!posters || posters.length === 0) {
-    return 0;
-  }
-
-  const database = getDatabase(environment_);
-
-  try {
-    const existingPosters = await database
-      .select({url: posterUrls.url})
-      .from(posterUrls)
-      .where(eq(posterUrls.movieUid, movieUid));
-
-    const existingUrls = new Set(existingPosters.map(p => p.url));
-
-    // バッチ挿入用の配列
-    const posterUrlsBatch: Array<typeof posterUrls.$inferInsert> = [];
-    let savedCount = 0;
-
-    for (const poster of posters) {
-      const url = `https://image.tmdb.org/t/p/original${poster.file_path}`;
-
-      if (existingUrls.has(url)) {
-        continue;
-      }
-
-      posterUrlsBatch.push({
-        movieUid,
-        url,
-        width: poster.width,
-        height: poster.height,
-        languageCode: poster.iso_639_1 || undefined,
-        sourceType: 'tmdb',
-        isPrimary: savedCount === 0 ? 1 : 0,
-      });
-
-      savedCount++;
-    }
-
-    // バッチ挿入
-    if (posterUrlsBatch.length > 0) {
-      await database.insert(posterUrls).values(posterUrlsBatch);
-    }
-
-    return savedCount;
-  } catch (error) {
-    console.error(`Error saving poster URLs for movie ${movieUid}:`, error);
-    throw error;
-  }
-}
-
 async function fetchAndStorePosterUrls(limit = 10): Promise<{
   processed: number;
   success: number;
@@ -319,14 +173,17 @@ async function fetchAndStorePosterUrls(limit = 10): Promise<{
 
     try {
       // 既にTMDB IDがある映画の場合、ポスター取得のみ行う
-      if (movie.tmdbId === null) {
+      if (movie.tmdbId === undefined) {
         // TMDB IDがない場合は、IMDb IDから検索
         console.log('  TMDb API からポスター情報を取得中...');
-        const movieData = await fetchMovieImages(movie.imdbId);
+        const movieData = await fetchTMDBMovieImages(
+          movie.imdbId,
+          TMDB_API_KEY!,
+        );
 
         if (movieData) {
           // TMDB ID を保存
-          await saveTMDBId(movie.uid, movieData.tmdbId);
+          await saveTMDBId(movie.imdbId, movieData.tmdbId, environment_);
 
           if (
             !movieData.images.posters ||
@@ -343,6 +200,7 @@ async function fetchAndStorePosterUrls(limit = 10): Promise<{
             const savedCount = await savePosterUrls(
               movie.uid,
               movieData.images.posters,
+              environment_,
             );
             result.postersAdded = savedCount;
 
@@ -364,17 +222,17 @@ async function fetchAndStorePosterUrls(limit = 10): Promise<{
         console.log(`  既存のTMDB ID を使用: ${movie.tmdbId}`);
 
         // TMDB IDから直接ポスター情報を取得
-        const imagesUrl = new URL(
-          `${TMDB_API_BASE_URL}/movie/${movie.tmdbId}/images`,
+        const images = await fetchTMDBImages(
+          movie.tmdbId,
+          'movie',
+          TMDB_API_KEY!,
         );
-        imagesUrl.searchParams.append('api_key', TMDB_API_KEY!);
 
-        const imagesResponse = await fetch(imagesUrl.toString());
-        if (!imagesResponse.ok) {
-          throw new Error(`TMDb API error: ${imagesResponse.statusText}`);
+        if (!images) {
+          throw new Error(
+            `Failed to fetch TMDb images for TMDb ID ${movie.tmdbId}`,
+          );
         }
-
-        const images: TMDBMovieImages = await imagesResponse.json();
 
         if (!images.posters || images.posters.length === 0) {
           result.error = 'No posters found';
@@ -385,7 +243,11 @@ async function fetchAndStorePosterUrls(limit = 10): Promise<{
             `  ポスター候補: ${images.posters.length}枚見つかりました`,
           );
           console.log('  データベースに保存中...');
-          const savedCount = await savePosterUrls(movie.uid, images.posters);
+          const savedCount = await savePosterUrls(
+            movie.uid,
+            images.posters,
+            environment_,
+          );
           result.postersAdded = savedCount;
 
           if (savedCount > 0) {


### PR DESCRIPTION
base は #225（スタックPR）。scrapers内の重複実装を common に寄せた。

- **TMDb共通化**: cannes-film-festival / movie-import-from-list / movie-posters / import-imdb-list が独自に持っていたTMDb configuration取得・検索・詳細取得・find・poster/tmdbId/翻訳保存を common/tmdb-utilities の既存関数に置換。common には `fetchTMDBConfiguration`（キャッシュ付き）と `fetchTMDBImages` を追加。import-imdb-list の localizedTitle 処理など完全一致しない部分は残した。movie-posters の tmdbId 未設定判定が `=== null`（normalize後はundefinedなので常にfalse）だった潜在バグも修正。
- **環境変数ロード統一**: availability-check-cli の手書きdotenv読み込み・手組みEnvironment、import-imdb-list-cli の existsSync ループ、movie-import-from-list-cli の `../.dev.vars` のみ読む config 呼び出しを `loadEnvironmentFiles()` / `buildEnvironment()` に置換。
- **CLI規約統一**: cannes-film-festival-cli / japan-academy-awards-cli / japanese-translations-cli の手書き `process.argv` パースを commander に置換（オプション体系は不変）。`process.exit(1)` を `process.exitCode = 1` に統一。
- **sniff削除**: import-imdb-list の release_date 列有無をランタイム判定する生SQLを削除し、drizzle insert に統一（列はマイグレーション0009/0011で存在）。
- **テスト**: savePosterUrls / saveJapaneseTranslation / saveTMDBId の libsql file DB + migrate() 統合テストを追加（8件）。

検証: `pnpm run test:scrapers`（212件）/ `pnpm lint` / `tsc --build --noEmit` すべてクリーン。

https://claude.ai/code/session_019c8odPKepqjUfxWaxEEB8x