### PR TITLE
X投稿のURLをスキームなしに変更

### DIFF
--- a/apps/scrapers/src/sns/post-text.test.ts
+++ b/apps/scrapers/src/sns/post-text.test.ts
@@ -87,10 +87,11 @@ describe('buildXPostText', () => {
     url: 'https://shine-film.com/movies/abc-123',
   };
 
-  it('本文の末尾にURLを含む', () => {
+  it('本文の末尾にスキームを外したURLを含む(リンク付き投稿の従量課金を避ける)', () => {
     const text = buildXPostText(xBase);
 
-    expect(text).toMatch(/https:\/\/shine-film\.com\/movies\/abc-123$/);
+    expect(text).toMatch(/\nshine-film\.com\/movies\/abc-123$/);
+    expect(text).not.toContain('https://');
   });
 
   it('タイトルと選出元と視聴可否を含む', () => {
@@ -105,14 +106,13 @@ describe('buildXPostText', () => {
     expect(buildXPostText(xBase)).not.toContain('#');
   });
 
-  it('長いタイトルでも本文のweighted長がURL込み280以内に収まる', () => {
+  it('長いタイトルでも全体のweighted長が280以内に収まる', () => {
     const text = buildXPostText({
       ...xBase,
       title: 'あ'.repeat(300),
     });
 
-    const withoutUrl = text.replace(/\nhttps:\/\/\S+$/, '');
-    expect(xWeightedLength(withoutUrl) + 1 + 23).toBeLessThanOrEqual(280);
-    expect(text).toMatch(/https:\/\/shine-film\.com\/movies\/abc-123$/);
+    expect(xWeightedLength(text)).toBeLessThanOrEqual(280);
+    expect(text).toMatch(/\nshine-film\.com\/movies\/abc-123$/);
   });
 });

--- a/apps/scrapers/src/sns/post-text.ts
+++ b/apps/scrapers/src/sns/post-text.ts
@@ -53,7 +53,9 @@ export function xWeightedLength(text: string): number {
 
 export function buildXPostText(input: DailyPostInput & {url: string}): string {
   const body = buildBodyLines(input);
-  const maxBodyWeight = X_MAX_WEIGHTED_LENGTH - X_URL_WEIGHT - 1;
+  const bareUrl = input.url.replace(/^https?:\/\//, '');
+  const urlWeight = Math.max(X_URL_WEIGHT, xWeightedLength(bareUrl));
+  const maxBodyWeight = X_MAX_WEIGHTED_LENGTH - urlWeight - 1;
 
   let truncatedBody = body;
   if (xWeightedLength(body) > maxBodyWeight) {
@@ -73,5 +75,5 @@ export function buildXPostText(input: DailyPostInput & {url: string}): string {
     truncatedBody = characters.slice(0, endIndex).join('') + '…';
   }
 
-  return `${truncatedBody}\n${input.url}`;
+  return `${truncatedBody}\n${bareUrl}`;
 }


### PR DESCRIPTION
X APIのPay-Per-Use課金はリンク入り投稿が$0.20/件（テキストのみは$0.015）。https:// を外した裸ドメイン形式にしてリンク課金を回避する。裸URLがt.co化されない場合に備え、weighted長は実文字数と23の大きい方で計算。