### PR TITLE
X版デイリー投稿botを追加

### DIFF
--- a/.github/workflows/sns-post.yml
+++ b/.github/workflows/sns-post.yml
@@ -51,3 +51,7 @@ jobs:
         env:
           BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_KEY_SECRET: ${{ secrets.X_API_KEY_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}

--- a/apps/scrapers/src/sns-post-cli.ts
+++ b/apps/scrapers/src/sns-post-cli.ts
@@ -1,15 +1,16 @@
 #!/usr/bin/env -S tsx
 
 /**
- * 今日のデイリーセレクションをBlueskyへ投稿するCLI。
+ * 今日のデイリーセレクションをBlueskyとXへ投稿するCLI。
  *
  * 使い方:
  *   pnpm run sns-post --dry-run   投稿せず本文とカード情報を表示
  *   pnpm run sns-post             実際に投稿する
  *
- * 必要な環境変数(実投稿時):
+ * 必要な環境変数(実投稿時、設定があるサービスにだけ投稿する):
  *   BLUESKY_IDENTIFIER   例: shine-film.com
  *   BLUESKY_APP_PASSWORD アプリパスワード
+ *   X_API_KEY / X_API_KEY_SECRET / X_ACCESS_TOKEN / X_ACCESS_TOKEN_SECRET
  */
 import process from 'node:process';
 import {loadEnvironmentFiles} from './common/environment';
@@ -23,7 +24,8 @@ import {
   publishPost,
   uploadBlob,
 } from './sns/bluesky';
-import {buildDailyPostText} from './sns/post-text';
+import {buildDailyPostText, buildXPostText} from './sns/post-text';
+import {postTweet, type XCredentials} from './sns/x';
 
 loadEnvironmentFiles();
 
@@ -65,6 +67,59 @@ async function fetchOgImage(
   return response.ok ? response.arrayBuffer() : undefined;
 }
 
+function getXCredentials(): XCredentials | undefined {
+  const consumerKey = process.env.X_API_KEY;
+  const consumerSecret = process.env.X_API_KEY_SECRET;
+  const accessToken = process.env.X_ACCESS_TOKEN;
+  const accessTokenSecret = process.env.X_ACCESS_TOKEN_SECRET;
+
+  return consumerKey && consumerSecret && accessToken && accessTokenSecret
+    ? {consumerKey, consumerSecret, accessToken, accessTokenSecret}
+    : undefined;
+}
+
+async function postToBluesky(
+  text: string,
+  movieUid: string,
+  link: {uri: string; title: string; description: string},
+): Promise<void> {
+  const identifier = process.env.BLUESKY_IDENTIFIER;
+  const password = process.env.BLUESKY_APP_PASSWORD;
+  if (!identifier || !password) {
+    console.log('Bluesky: 認証情報が無いためスキップします');
+    return;
+  }
+
+  const session = await createSession(identifier, password);
+  const ogImage = await fetchOgImage(movieUid);
+  const thumb = ogImage
+    ? await uploadBlob(session, ogImage, 'image/png')
+    : undefined;
+
+  const result = await publishPost(
+    session,
+    buildPostRecord({
+      text,
+      createdAt: new Date().toISOString(),
+      link,
+      thumb,
+    }),
+  );
+
+  console.log(`Bluesky: 投稿しました ${result.uri}`);
+}
+
+async function postToX(text: string): Promise<void> {
+  const credentials = getXCredentials();
+  if (!credentials) {
+    console.log('X: 認証情報が無いためスキップします');
+    return;
+  }
+
+  const result = await postTweet(credentials, text);
+  console.log(`X: 投稿しました https://x.com/i/status/${result.id}`);
+}
+
 async function main() {
   const isDryRun = process.argv.includes('--dry-run');
 
@@ -80,11 +135,16 @@ async function main() {
   ];
   const availabilityLabels = buildAvailabilityLabels(movie.availability ?? []);
 
-  const text = buildDailyPostText({
+  const postInput = {
     title,
     year: movie.year,
     organizations: organizations.slice(0, MAX_TEXT_ORGANIZATIONS),
     availabilityLabels: availabilityLabels.slice(0, MAX_TEXT_AVAILABILITY),
+  };
+  const text = buildDailyPostText(postInput);
+  const xText = buildXPostText({
+    ...postInput,
+    url: `${SITE_URL}/movies/${movie.uid}`,
   });
 
   const link = {
@@ -93,43 +153,38 @@ async function main() {
     description: `『${title}』をいま観られるかをまとめています。`,
   };
 
-  console.log('--- 投稿内容 ---');
+  console.log('--- Bluesky投稿内容 ---');
   console.log(text);
   console.log('--- リンクカード ---');
   console.log(`uri:   ${link.uri}`);
   console.log(`title: ${link.title}`);
   console.log(`thumb: ${SITE_URL}/og/movie.png?id=${movie.uid}`);
+  console.log('--- X投稿内容 ---');
+  console.log(xText);
 
   if (isDryRun) {
     console.log('\n(dry-run: 投稿していません)');
     return;
   }
 
-  const identifier = process.env.BLUESKY_IDENTIFIER;
-  const password = process.env.BLUESKY_APP_PASSWORD;
-  if (!identifier || !password) {
-    throw new Error(
-      'BLUESKY_IDENTIFIER と BLUESKY_APP_PASSWORD を設定してください。',
-    );
+  const errors: Error[] = [];
+  try {
+    await postToBluesky(text, movie.uid, link);
+  } catch (error) {
+    errors.push(error as Error);
+    console.error('Bluesky: 投稿に失敗しました:', error);
   }
 
-  const session = await createSession(identifier, password);
-  const ogImage = await fetchOgImage(movie.uid);
-  const thumb = ogImage
-    ? await uploadBlob(session, ogImage, 'image/png')
-    : undefined;
+  try {
+    await postToX(xText);
+  } catch (error) {
+    errors.push(error as Error);
+    console.error('X: 投稿に失敗しました:', error);
+  }
 
-  const result = await publishPost(
-    session,
-    buildPostRecord({
-      text,
-      createdAt: new Date().toISOString(),
-      link,
-      thumb,
-    }),
-  );
-
-  console.log(`\n投稿しました: ${result.uri}`);
+  if (errors.length > 0) {
+    throw new Error(`${errors.length}件の投稿が失敗しました`);
+  }
 }
 
 try {

--- a/apps/scrapers/src/sns/post-text.test.ts
+++ b/apps/scrapers/src/sns/post-text.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {buildDailyPostText} from './post-text';
+import {buildDailyPostText, buildXPostText, xWeightedLength} from './post-text';
 
 const base = {
   title: 'ハウスメイド',
@@ -71,5 +71,48 @@ describe('buildDailyPostText', () => {
 
     expect([...text].length).toBeLessThanOrEqual(300);
     expect(text).toMatch(/#青空映画部$/);
+  });
+});
+
+describe('xWeightedLength', () => {
+  it('ASCIIは1、日本語は2で数える', () => {
+    expect(xWeightedLength('ab')).toBe(2);
+    expect(xWeightedLength('あい')).toBe(4);
+  });
+});
+
+describe('buildXPostText', () => {
+  const xBase = {
+    ...base,
+    url: 'https://shine-film.com/movies/abc-123',
+  };
+
+  it('本文の末尾にURLを含む', () => {
+    const text = buildXPostText(xBase);
+
+    expect(text).toMatch(/https:\/\/shine-film\.com\/movies\/abc-123$/);
+  });
+
+  it('タイトルと選出元と視聴可否を含む', () => {
+    const text = buildXPostText(xBase);
+
+    expect(text).toContain('『ハウスメイド』(2010)');
+    expect(text).toContain('Cannes Film Festival');
+    expect(text).toContain('U-NEXT 見放題');
+  });
+
+  it('ハッシュタグは付けない', () => {
+    expect(buildXPostText(xBase)).not.toContain('#');
+  });
+
+  it('長いタイトルでも本文のweighted長がURL込み280以内に収まる', () => {
+    const text = buildXPostText({
+      ...xBase,
+      title: 'あ'.repeat(300),
+    });
+
+    const withoutUrl = text.replace(/\nhttps:\/\/\S+$/, '');
+    expect(xWeightedLength(withoutUrl) + 1 + 23).toBeLessThanOrEqual(280);
+    expect(text).toMatch(/https:\/\/shine-film\.com\/movies\/abc-123$/);
   });
 });

--- a/apps/scrapers/src/sns/post-text.ts
+++ b/apps/scrapers/src/sns/post-text.ts
@@ -1,6 +1,8 @@
 const MAX_ORGANIZATIONS = 2;
 const MAX_POST_LENGTH = 300;
 const HASHTAG = '#青空映画部';
+const X_MAX_WEIGHTED_LENGTH = 280;
+const X_URL_WEIGHT = 23;
 
 type DailyPostInput = {
   title: string;
@@ -9,7 +11,7 @@ type DailyPostInput = {
   availabilityLabels: string[];
 };
 
-export function buildDailyPostText({
+function buildBodyLines({
   title,
   year,
   organizations,
@@ -26,7 +28,11 @@ export function buildDailyPostText({
     lines.push(`▶ ${availabilityLabels.join(' / ')}`);
   }
 
-  const body = lines.join('\n');
+  return lines.join('\n');
+}
+
+export function buildDailyPostText(input: DailyPostInput): string {
+  const body = buildBodyLines(input);
   const maxBodyLength = MAX_POST_LENGTH - [...`\n${HASHTAG}`].length;
   const truncatedBody =
     [...body].length <= maxBodyLength
@@ -34,4 +40,38 @@ export function buildDailyPostText({
       : [...body].slice(0, maxBodyLength - 1).join('') + '…';
 
   return `${truncatedBody}\n${HASHTAG}`;
+}
+
+export function xWeightedLength(text: string): number {
+  let length = 0;
+  for (const character of text) {
+    length += character.codePointAt(0)! < 0x11_00 ? 1 : 2;
+  }
+
+  return length;
+}
+
+export function buildXPostText(input: DailyPostInput & {url: string}): string {
+  const body = buildBodyLines(input);
+  const maxBodyWeight = X_MAX_WEIGHTED_LENGTH - X_URL_WEIGHT - 1;
+
+  let truncatedBody = body;
+  if (xWeightedLength(body) > maxBodyWeight) {
+    const characters = [...body];
+    let weight = 2;
+    let endIndex = 0;
+    for (const [index, character] of characters.entries()) {
+      const characterWeight = character.codePointAt(0)! < 0x11_00 ? 1 : 2;
+      if (weight + characterWeight > maxBodyWeight) {
+        break;
+      }
+
+      weight += characterWeight;
+      endIndex = index + 1;
+    }
+
+    truncatedBody = characters.slice(0, endIndex).join('') + '…';
+  }
+
+  return `${truncatedBody}\n${input.url}`;
 }

--- a/apps/scrapers/src/sns/x.test.ts
+++ b/apps/scrapers/src/sns/x.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from 'vitest';
+import {buildOAuth1Header, percentEncode} from './x';
+
+describe('percentEncode', () => {
+  it('RFC 3986の未予約文字はそのまま残す', () => {
+    expect(percentEncode('Abc123-._~')).toBe('Abc123-._~');
+  });
+
+  it('スペースや記号をエンコードする', () => {
+    expect(percentEncode('Hello Ladies + Gentlemen!')).toBe(
+      'Hello%20Ladies%20%2B%20Gentlemen%21',
+    );
+  });
+
+  it('日本語をUTF-8でエンコードする', () => {
+    expect(percentEncode('あ')).toBe('%E3%81%82');
+  });
+});
+
+describe('buildOAuth1Header', () => {
+  it('Twitter公式ドキュメントのテストベクトルと一致する署名を生成する', () => {
+    const header = buildOAuth1Header({
+      method: 'POST',
+      url: 'https://api.twitter.com/1.1/statuses/update.json',
+      consumerKey: 'xvz1evFS4wEEPTGEFPHBog',
+      consumerSecret: 'kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw',
+      accessToken: '370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb',
+      accessTokenSecret: 'LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE',
+      nonce: 'kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg',
+      timestamp: 1_318_622_958,
+      extraParams: {
+        status: 'Hello Ladies + Gentlemen, a signed OAuth request!',
+        include_entities: 'true',
+      },
+    });
+
+    expect(header).toContain(
+      'oauth_signature="hCtSmYh%2BiHYCEqBWrE7C7hYmtUk%3D"',
+    );
+  });
+
+  it('OAuth認証ヘッダーの形式で返す', () => {
+    const header = buildOAuth1Header({
+      method: 'POST',
+      url: 'https://api.x.com/2/tweets',
+      consumerKey: 'ck',
+      consumerSecret: 'cs',
+      accessToken: 'at',
+      accessTokenSecret: 'ats',
+      nonce: 'nonce',
+      timestamp: 1_700_000_000,
+    });
+
+    expect(header).toMatch(/^OAuth /);
+    expect(header).toContain('oauth_consumer_key="ck"');
+    expect(header).toContain('oauth_token="at"');
+    expect(header).toContain('oauth_signature_method="HMAC-SHA1"');
+    expect(header).toContain('oauth_version="1.0"');
+    expect(header).toContain('oauth_timestamp="1700000000"');
+  });
+});

--- a/apps/scrapers/src/sns/x.ts
+++ b/apps/scrapers/src/sns/x.ts
@@ -1,0 +1,108 @@
+/**
+ * X (Twitter) API v2 への投稿クライアント。
+ * OAuth 1.0a user context で署名し POST /2/tweets を叩く。
+ * JSONボディはOAuth 1.0aの署名対象に含まれない。
+ */
+import {createHmac, randomBytes} from 'node:crypto';
+
+const TWEETS_ENDPOINT = 'https://api.x.com/2/tweets';
+
+export type XCredentials = {
+  consumerKey: string;
+  consumerSecret: string;
+  accessToken: string;
+  accessTokenSecret: string;
+};
+
+export function percentEncode(value: string): string {
+  return encodeURIComponent(value).replaceAll(
+    /[!'()*]/g,
+    character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`,
+  );
+}
+
+type OAuth1HeaderOptions = XCredentials & {
+  method: string;
+  url: string;
+  nonce: string;
+  timestamp: number;
+  extraParams?: Record<string, string>;
+};
+
+export function buildOAuth1Header({
+  method,
+  url,
+  consumerKey,
+  consumerSecret,
+  accessToken,
+  accessTokenSecret,
+  nonce,
+  timestamp,
+  extraParams: extraParameters = {},
+}: OAuth1HeaderOptions): string {
+  const oauthParameters: Record<string, string> = {
+    oauth_consumer_key: consumerKey,
+    oauth_nonce: nonce,
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: String(timestamp),
+    oauth_token: accessToken,
+    oauth_version: '1.0',
+  };
+
+  const allParameters = {...oauthParameters, ...extraParameters};
+  const parameterString = Object.entries(allParameters)
+    .map(([key, value]) => [percentEncode(key), percentEncode(value)])
+    .toSorted(([a], [b]) => (a < b ? -1 : 1))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+
+  const signatureBase = [
+    method.toUpperCase(),
+    percentEncode(url),
+    percentEncode(parameterString),
+  ].join('&');
+  const signingKey = `${percentEncode(consumerSecret)}&${percentEncode(
+    accessTokenSecret,
+  )}`;
+  const signature = createHmac('sha1', signingKey)
+    .update(signatureBase)
+    .digest('base64');
+
+  const headerParameters = {...oauthParameters, oauth_signature: signature};
+  const header = Object.entries(headerParameters)
+    .toSorted(([a], [b]) => (a < b ? -1 : 1))
+    .map(([key, value]) => `${percentEncode(key)}="${percentEncode(value)}"`)
+    .join(', ');
+
+  return `OAuth ${header}`;
+}
+
+export async function postTweet(
+  credentials: XCredentials,
+  text: string,
+): Promise<{id: string}> {
+  const authorization = buildOAuth1Header({
+    ...credentials,
+    method: 'POST',
+    url: TWEETS_ENDPOINT,
+    nonce: randomBytes(16).toString('hex'),
+    timestamp: Math.floor(Date.now() / 1000),
+  });
+
+  const response = await fetch(TWEETS_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: authorization,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({text}),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`X API /2/tweets failed: ${response.status} ${body}`);
+  }
+
+  const result = (await response.json()) as {data: {id: string}};
+  return {id: result.data.id};
+}


### PR DESCRIPTION
sns-postにX (API v2 POST /2/tweets) への投稿を追加。OAuth 1.0a署名は公式ドキュメントのテストベクトルで検証。X用本文はweighted 280字制限（URL=23換算）でハッシュタグなし・URL入り。Bluesky/Xは片方が失敗してももう片方は投稿し、失敗があればexit 1。ワークフローにX系secretsを追加。