### PR TITLE
MastheadのSHINEロゴをトップへのリンクにする

### DIFF
--- a/apps/front/app/components/editorial/masthead.test.tsx
+++ b/apps/front/app/components/editorial/masthead.test.tsx
@@ -16,6 +16,14 @@ describe('Masthead', () => {
     expect(screen.getByRole('button', {name: /theme/i})).toBeInTheDocument();
   });
 
+  it('SHINE ロゴはトップページへのリンクにする', () => {
+    render(<Masthead locale="ja" />);
+    expect(screen.getByRole('link', {name: 'SHINE'})).toHaveAttribute(
+      'href',
+      '/',
+    );
+  });
+
   it('AWARDS リンクを描画する', () => {
     render(<Masthead locale="ja" />);
     expect(screen.getByRole('link', {name: /awards/i})).toHaveAttribute(

--- a/apps/front/app/components/editorial/masthead.tsx
+++ b/apps/front/app/components/editorial/masthead.tsx
@@ -19,8 +19,10 @@ export function Masthead({locale = 'en'}: {locale?: string}) {
 
   return (
     <header className="flex flex-wrap items-end justify-between gap-x-4 gap-y-2.5 border-b-2 border-ink pb-2.5 mb-6">
-      <h1 className="font-display font-black text-4xl md:text-5xl tracking-[-0.06em] leading-none text-ink">
-        SHINE
+      <h1 className="font-display font-black text-4xl md:text-5xl tracking-[-0.06em] leading-none">
+        <a href="/" className="no-underline text-ink">
+          SHINE
+        </a>
       </h1>
       <div className="ml-auto flex items-center gap-2 md:gap-3">
         <p className="hidden md:block text-right font-mono text-[10px] leading-tight text-ink-muted">


### PR DESCRIPTION
ヘッダーにDAILY/AWARDS/SEARCHはあるのにトップへ戻る動線がなかったので、SHINEロゴを / へのリンクにした。