### PR TITLE
映画キャッシュキーをv3にバンプ

### DIFF
--- a/apps/api/src/cache.test.ts
+++ b/apps/api/src/cache.test.ts
@@ -34,8 +34,8 @@ describe('Cache Utilities', () => {
       const fullKey = getCacheKeyForMovie(movieId, true);
       const englishKey = getCacheKeyForMovie(movieId, false, 'en');
 
-      expect(basicKey).toBe(`movie:${movieId}:basic:ja:v2`);
-      expect(fullKey).toBe(`movie:${movieId}:full:ja:v2`);
+      expect(basicKey).toBe(`movie:${movieId}:basic:ja:v3`);
+      expect(fullKey).toBe(`movie:${movieId}:full:ja:v3`);
       expect(basicKey).not.toBe(fullKey);
       expect(englishKey).not.toBe(basicKey);
     });

--- a/apps/api/src/utils/cache.ts
+++ b/apps/api/src/utils/cache.ts
@@ -170,7 +170,7 @@ export const getCacheKeyForMovie = (
   locale: string = 'ja',
 ): string => {
   const suffix = includeDetails ? 'full' : 'basic';
-  return `movie:${movieId}:${suffix}:${locale}:v2`;
+  return `movie:${movieId}:${suffix}:${locale}:v3`;
 };
 
 export const getMovieCacheKeysForAllLocales = (movieId: string): string[] =>


### PR DESCRIPTION
タイトルフォールバック修正(PR #249)前にEdgeCacheへ入った「Unknown Title」応答が最大24時間残る。Cache APIはPoP単位でdeleteが全域に効かないため、キーのバージョンをv2→v3に上げて旧エントリを切り離す。旧キーはTTLで自然消滅。