### PR TITLE
映画検索を全言語のタイトルに対して行う

### DIFF
--- a/apps/api/src/services/__tests__/movies-service-title-fallback.test.ts
+++ b/apps/api/src/services/__tests__/movies-service-title-fallback.test.ts
@@ -104,5 +104,40 @@ describe('タイトルのフォールバック', () => {
       expect(result.movies).toHaveLength(1);
       expect(result.movies[0].title).toBe('The Racket');
     });
+
+    it('日本語タイトルで検索できる', async () => {
+      const service = new MoviesService(environment);
+      const result = await service.searchMovies({
+        page: 1,
+        limit: 10,
+        query: '日本語タイトル',
+      });
+
+      expect(result.movies.map(movie => movie.uid)).toEqual(['movie-ja']);
+    });
+
+    it('ja以外の言語のタイトルでも検索にヒットする', async () => {
+      const service = new MoviesService(environment);
+      const result = await service.searchMovies({
+        page: 1,
+        limit: 10,
+        query: 'Racket',
+      });
+
+      expect(result.movies.map(movie => movie.uid)).toEqual([
+        'movie-en-default',
+      ]);
+    });
+
+    it('検索結果の総数もヒットした映画数と一致する', async () => {
+      const service = new MoviesService(environment);
+      const result = await service.searchMovies({
+        page: 1,
+        limit: 10,
+        query: 'Racket',
+      });
+
+      expect(result.pagination.totalCount).toBe(1);
+    });
   });
 });

--- a/apps/api/src/services/movies-service.ts
+++ b/apps/api/src/services/movies-service.ts
@@ -1,4 +1,4 @@
-import {and, eq, inArray, isNull, like, sql} from '@shine/database';
+import {and, eq, inArray, isNull, sql} from '@shine/database';
 import {articleLinks} from '@shine/database/schema/article-links';
 import {awardCategories} from '@shine/database/schema/award-categories';
 import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
@@ -28,7 +28,15 @@ export class MoviesService extends BaseService {
     const conditions = [isNull(movies.deletedAt)];
 
     if (query) {
-      conditions.push(like(translations.content, `%${query}%`));
+      conditions.push(sql`
+				EXISTS (
+				  SELECT 1
+				  FROM translations
+				  WHERE translations.resource_uid = movies.uid
+				    AND translations.resource_type = 'movie_title'
+				    AND translations.content LIKE ${`%${query}%`}
+				)
+			`);
     }
 
     if (year && !Number.isNaN(Number(year))) {
@@ -66,15 +74,7 @@ export class MoviesService extends BaseService {
 					)
 				`.as('hasNominations'),
       })
-      .from(movies)
-      .leftJoin(
-        translations,
-        and(
-          eq(translations.resourceUid, movies.uid),
-          eq(translations.resourceType, 'movie_title'),
-          eq(translations.languageCode, 'ja'),
-        ),
-      );
+      .from(movies);
 
     type BaseQuery = typeof baseQuery;
     type SearchResultRow = Awaited<ReturnType<BaseQuery['execute']>>[number];
@@ -104,15 +104,7 @@ export class MoviesService extends BaseService {
     // Build count query
     const baseCountQuery = this.database
       .select({count: sql`COUNT(DISTINCT movies.uid)`.as('count')})
-      .from(movies)
-      .leftJoin(
-        translations,
-        and(
-          eq(translations.resourceUid, movies.uid),
-          eq(translations.resourceType, 'movie_title'),
-          eq(translations.languageCode, 'ja'),
-        ),
-      );
+      .from(movies);
 
     const countQuery = (() => {
       const withAwards =


### PR DESCRIPTION
検索のLIKE条件がjaタイトルのJOINにしか当たらず、日本語訳の無い映画は原題で検索してもヒットしなかった。translationsへのEXISTSサブクエリに変更し、全言語のタイトルでマッチするようにした。表示タイトルはPR #249のフォールバックをそのまま使う。