### PR TITLE
映画詳細ページに関連映画セクションを追加

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -208,6 +208,68 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /movies/{id}/related:
+    get:
+      summary: Get related movies
+      description: Returns movies sharing an award category with the given movie, winners first
+      operationId: getRelatedMovies
+      tags:
+        - Movies
+      security: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: locale
+          in: query
+          description: Language preference for movie titles
+          required: false
+          schema:
+            type: string
+            enum: [en, ja]
+            default: ja
+        - name: limit
+          in: query
+          description: Maximum number of movies to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+            default: 6
+      responses:
+        '200':
+          description: Successfully retrieved related movies
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [movies]
+                properties:
+                  movies:
+                    type: array
+                    items:
+                      type: object
+                      required: [uid, title]
+                      properties:
+                        uid:
+                          type: string
+                          format: uuid
+                        title:
+                          type: string
+                        year:
+                          type: integer
+                        posterUrl:
+                          type: string
+                          format: uri
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /movies/{id}/article-links:
     get:
       summary: Get movie article links

--- a/apps/api/src/__tests__/related-movies.test.ts
+++ b/apps/api/src/__tests__/related-movies.test.ts
@@ -1,0 +1,245 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {moviesRoutes} from '../routes/movies';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+type RelatedMovie = {
+  uid: string;
+  title: string;
+  year: number | undefined;
+  posterUrl: string | undefined;
+};
+
+type RelatedResponse = {movies: RelatedMovie[]};
+
+async function createTestEnvironment(): Promise<Environment> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-test-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+
+  await database.insert(awardOrganizations).values([
+    {uid: 'org-cannes', name: 'Cannes Film Festival'},
+    {uid: 'org-other', name: 'Other Awards'},
+  ]);
+  await database.insert(awardCategories).values([
+    {uid: 'cat-palme', organizationUid: 'org-cannes', name: "Palme d'Or"},
+    {uid: 'cat-other', organizationUid: 'org-other', name: 'Other Prize'},
+  ]);
+  await database.insert(awardCeremonies).values([
+    {uid: 'cer-2023', organizationUid: 'org-cannes', year: 2023},
+    {uid: 'cer-2022', organizationUid: 'org-cannes', year: 2022},
+    {uid: 'cer-2021', organizationUid: 'org-cannes', year: 2021},
+    {uid: 'cer-other', organizationUid: 'org-other', year: 2023},
+  ]);
+
+  await database.insert(movies).values([
+    {uid: 'movie-target', year: 2023},
+    {uid: 'movie-winner', year: 2022},
+    {uid: 'movie-nominee', year: 2021},
+    {uid: 'movie-unrelated', year: 2023},
+    {uid: 'movie-deleted', year: 2022, deletedAt: 1},
+  ]);
+
+  await database.insert(translations).values([
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-target',
+      languageCode: 'en',
+      content: 'Target Movie',
+      isDefault: 1,
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-winner',
+      languageCode: 'ja',
+      content: '受賞作',
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-winner',
+      languageCode: 'en',
+      content: 'Winner Movie',
+      isDefault: 1,
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-nominee',
+      languageCode: 'en',
+      content: 'Nominee Movie',
+      isDefault: 1,
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-unrelated',
+      languageCode: 'en',
+      content: 'Unrelated Movie',
+      isDefault: 1,
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-deleted',
+      languageCode: 'en',
+      content: 'Deleted Movie',
+      isDefault: 1,
+    },
+  ]);
+
+  await database.insert(posterUrls).values({
+    movieUid: 'movie-winner',
+    url: 'https://example.com/winner.jpg',
+    isPrimary: 1,
+  });
+
+  await database.insert(nominations).values([
+    {
+      uid: 'nom-target',
+      movieUid: 'movie-target',
+      ceremonyUid: 'cer-2023',
+      categoryUid: 'cat-palme',
+      isWinner: 0,
+    },
+    {
+      uid: 'nom-winner',
+      movieUid: 'movie-winner',
+      ceremonyUid: 'cer-2022',
+      categoryUid: 'cat-palme',
+      isWinner: 1,
+    },
+    {
+      uid: 'nom-nominee',
+      movieUid: 'movie-nominee',
+      ceremonyUid: 'cer-2021',
+      categoryUid: 'cat-palme',
+      isWinner: 0,
+    },
+    {
+      uid: 'nom-unrelated',
+      movieUid: 'movie-unrelated',
+      ceremonyUid: 'cer-other',
+      categoryUid: 'cat-other',
+      isWinner: 1,
+    },
+    {
+      uid: 'nom-deleted',
+      movieUid: 'movie-deleted',
+      ceremonyUid: 'cer-2022',
+      categoryUid: 'cat-palme',
+      isWinner: 1,
+    },
+  ]);
+
+  return environment;
+}
+
+describe('GET /movies/:id/related', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  it('同じ賞カテゴリの映画を返す（自分自身は除く）', async () => {
+    const response = await moviesRoutes.request(
+      '/movie-target/related',
+      {},
+      environment,
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as RelatedResponse;
+    const uids = body.movies.map(movie => movie.uid);
+    expect(uids).toContain('movie-winner');
+    expect(uids).toContain('movie-nominee');
+    expect(uids).not.toContain('movie-target');
+  });
+
+  it('別カテゴリだけの映画は含めない', async () => {
+    const response = await moviesRoutes.request(
+      '/movie-target/related',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as RelatedResponse;
+    expect(body.movies.map(movie => movie.uid)).not.toContain(
+      'movie-unrelated',
+    );
+  });
+
+  it('削除済みの映画は含めない', async () => {
+    const response = await moviesRoutes.request(
+      '/movie-target/related',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as RelatedResponse;
+    expect(body.movies.map(movie => movie.uid)).not.toContain('movie-deleted');
+  });
+
+  it('受賞作を先頭にする', async () => {
+    const response = await moviesRoutes.request(
+      '/movie-target/related',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as RelatedResponse;
+    expect(body.movies[0].uid).toBe('movie-winner');
+  });
+
+  it('localeのタイトルとポスターを返す', async () => {
+    const response = await moviesRoutes.request(
+      '/movie-target/related?locale=ja',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as RelatedResponse;
+    const winner = body.movies.find(movie => movie.uid === 'movie-winner');
+    expect(winner?.title).toBe('受賞作');
+    expect(winner?.posterUrl).toBe('https://example.com/winner.jpg');
+  });
+
+  it('limitで件数を絞れる', async () => {
+    const response = await moviesRoutes.request(
+      '/movie-target/related?limit=1',
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as RelatedResponse;
+    expect(body.movies).toHaveLength(1);
+  });
+
+  it('存在しない映画は404を返す', async () => {
+    const response = await moviesRoutes.request(
+      '/no-such-movie/related',
+      {},
+      environment,
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -8,6 +8,7 @@ import {
 } from '@shine/database';
 import {articleLinks} from '@shine/database/schema/article-links';
 import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
 import {Hono} from 'hono';
 import {authMiddleware} from '../auth';
 import {sanitizeText, sanitizeUrl} from '../middleware/sanitizer';
@@ -202,6 +203,90 @@ moviesRoutes.get('/:id', async c => {
       return c.json({error: 'Movie not found'}, 404);
     }
 
+    return c.json({error: 'Internal server error'}, 500);
+  }
+});
+
+// Related movies sharing an award category
+moviesRoutes.get('/:id/related', async c => {
+  try {
+    const database = getDatabase(c.env);
+    const movieId = c.req.param('id');
+    const locale = c.req.query('locale') === 'en' ? 'en' : 'ja';
+    const limitParameter = Number(c.req.query('limit') ?? '6');
+    const limit =
+      Number.isInteger(limitParameter) && limitParameter > 0
+        ? Math.min(limitParameter, 12)
+        : 6;
+
+    const target = await database
+      .select({uid: movies.uid, year: movies.year})
+      .from(movies)
+      .where(and(eq(movies.uid, movieId), isNull(movies.deletedAt)))
+      .limit(1);
+
+    if (target.length === 0) {
+      return c.json({error: 'Movie not found'}, 404);
+    }
+
+    const targetYear = target[0].year ?? 0;
+
+    const rows = await database
+      .select({
+        uid: movies.uid,
+        year: movies.year,
+        localeTitle: sql<string | undefined>`(
+          SELECT content FROM translations
+          WHERE resource_type = 'movie_title'
+            AND resource_uid = ${movies.uid}
+            AND language_code = ${locale}
+          LIMIT 1
+        )`,
+        defaultTitle: sql<string | undefined>`(
+          SELECT content FROM translations
+          WHERE resource_type = 'movie_title'
+            AND resource_uid = ${movies.uid}
+            AND is_default = 1
+          LIMIT 1
+        )`,
+        posterUrl: sql<string | undefined>`(
+          SELECT url FROM poster_urls
+          WHERE movie_uid = ${movies.uid}
+          ORDER BY is_primary DESC
+          LIMIT 1
+        )`,
+      })
+      .from(nominations)
+      .innerJoin(movies, eq(nominations.movieUid, movies.uid))
+      .where(
+        and(
+          sql`${nominations.categoryUid} IN (
+            SELECT category_uid FROM nominations WHERE movie_uid = ${movieId}
+          )`,
+          sql`${movies.uid} != ${movieId}`,
+          isNull(movies.deletedAt),
+        ),
+      )
+      .groupBy(movies.uid)
+      .orderBy(
+        sql`MAX(${nominations.isWinner}) DESC`,
+        sql`ABS(COALESCE(${movies.year}, 0) - ${targetYear}) ASC`,
+      )
+      .limit(limit);
+
+    const relatedMovies = rows.map(row => ({
+      uid: row.uid,
+      title: row.localeTitle ?? row.defaultTitle ?? 'Unknown Title',
+      year: row.year ?? undefined,
+      posterUrl: row.posterUrl ?? undefined,
+    }));
+
+    return createCachedResponse(
+      {movies: relatedMovies},
+      getCacheTTL.movie.full,
+    );
+  } catch (error) {
+    console.error('Error fetching related movies:', error);
     return c.json({error: 'Internal server error'}, 500);
   }
 });

--- a/apps/front/app/routes/movies.$id.test.tsx
+++ b/apps/front/app/routes/movies.$id.test.tsx
@@ -79,6 +79,21 @@ const mockMovieDetail = {
   ],
 };
 
+const mockRelatedMovies = [
+  {
+    uid: 'related-1',
+    title: '関連映画A',
+    year: 2022,
+    posterUrl: 'https://example.com/related-a.jpg',
+  },
+  {
+    uid: 'related-2',
+    title: '関連映画B',
+    year: 2021,
+    posterUrl: undefined,
+  },
+];
+
 // Fetchのモック
 globalThis.fetch = vi.fn();
 
@@ -204,6 +219,10 @@ describe('MovieDetail Component', () => {
         ok: true,
         json: async () => mockMovieDetail,
       } as Response);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({movies: mockRelatedMovies}),
+      } as Response);
 
       const context = createMockContext();
       const parameters = {id: 'movie-123'};
@@ -223,11 +242,44 @@ describe('MovieDetail Component', () => {
           signal: request.signal,
         },
       );
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8787/movies/movie-123/related?locale=ja&limit=6',
+        {
+          signal: request.signal,
+        },
+      );
       expect(result).toEqual({
         movieDetail: mockMovieDetail,
+        relatedMovies: mockRelatedMovies,
         turnstileSiteKey: 'test-site-key',
         locale: 'ja',
         apiUrl: 'http://localhost:8787',
+      });
+    });
+
+    it('関連映画の取得に失敗しても詳細は返す', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMovieDetail,
+      } as Response);
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const context = createMockContext();
+      const parameters = {id: 'movie-123'};
+      const request = new Request('http://localhost:3000/movies/movie-123');
+      const result = await loader(
+        createLoaderArguments(context, request, parameters, {
+          matches: createMatches(
+            createLoaderData(),
+            createParameters(parameters.id),
+          ),
+        }),
+      );
+
+      expect(result).toMatchObject({
+        movieDetail: mockMovieDetail,
+        relatedMovies: [],
       });
     });
 
@@ -428,6 +480,40 @@ describe('MovieDetail Component', () => {
   });
 
   describe('Component', () => {
+    it('関連映画のリンクを表示する', () => {
+      const loaderData = createLoaderData({relatedMovies: mockRelatedMovies});
+      const parameters = createParameters('movie-123');
+
+      render(
+        <MovieDetail
+          loaderData={loaderData}
+          actionData={createActionData()}
+          params={parameters}
+          matches={createMatches(loaderData, parameters)}
+        />,
+      );
+
+      const link = screen.getByRole('link', {name: /関連映画A/});
+      expect(link).toHaveAttribute('href', '/movies/related-1');
+      expect(screen.getByText('関連映画')).toBeInTheDocument();
+    });
+
+    it('関連映画が無ければセクションを出さない', () => {
+      const loaderData = createLoaderData({relatedMovies: []});
+      const parameters = createParameters('movie-123');
+
+      render(
+        <MovieDetail
+          loaderData={loaderData}
+          actionData={createActionData()}
+          params={parameters}
+          matches={createMatches(loaderData, parameters)}
+        />,
+      );
+
+      expect(screen.queryByText('関連映画')).not.toBeInTheDocument();
+    });
+
     it('映画詳細データが正常に表示される', () => {
       const loaderData = createLoaderData();
       const parameters = createParameters('movie-123');

--- a/apps/front/app/routes/movies.$id.tsx
+++ b/apps/front/app/routes/movies.$id.tsx
@@ -69,8 +69,16 @@ type LoaderErrorResponse = {
   locale: Locale;
 };
 
+type RelatedMovie = {
+  uid: string;
+  title: string;
+  year?: number;
+  posterUrl?: string;
+};
+
 type LoaderSuccessResponse = {
   movieDetail: MovieDetailData;
+  relatedMovies?: RelatedMovie[];
   turnstileSiteKey?: string;
   locale: Locale;
   apiUrl?: string;
@@ -499,6 +507,29 @@ export function meta({data, params}: Route.MetaArgs): Route.MetaDescriptors {
   ];
 }
 
+async function fetchRelatedMovies(
+  apiUrl: string,
+  movieId: string,
+  locale: Locale,
+  signal?: AbortSignal,
+): Promise<RelatedMovie[]> {
+  try {
+    const response = await fetch(
+      `${apiUrl}/movies/${movieId}/related?locale=${locale}&limit=6`,
+      {signal},
+    );
+
+    if (!response?.ok) {
+      return [];
+    }
+
+    const body = (await response.json()) as {movies?: RelatedMovie[]};
+    return body.movies ?? [];
+  } catch {
+    return [];
+  }
+}
+
 export async function loader({
   context,
   params,
@@ -511,9 +542,12 @@ export async function loader({
       context.cloudflare as CloudflareContext | undefined
     )?.env;
     const apiUrl = resolveApiUrl(context);
-    const response = await fetch(`${apiUrl}/movies/${params.id}`, {
-      signal: request.signal, // React Router v7推奨：abortシグナル
-    });
+    const [response, relatedMovies] = await Promise.all([
+      fetch(`${apiUrl}/movies/${params.id}`, {
+        signal: request.signal, // React Router v7推奨：abortシグナル
+      }),
+      fetchRelatedMovies(apiUrl, params.id, locale, request.signal),
+    ]);
 
     if (response.status === 404) {
       return {
@@ -533,7 +567,7 @@ export async function loader({
 
     const movieDetail = (await response.json()) as MovieDetailData;
     const turnstileSiteKey = cloudflareEnvironment?.PUBLIC_TURNSTILE_SITE_KEY;
-    return {movieDetail, turnstileSiteKey, locale, apiUrl};
+    return {movieDetail, relatedMovies, turnstileSiteKey, locale, apiUrl};
   } catch {
     return {
       error: 'APIへの接続に失敗しました',
@@ -641,6 +675,7 @@ export default function MovieDetail({
   }
 
   const {movieDetail, turnstileSiteKey} = data;
+  const relatedMovies = data.relatedMovies ?? [];
   const title = movieDetail.title || 'タイトル不明';
 
   const metaItems: string[] = [];
@@ -705,6 +740,35 @@ export default function MovieDetail({
             locale="ja"
           />
         </section>
+
+        {/* Related Movies */}
+        {relatedMovies.length > 0 && (
+          <section className="mb-8">
+            <p className="font-mono text-xs text-ink-muted mb-3">関連映画</p>
+            <div className="grid grid-cols-3 md:grid-cols-6 gap-3">
+              {relatedMovies.map(relatedMovie => (
+                <a
+                  key={relatedMovie.uid}
+                  href={`/movies/${relatedMovie.uid}`}
+                  className="no-underline text-ink">
+                  <PosterFrame
+                    posterUrl={relatedMovie.posterUrl}
+                    alt={`${relatedMovie.title} poster`}
+                    className="w-full"
+                  />
+                  <span className="block font-display font-bold text-xs leading-tight mt-1.5">
+                    {relatedMovie.title}
+                  </span>
+                  {relatedMovie.year && (
+                    <span className="block font-mono text-[10px] text-ink-muted mt-0.5">
+                      {relatedMovie.year}
+                    </span>
+                  )}
+                </a>
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Article Links */}
         <ArticleLinksSection


### PR DESCRIPTION
同じ賞カテゴリの映画を返す公開API GET /movies/:id/related（受賞作優先・年の近い順、削除済み除外、locale/limit対応）を追加し、詳細ページのWATCHセクションの下に「関連映画」（ポスター+タイトル最大6件）を表示する。関連取得の失敗はページ表示に影響しない。openapi.ymlも更新。