### PR TITLE
fix(front): Web Analyticsトークンの不一致を修正

### DIFF
--- a/apps/front/wrangler.jsonc
+++ b/apps/front/wrangler.jsonc
@@ -15,7 +15,7 @@
         "PUBLIC_API_URL": "https://shine-api.yuta25.workers.dev",
         "PUBLIC_TURNSTILE_SITE_KEY": "0x4AAAAAACBZwqj0sn-sCTK5",
         // Cloudflare Web Analytics の siteTag。beacon の token として使う
-        "PUBLIC_WEB_ANALYTICS_TOKEN": "9602f73a32304a60b7a170124731564a",
+        "PUBLIC_WEB_ANALYTICS_TOKEN": "c0dd704af80b4024bf03df608f5e6123",
       },
     },
   },


### PR DESCRIPTION
本番のビーコンは `9602f73a…` を送っていたが、ダッシュボードの Web Analytics サイトのトークンは `c0dd704a…` で、計測データが全て破棄されていた（7日間アクセス0の原因）。wrangler.jsonc のトークンを差し替え。