### PR TITLE
「今日の1本」のRSSフィードを追加

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -60,6 +60,60 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /selections/daily/history:
+    get:
+      summary: Get recent daily selections
+      description: Returns recent daily movie selections in reverse chronological order, e.g. for RSS feeds
+      operationId: getDailySelectionHistory
+      tags:
+        - Movies
+      security: []
+      parameters:
+        - name: locale
+          in: query
+          description: Language preference for movie titles
+          required: false
+          schema:
+            type: string
+            enum: [en, ja]
+            default: ja
+        - name: limit
+          in: query
+          description: Maximum number of items to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 30
+            default: 14
+      responses:
+        '200':
+          description: Successfully retrieved daily selection history
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      required: [uid, title, selectionDate]
+                      properties:
+                        uid:
+                          type: string
+                          format: uuid
+                        title:
+                          type: string
+                        year:
+                          type: integer
+                        selectionDate:
+                          type: string
+                          format: date
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /movies/search:
     get:
       summary: Search movies

--- a/apps/api/src/__tests__/selections-history.test.ts
+++ b/apps/api/src/__tests__/selections-history.test.ts
@@ -1,0 +1,192 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {eq, getDatabase, type Environment} from '@shine/database';
+import {movieSelections} from '@shine/database/schema/movie-selections';
+import {movies} from '@shine/database/schema/movies';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {selectionsRoutes} from '../routes/selections';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+type HistoryItem = {
+  uid: string;
+  title: string;
+  year: number | undefined;
+  selectionDate: string;
+};
+
+type HistoryResponse = {items: HistoryItem[]};
+
+function toDateString(daysAgo: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return `${date.getFullYear()}-${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+}
+
+async function createTestEnvironment(): Promise<Environment> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-test-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+
+  const movieRows = [
+    {uid: 'movie-1', year: 2001},
+    {uid: 'movie-2', year: 2002},
+    {uid: 'movie-3', year: 2003},
+  ];
+  await database.insert(movies).values(movieRows);
+
+  await database.insert(translations).values([
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-1',
+      languageCode: 'ja',
+      content: '映画その1',
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-1',
+      languageCode: 'en',
+      content: 'Movie One',
+      isDefault: 1,
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-2',
+      languageCode: 'en',
+      content: 'Movie Two',
+      isDefault: 1,
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-3',
+      languageCode: 'ja',
+      content: '映画その3',
+    },
+  ]);
+
+  await database.insert(movieSelections).values([
+    {
+      selectionType: 'daily',
+      selectionDate: toDateString(0),
+      movieId: 'movie-1',
+    },
+    {
+      selectionType: 'daily',
+      selectionDate: toDateString(1),
+      movieId: 'movie-2',
+    },
+    {
+      selectionType: 'daily',
+      selectionDate: toDateString(2),
+      movieId: 'movie-3',
+    },
+    {
+      selectionType: 'weekly',
+      selectionDate: toDateString(0),
+      movieId: 'movie-2',
+    },
+  ]);
+
+  return environment;
+}
+
+describe('GET /selections/daily/history', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  it('日次セレクションを日付の新しい順に返す', async () => {
+    const response = await selectionsRoutes.request(
+      '/selections/daily/history?locale=ja',
+      {},
+      environment,
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as HistoryResponse;
+    expect(body.items.map(item => item.selectionDate)).toEqual([
+      toDateString(0),
+      toDateString(1),
+      toDateString(2),
+    ]);
+  });
+
+  it('localeのタイトルを返し、無ければデフォルトにフォールバックする', async () => {
+    const response = await selectionsRoutes.request(
+      '/selections/daily/history?locale=ja',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as HistoryResponse;
+    const titles = Object.fromEntries(
+      body.items.map(item => [item.uid, item.title]),
+    );
+    expect(titles['movie-1']).toBe('映画その1');
+    expect(titles['movie-2']).toBe('Movie Two');
+  });
+
+  it('未来の日付のセレクションは含めない', async () => {
+    const database = getDatabase(environment);
+    await database.insert(movieSelections).values({
+      selectionType: 'daily',
+      selectionDate: toDateString(-1),
+      movieId: 'movie-2',
+    });
+
+    const response = await selectionsRoutes.request(
+      '/selections/daily/history',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as HistoryResponse;
+    expect(
+      body.items.every(item => item.selectionDate <= toDateString(0)),
+    ).toBe(true);
+  });
+
+  it('limitで件数を絞れる', async () => {
+    const response = await selectionsRoutes.request(
+      '/selections/daily/history?limit=2',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as HistoryResponse;
+    expect(body.items).toHaveLength(2);
+  });
+
+  it('削除済みの映画は含めない', async () => {
+    const database = getDatabase(environment);
+    await database
+      .update(movies)
+      .set({deletedAt: Math.floor(Date.now() / 1000)})
+      .where(eq(movies.uid, 'movie-2'));
+
+    const response = await selectionsRoutes.request(
+      '/selections/daily/history',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as HistoryResponse;
+    expect(body.items.map(item => item.uid)).toEqual(['movie-1', 'movie-3']);
+  });
+});

--- a/apps/api/src/routes/selections.ts
+++ b/apps/api/src/routes/selections.ts
@@ -227,6 +227,64 @@ selectionsRoutes.get('/', async c => {
   }
 });
 
+// Public: recent daily selections (for RSS feed etc.)
+selectionsRoutes.get('/selections/daily/history', async c => {
+  try {
+    const database = getDatabase(c.env);
+    const locale = c.req.query('locale') === 'en' ? 'en' : 'ja';
+    const limitParameter = Number(c.req.query('limit') ?? '14');
+    const limit =
+      Number.isInteger(limitParameter) && limitParameter > 0
+        ? Math.min(limitParameter, 30)
+        : 14;
+    const today = getSelectionDate(new Date(), 'daily');
+
+    const rows = await database
+      .select({
+        uid: movies.uid,
+        year: movies.year,
+        selectionDate: movieSelections.selectionDate,
+        localeTitle: sql<string | undefined>`(
+          SELECT content FROM translations
+          WHERE resource_type = 'movie_title'
+            AND resource_uid = ${movies.uid}
+            AND language_code = ${locale}
+          LIMIT 1
+        )`,
+        defaultTitle: sql<string | undefined>`(
+          SELECT content FROM translations
+          WHERE resource_type = 'movie_title'
+            AND resource_uid = ${movies.uid}
+            AND is_default = 1
+          LIMIT 1
+        )`,
+      })
+      .from(movieSelections)
+      .innerJoin(movies, eq(movieSelections.movieId, movies.uid))
+      .where(
+        and(
+          eq(movieSelections.selectionType, 'daily'),
+          sql`${movieSelections.selectionDate} <= ${today}`,
+          isNull(movies.deletedAt),
+        ),
+      )
+      .orderBy(sql`${movieSelections.selectionDate} DESC`)
+      .limit(limit);
+
+    const items = rows.map(row => ({
+      uid: row.uid,
+      title: row.localeTitle ?? row.defaultTitle ?? 'Unknown Title',
+      year: row.year ?? undefined,
+      selectionDate: row.selectionDate,
+    }));
+
+    return createCachedResponse({items}, getCacheTTL.selections.daily);
+  } catch (error) {
+    console.error('Error fetching daily selection history:', error);
+    return c.json({error: 'Internal server error'}, 500);
+  }
+});
+
 // Admin: Reselect movie for a specific period
 selectionsRoutes.post('/reselect', authMiddleware, async c => {
   try {

--- a/apps/front/app/lib/feed.test.ts
+++ b/apps/front/app/lib/feed.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from 'vitest';
+import {buildRssFeed} from './feed';
+
+const items = [
+  {
+    uid: 'movie-1',
+    title: 'ニーチェの馬',
+    year: 2011,
+    selectionDate: '2026-08-02',
+  },
+  {
+    uid: 'movie-2',
+    title: 'Tom & Jerry <Special>',
+    year: undefined,
+    selectionDate: '2026-08-01',
+  },
+];
+
+describe('buildRssFeed', () => {
+  it('RSS 2.0のフィードを生成する', () => {
+    const xml = buildRssFeed(items);
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<rss version="2.0">');
+    expect(xml).toContain('<title>SHINE — 今日の1本</title>');
+    expect(xml).toContain('<link>https://shine-film.com</link>');
+  });
+
+  it('itemに映画タイトルと年、詳細ページへのリンクを含む', () => {
+    const xml = buildRssFeed(items);
+
+    expect(xml).toContain('<title>『ニーチェの馬』(2011)</title>');
+    expect(xml).toContain('<link>https://shine-film.com/movies/movie-1</link>');
+  });
+
+  it('年が無ければ括弧を出さない', () => {
+    const xml = buildRssFeed(items);
+
+    expect(xml).toContain('『Tom &amp; Jerry &lt;Special&gt;』</title>');
+  });
+
+  it('guidは日付と映画uidの組で一意にする', () => {
+    const xml = buildRssFeed(items);
+
+    expect(xml).toContain(
+      '<guid isPermaLink="false">daily-2026-08-02-movie-1</guid>',
+    );
+  });
+
+  it('pubDateはJSTの0時をRFC1123形式で出す', () => {
+    const xml = buildRssFeed(items);
+
+    expect(xml).toContain('<pubDate>Sat, 01 Aug 2026 15:00:00 GMT</pubDate>');
+  });
+
+  it('XMLの特殊文字をエスケープする', () => {
+    const xml = buildRssFeed(items);
+
+    expect(xml).not.toContain('Tom & Jerry <Special>');
+  });
+});

--- a/apps/front/app/lib/feed.ts
+++ b/apps/front/app/lib/feed.ts
@@ -1,0 +1,54 @@
+import {SITE_URL} from './meta';
+
+export type FeedItem = {
+  uid: string;
+  title: string;
+  year?: number;
+  selectionDate: string;
+};
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function toPubDate(selectionDate: string): string {
+  return new Date(`${selectionDate}T00:00:00+09:00`).toUTCString();
+}
+
+export function buildRssFeed(items: FeedItem[]): string {
+  const itemElements = items
+    .map(item => {
+      const yearPart = item.year ? `(${item.year})` : '';
+      return [
+        '    <item>',
+        `      <title>${escapeXml(`『${item.title}』${yearPart}`)}</title>`,
+        `      <link>${SITE_URL}/movies/${item.uid}</link>`,
+        `      <guid isPermaLink="false">daily-${item.selectionDate}-${item.uid}</guid>`,
+        `      <pubDate>${toPubDate(item.selectionDate)}</pubDate>`,
+        `      <description>${escapeXml(
+          `『${item.title}』${yearPart}。いま配信・レンタルで観られるかをまとめています。`,
+        )}</description>`,
+        '    </item>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0">',
+    '  <channel>',
+    '    <title>SHINE — 今日の1本</title>',
+    `    <link>${SITE_URL}</link>`,
+    '    <description>映画賞や名作リストに選ばれた映画から毎日1本を紹介します。</description>',
+    '    <language>ja</language>',
+    itemElements,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n');
+}

--- a/apps/front/app/root.tsx
+++ b/apps/front/app/root.tsx
@@ -31,6 +31,12 @@ export function headers(): HeadersInit {
 }
 
 export const links: Route.LinksFunction = () => [
+  {
+    rel: 'alternate',
+    type: 'application/rss+xml',
+    title: 'SHINE — 今日の1本',
+    href: '/feed.xml',
+  },
   {rel: 'preconnect', href: 'https://fonts.googleapis.com'},
   {
     rel: 'preconnect',

--- a/apps/front/app/routes.ts
+++ b/apps/front/app/routes.ts
@@ -7,6 +7,7 @@ export default [
   route('awards', 'routes/awards.tsx'),
   route('awards/:slug', 'routes/awards.$slug.tsx'),
   route('robots.txt', 'routes/robots.tsx'),
+  route('feed.xml', 'routes/feed.tsx'),
   route('sitemap.xml', 'routes/sitemap-index.tsx'),
   route('sitemap/movies.xml', 'routes/sitemap-movies.tsx'),
   route('sitemap/awards.xml', 'routes/sitemap-awards.tsx'),

--- a/apps/front/app/routes/feed.tsx
+++ b/apps/front/app/routes/feed.tsx
@@ -1,0 +1,23 @@
+import type {Route} from './+types/feed';
+import {resolveApiUrl} from '@/lib/api';
+import {buildRssFeed, type FeedItem} from '@/lib/feed';
+
+export async function loader({context, request}: Route.LoaderArgs) {
+  const response = await fetch(
+    `${resolveApiUrl(context)}/selections/daily/history?locale=ja`,
+    {signal: request.signal},
+  );
+
+  if (!response.ok) {
+    return new Response('Failed to load feed', {status: 502});
+  }
+
+  const {items} = (await response.json()) as {items: FeedItem[]};
+
+  return new Response(buildRssFeed(items), {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}


### PR DESCRIPTION
APIに公開エンドポイント GET /selections/daily/history（直近の日次セレクション、locale/limit対応、削除済み・未来日は除外）を追加し、フロントの /feed.xml でRSS 2.0として配信する。root.tsxにalternateリンクを追加。openapi.ymlも更新。