### PR TITLE
「今日の1本」アーカイブページ /daily を追加

### DIFF
--- a/apps/front/app/components/editorial/masthead.tsx
+++ b/apps/front/app/components/editorial/masthead.tsx
@@ -30,6 +30,12 @@ export function Masthead({locale = 'en'}: {locale?: string}) {
         </p>
         <LanguageSelector locale={locale} />
         <a
+          href="/daily"
+          aria-label="Daily picks"
+          className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">
+          DAILY
+        </a>
+        <a
           href="/awards"
           aria-label="Awards"
           className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">

--- a/apps/front/app/routes.ts
+++ b/apps/front/app/routes.ts
@@ -4,6 +4,7 @@ export default [
   index('routes/home.tsx'),
   route('search', 'routes/search.tsx'),
   route('movies/:id', 'routes/movies.$id.tsx'),
+  route('daily', 'routes/daily.tsx'),
   route('awards', 'routes/awards.tsx'),
   route('awards/:slug', 'routes/awards.$slug.tsx'),
   route('robots.txt', 'routes/robots.tsx'),

--- a/apps/front/app/routes/daily.test.tsx
+++ b/apps/front/app/routes/daily.test.tsx
@@ -1,0 +1,145 @@
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import DailyArchivePage, {loader, meta} from './daily';
+import type {Route} from './+types/daily';
+
+globalThis.fetch = vi.fn();
+
+const createMockContext = (apiUrl = 'http://localhost:8787') => ({
+  cloudflare: {
+    env: {
+      PUBLIC_API_URL: apiUrl,
+    },
+  },
+});
+
+const mockHistory = {
+  items: [
+    {
+      uid: 'movie-1',
+      title: '脱出',
+      year: 1972,
+      selectionDate: '2026-08-05',
+    },
+    {
+      uid: 'movie-2',
+      title: 'エンター・ザ・ボイド',
+      year: 2009,
+      selectionDate: '2026-08-04',
+    },
+    {
+      uid: 'movie-3',
+      title: '東への道',
+      year: 1920,
+      selectionDate: '2026-08-03',
+    },
+  ],
+};
+
+const cast = <T,>(value?: unknown): T => value as T;
+
+type LoaderArguments = Route.LoaderArgs;
+type ComponentProperties = Route.ComponentProps;
+
+const createLoaderArguments = (
+  context: unknown,
+  request: Request,
+): LoaderArguments =>
+  cast<LoaderArguments>({
+    context,
+    request,
+    params: {},
+    matches: [],
+  });
+
+const createComponentProperties = (): ComponentProperties =>
+  cast<ComponentProperties>({
+    loaderData: {items: mockHistory.items, locale: 'ja'},
+    params: {},
+    matches: [],
+  });
+
+describe('Daily archive page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loader', () => {
+    it('APIから日次セレクション履歴を取得する', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockHistory,
+      } as Response);
+
+      const request = new Request('http://localhost:3000/daily');
+      const result = await loader(
+        createLoaderArguments(createMockContext(), request),
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8787/selections/daily/history?locale=ja&limit=30',
+        {signal: request.signal},
+      );
+      expect(result).toEqual({items: mockHistory.items, locale: 'ja'});
+    });
+
+    it('APIが失敗したら502を投げる', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      const request = new Request('http://localhost:3000/daily');
+
+      await expect(
+        loader(createLoaderArguments(createMockContext(), request)),
+      ).rejects.toMatchObject({status: 502});
+    });
+  });
+
+  describe('meta', () => {
+    it('タイトルとdescriptionを返す', () => {
+      const result = meta(
+        cast<Route.MetaArgs>({
+          data: {items: mockHistory.items, locale: 'ja'},
+          params: {},
+          location: {
+            pathname: '/daily',
+            search: '',
+            hash: '',
+            state: undefined,
+            key: 'daily-test',
+          },
+          matches: [],
+        }),
+      );
+
+      expect(result).toContainEqual({title: '今日の1本 アーカイブ | SHINE'});
+    });
+  });
+
+  describe('component', () => {
+    it('映画タイトルと詳細ページへのリンクを表示する', () => {
+      render(<DailyArchivePage {...createComponentProperties()} />);
+
+      const link = screen.getByRole('link', {name: /脱出/});
+      expect(link).toHaveAttribute('href', '/movies/movie-1');
+    });
+
+    it('セレクション日付を表示する', () => {
+      render(<DailyArchivePage {...createComponentProperties()} />);
+
+      expect(screen.getByText('2026-08-05')).toBeInTheDocument();
+    });
+
+    it('全アイテムを表示する', () => {
+      render(<DailyArchivePage {...createComponentProperties()} />);
+
+      expect(screen.getAllByRole('link', {name: /『/})).toHaveLength(3);
+    });
+  });
+});

--- a/apps/front/app/routes/daily.tsx
+++ b/apps/front/app/routes/daily.tsx
@@ -1,0 +1,83 @@
+import type {Route} from './+types/daily';
+import {resolveApiUrl} from '@/lib/api';
+import {Masthead} from '@/components/editorial/masthead';
+import {SiteFooter} from '@/components/editorial/site-footer';
+import {DEFAULT_LOCALE, getLocaleFromRequest, type Locale} from '@/lib/locale';
+import {SITE_URL, buildSocialMeta} from '@/lib/meta';
+
+type DailyHistoryItem = {
+  uid: string;
+  title: string;
+  year?: number;
+  selectionDate: string;
+};
+
+export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
+  const {locale} = data as {locale?: Locale};
+
+  return buildSocialMeta({
+    title: '今日の1本 アーカイブ | SHINE',
+    description:
+      '映画賞や名作リストに選ばれた映画から毎日1本を紹介する「今日の1本」の過去のセレクション一覧。',
+    path: '/daily',
+    locale: locale ?? DEFAULT_LOCALE,
+    imageUrl: `${SITE_URL}/og/home.png`,
+    largeImage: true,
+  });
+}
+
+export async function loader({context, request}: Route.LoaderArgs) {
+  const locale = getLocaleFromRequest(request);
+
+  const response = await fetch(
+    `${resolveApiUrl(context)}/selections/daily/history?locale=${locale}&limit=30`,
+    {signal: request.signal},
+  );
+
+  if (!response.ok) {
+    throw new Response('Failed to load daily history', {status: 502});
+  }
+
+  const body = (await response.json()) as {items: DailyHistoryItem[]};
+  return {items: body.items, locale};
+}
+
+export default function DailyArchive({loaderData}: Route.ComponentProps) {
+  const {items, locale} = loaderData as {
+    items: DailyHistoryItem[];
+    locale: Locale;
+  };
+
+  return (
+    <div className="min-h-screen bg-paper text-ink">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <Masthead locale={locale} />
+
+        <h1 className="font-display font-black text-2xl md:text-3xl tracking-tight mb-2">
+          DAILY PICKS
+        </h1>
+        <p className="font-mono text-xs text-ink-muted mb-8">
+          「今日の1本」の過去のセレクション
+        </p>
+
+        <div>
+          {items.map(item => (
+            <a
+              key={`${item.selectionDate}-${item.uid}`}
+              href={`/movies/${item.uid}`}
+              className="flex items-baseline gap-3 py-3 border-t-2 border-ink no-underline text-ink">
+              <span className="font-mono text-xs text-ink-muted shrink-0">
+                {item.selectionDate}
+              </span>
+              <span className="flex-1 font-display font-extrabold text-base md:text-lg leading-tight">
+                『{item.title}』{item.year ? `(${item.year})` : ''}
+              </span>
+            </a>
+          ))}
+        </div>
+
+        <SiteFooter locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/apps/front/app/routes/sitemap-awards.tsx
+++ b/apps/front/app/routes/sitemap-awards.tsx
@@ -23,6 +23,7 @@ export async function loader({context, request}: Route.LoaderArgs) {
   const slugs = await fetchAwardSlugs(context, request.signal);
   const entries: SitemapEntry[] = [
     {path: '/awards', changefreq: 'weekly'},
+    {path: '/daily', changefreq: 'daily'},
     ...slugs.map(slug => ({
       path: `/awards/${slug}`,
       changefreq: 'weekly' as const,


### PR DESCRIPTION
/selections/daily/history を使って過去の日次セレクション（最大30件）を一覧表示するページ。Mastheadに DAILY ボタン、sitemapに /daily を追加。