### PR TITLE
fix(api): /movies/search の hasAwards=false が全件返すのを修正

### DIFF
--- a/apps/api/src/__tests__/movie-search-has-awards.test.ts
+++ b/apps/api/src/__tests__/movie-search-has-awards.test.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {moviesRoutes} from '../routes/movies';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+type SearchResponse = {
+  movies: Array<{uid: string}>;
+  pagination: {totalCount: number};
+};
+
+async function createTestEnvironment(): Promise<Environment> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-test-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+
+  await database.insert(awardOrganizations).values({
+    uid: 'org-cannes',
+    name: 'Cannes Film Festival',
+  });
+  await database.insert(awardCategories).values({
+    uid: 'cat-palme',
+    organizationUid: 'org-cannes',
+    name: "Palme d'Or",
+  });
+  await database.insert(awardCeremonies).values([
+    {uid: 'cer-2022', organizationUid: 'org-cannes', year: 2022},
+    {uid: 'cer-2023', organizationUid: 'org-cannes', year: 2023},
+  ]);
+
+  await database.insert(movies).values([
+    {uid: 'movie-awarded-1', year: 2022},
+    {uid: 'movie-awarded-2', year: 2023},
+    {uid: 'movie-plain-1', year: 2022},
+    {uid: 'movie-plain-2', year: 2023},
+    {uid: 'movie-deleted', year: 2023, deletedAt: 1},
+  ]);
+
+  await database.insert(translations).values(
+    [
+      'movie-awarded-1',
+      'movie-awarded-2',
+      'movie-plain-1',
+      'movie-plain-2',
+      'movie-deleted',
+    ].map(uid => ({
+      resourceType: 'movie_title' as const,
+      resourceUid: uid,
+      languageCode: 'en',
+      content: `Title ${uid}`,
+      isDefault: 1,
+    })),
+  );
+
+  await database.insert(nominations).values([
+    {
+      uid: 'nom-1',
+      movieUid: 'movie-awarded-1',
+      ceremonyUid: 'cer-2022',
+      categoryUid: 'cat-palme',
+      isWinner: 1,
+    },
+    {
+      uid: 'nom-2',
+      movieUid: 'movie-awarded-2',
+      ceremonyUid: 'cer-2023',
+      categoryUid: 'cat-palme',
+      isWinner: 0,
+    },
+  ]);
+
+  return environment;
+}
+
+async function search(environment: Environment, queryString: string) {
+  const response = await moviesRoutes.request(
+    `/search${queryString}`,
+    {},
+    environment,
+  );
+  expect(response.status).toBe(200);
+  return (await response.json()) as SearchResponse;
+}
+
+describe('GET /movies/search hasAwards filter', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  it('hasAwards=false でノミネートのない映画だけを返す', async () => {
+    const body = await search(environment, '?hasAwards=false');
+
+    expect(body.movies.map(movie => movie.uid).toSorted()).toEqual([
+      'movie-plain-1',
+      'movie-plain-2',
+    ]);
+  });
+
+  it('hasAwards=false の totalCount はノミネートのない映画の件数', async () => {
+    const body = await search(environment, '?hasAwards=false');
+
+    expect(body.pagination.totalCount).toBe(2);
+  });
+
+  it('hasAwards=true でノミネートのある映画だけを返す', async () => {
+    const body = await search(environment, '?hasAwards=true');
+
+    expect(body.movies.map(movie => movie.uid).toSorted()).toEqual([
+      'movie-awarded-1',
+      'movie-awarded-2',
+    ]);
+  });
+
+  it('hasAwards=true の totalCount はノミネートのある映画の件数', async () => {
+    const body = await search(environment, '?hasAwards=true');
+
+    expect(body.pagination.totalCount).toBe(2);
+  });
+
+  it('hasAwards 未指定なら削除済み以外の全映画を返す', async () => {
+    const body = await search(environment, '');
+
+    expect(body.movies.map(movie => movie.uid).toSorted()).toEqual([
+      'movie-awarded-1',
+      'movie-awarded-2',
+      'movie-plain-1',
+      'movie-plain-2',
+    ]);
+  });
+});

--- a/apps/api/src/services/movies-service.ts
+++ b/apps/api/src/services/movies-service.ts
@@ -47,6 +47,24 @@ export class MoviesService extends BaseService {
       conditions.push(eq(movies.originalLanguage, language));
     }
 
+    if (hasAwards === true) {
+      conditions.push(sql`
+				EXISTS (
+				  SELECT 1
+				  FROM nominations
+				  WHERE nominations.movie_uid = movies.uid
+				)
+			`);
+    } else if (hasAwards === false) {
+      conditions.push(sql`
+				NOT EXISTS (
+				  SELECT 1
+				  FROM nominations
+				  WHERE nominations.movie_uid = movies.uid
+				)
+			`);
+    }
+
     // Base query with movie and translation data
     const baseQuery = this.database
       .select({
@@ -79,46 +97,12 @@ export class MoviesService extends BaseService {
     type BaseQuery = typeof baseQuery;
     type SearchResultRow = Awaited<ReturnType<BaseQuery['execute']>>[number];
 
-    // Build final query with conditions
-    const finalQuery = (() => {
-      if (String(hasAwards) === 'true') {
-        // Join nominations for awards filter
-        const joined = baseQuery.innerJoin(
-          nominations,
-          eq(nominations.movieUid, movies.uid),
-        );
+    const finalQuery = baseQuery.where(and(...conditions));
 
-        const filtered =
-          conditions.length > 0 ? joined.where(and(...conditions)) : joined;
-
-        return filtered.groupBy(movies.uid);
-      }
-
-      if (conditions.length > 0) {
-        return baseQuery.where(and(...conditions));
-      }
-
-      return baseQuery;
-    })();
-
-    // Build count query
-    const baseCountQuery = this.database
-      .select({count: sql`COUNT(DISTINCT movies.uid)`.as('count')})
-      .from(movies);
-
-    const countQuery = (() => {
-      const withAwards =
-        String(hasAwards) === 'true'
-          ? baseCountQuery.innerJoin(
-              nominations,
-              eq(nominations.movieUid, movies.uid),
-            )
-          : baseCountQuery;
-
-      return conditions.length > 0
-        ? withAwards.where(and(...conditions))
-        : withAwards;
-    })();
+    const countQuery = this.database
+      .select({count: sql`COUNT(*)`.as('count')})
+      .from(movies)
+      .where(and(...conditions));
 
     // Run search and count queries in parallel
     const [searchResults, totalCountResult] = await Promise.all([


### PR DESCRIPTION
`/movies/search?hasAwards=false` はサービス側が `hasAwards === true` のときしかフィルターしておらず、全件返していた。EXISTS / NOT EXISTS の条件に統一して false 側を実装し、true 側の innerJoin + groupBy も EXISTS に置き換えて検索・件数クエリを単純化した。実DB（libsql file: + migrate）でのフィルターテストを追加。