### PR TITLE
robots.txtで/__manifestをクロール対象から除外

### DIFF
--- a/apps/front/app/routes/robots.test.ts
+++ b/apps/front/app/routes/robots.test.ts
@@ -28,6 +28,10 @@ describe('robots.txt', () => {
     expect(await robotsBody()).not.toContain('Disallow: /search');
   });
 
+  it('React Routerのマニフェストをクロール対象から除外する', async () => {
+    expect(await robotsBody()).toContain('Disallow: /__manifest');
+  });
+
   it('プレーンテキストとして返す', () => {
     expect(loader().headers.get('content-type')).toContain('text/plain');
   });

--- a/apps/front/app/routes/robots.tsx
+++ b/apps/front/app/routes/robots.tsx
@@ -5,6 +5,7 @@ import {SITE_URL} from '@/lib/meta';
 const ROBOTS_TXT = `User-agent: *
 Allow: /
 Disallow: /admin
+Disallow: /__manifest
 
 Sitemap: ${SITE_URL}/sitemap.xml
 `;


### PR DESCRIPTION
Search Consoleで React Router の `/__manifest` エンドポイントが「クロール済み - インデックス未登録」に出ていたため、robots.txt に `Disallow: /__manifest` を追加。