### PR TITLE
Bluesky投稿に #青空映画部 タグを追加

### DIFF
--- a/apps/scrapers/src/sns/bluesky.test.ts
+++ b/apps/scrapers/src/sns/bluesky.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {buildPostRecord} from './bluesky';
+import {buildPostRecord, detectTagFacets} from './bluesky';
 
 const base = {
   text: '今日の1本 —『ハウスメイド』(2010)',
@@ -56,5 +56,49 @@ describe('buildPostRecord', () => {
     const record = buildPostRecord(base);
 
     expect('thumb' in record.embed.external).toBe(false);
+  });
+
+  it('本文にハッシュタグがあればfacetsを付ける', () => {
+    const record = buildPostRecord({...base, text: 'こんにちは #青空映画部'});
+
+    expect(record.facets).toEqual([
+      {
+        index: {byteStart: 16, byteEnd: 32},
+        features: [{$type: 'app.bsky.richtext.facet#tag', tag: '青空映画部'}],
+      },
+    ]);
+  });
+
+  it('ハッシュタグが無ければfacetsキー自体を含めない', () => {
+    const record = buildPostRecord(base);
+
+    expect('facets' in record).toBe(false);
+  });
+});
+
+describe('detectTagFacets', () => {
+  it('UTF-8バイトオフセットでタグ位置を返す', () => {
+    const facets = detectTagFacets('abc #tag def');
+
+    expect(facets).toEqual([
+      {
+        index: {byteStart: 4, byteEnd: 8},
+        features: [{$type: 'app.bsky.richtext.facet#tag', tag: 'tag'}],
+      },
+    ]);
+  });
+
+  it('複数のタグを検出する', () => {
+    const facets = detectTagFacets('#foo #bar');
+
+    expect(facets).toHaveLength(2);
+    expect(facets[1]).toEqual({
+      index: {byteStart: 5, byteEnd: 9},
+      features: [{$type: 'app.bsky.richtext.facet#tag', tag: 'bar'}],
+    });
+  });
+
+  it('タグが無ければ空配列を返す', () => {
+    expect(detectTagFacets('タグなし本文')).toEqual([]);
   });
 });

--- a/apps/scrapers/src/sns/bluesky.ts
+++ b/apps/scrapers/src/sns/bluesky.ts
@@ -24,16 +24,38 @@ type PostRecordInput = {
   thumb?: BlobReference;
 };
 
+export type TagFacet = {
+  index: {byteStart: number; byteEnd: number};
+  features: Array<{$type: 'app.bsky.richtext.facet#tag'; tag: string}>;
+};
+
 export type PostRecord = {
   $type: 'app.bsky.feed.post';
   text: string;
   createdAt: string;
   langs: string[];
+  facets?: TagFacet[];
   embed: {
     $type: 'app.bsky.embed.external';
     external: ExternalLink & {thumb?: BlobReference};
   };
 };
+
+export function detectTagFacets(text: string): TagFacet[] {
+  const encoder = new TextEncoder();
+  const facets: TagFacet[] = [];
+
+  for (const match of text.matchAll(/#([^\s#]+)/g)) {
+    const byteStart = encoder.encode(text.slice(0, match.index)).length;
+    const byteEnd = byteStart + encoder.encode(match[0]).length;
+    facets.push({
+      index: {byteStart, byteEnd},
+      features: [{$type: 'app.bsky.richtext.facet#tag', tag: match[1]}],
+    });
+  }
+
+  return facets;
+}
 
 export function buildPostRecord({
   text,
@@ -41,11 +63,13 @@ export function buildPostRecord({
   link,
   thumb,
 }: PostRecordInput): PostRecord {
+  const facets = detectTagFacets(text);
   return {
     $type: 'app.bsky.feed.post',
     text,
     createdAt,
     langs: ['ja'],
+    ...(facets.length > 0 ? {facets} : {}),
     embed: {
       $type: 'app.bsky.embed.external',
       external: {...link, ...(thumb ? {thumb} : {})},

--- a/apps/scrapers/src/sns/post-text.test.ts
+++ b/apps/scrapers/src/sns/post-text.test.ts
@@ -58,4 +58,18 @@ describe('buildDailyPostText', () => {
 
     expect([...text].length).toBeLessThanOrEqual(300);
   });
+
+  it('末尾に #青空映画部 タグを付ける', () => {
+    expect(buildDailyPostText(base)).toMatch(/#青空映画部$/);
+  });
+
+  it('切り詰めが起きてもタグは末尾に残る', () => {
+    const text = buildDailyPostText({
+      ...base,
+      title: 'あ'.repeat(400),
+    });
+
+    expect([...text].length).toBeLessThanOrEqual(300);
+    expect(text).toMatch(/#青空映画部$/);
+  });
 });

--- a/apps/scrapers/src/sns/post-text.ts
+++ b/apps/scrapers/src/sns/post-text.ts
@@ -1,5 +1,6 @@
 const MAX_ORGANIZATIONS = 2;
 const MAX_POST_LENGTH = 300;
+const HASHTAG = '#青空映画部';
 
 type DailyPostInput = {
   title: string;
@@ -25,8 +26,12 @@ export function buildDailyPostText({
     lines.push(`▶ ${availabilityLabels.join(' / ')}`);
   }
 
-  const text = lines.join('\n');
-  return [...text].length <= MAX_POST_LENGTH
-    ? text
-    : [...text].slice(0, MAX_POST_LENGTH - 1).join('') + '…';
+  const body = lines.join('\n');
+  const maxBodyLength = MAX_POST_LENGTH - [...`\n${HASHTAG}`].length;
+  const truncatedBody =
+    [...body].length <= maxBodyLength
+      ? body
+      : [...body].slice(0, maxBodyLength - 1).join('') + '…';
+
+  return `${truncatedBody}\n${HASHTAG}`;
 }


### PR DESCRIPTION
デイリー投稿の末尾に #青空映画部 を付け、richtext facet (app.bsky.richtext.facet#tag) でクリック・検索可能にした。300字上限の切り詰め時もタグは残す。