### PR TITLE
スクレイパーのリトライ統一とrelease_dateスキーマドリフトの解消

### DIFF
--- a/apps/api/src/services/admin-service.ts
+++ b/apps/api/src/services/admin-service.ts
@@ -14,7 +14,6 @@ import type {
   TMDBMovieData,
   TMDBTvData,
 } from '@shine/scrapers/common/tmdb-utilities';
-import {generateUUID} from '@shine/utils';
 import puppeteer from '@cloudflare/puppeteer';
 import {BaseService} from './base-service';
 import {
@@ -238,23 +237,10 @@ export class AdminService extends BaseService {
 
     movieValues.mediaType = detectedMediaType;
 
-    let newMovie: typeof movies.$inferSelect | undefined;
-
-    try {
-      [newMovie] = await this.database
-        .insert(movies)
-        .values(movieValues)
-        .returning();
-    } catch (error) {
-      if (this.isMissingColumnError(error, 'release_date')) {
-        newMovie = await this.insertMovieWithoutReleaseDate(
-          movieValues,
-          normalizedImdbId,
-        );
-      } else {
-        throw error;
-      }
-    }
+    const [newMovie] = await this.database
+      .insert(movies)
+      .values(movieValues)
+      .returning();
 
     if (!newMovie) {
       throw new Error('Failed to create movie');
@@ -1481,128 +1467,5 @@ export class AdminService extends BaseService {
     }
 
     return addedCount;
-  }
-
-  private isMissingColumnError(error: unknown, column: string): boolean {
-    if (!(error instanceof Error)) {
-      return false;
-    }
-
-    const message = error.message ?? '';
-    if (
-      message.includes(`column named ${column}`) ||
-      message.includes(`no such column: ${column}`) ||
-      message.includes(`has no column named ${column}`)
-    ) {
-      return true;
-    }
-
-    const cause = (error as {cause?: unknown}).cause;
-    if (cause) {
-      return this.isMissingColumnError(cause, column);
-    }
-
-    return false;
-  }
-
-  private async insertMovieWithoutReleaseDate(
-    movieValues: typeof movies.$inferInsert,
-    imdbId: string,
-  ): Promise<typeof movies.$inferSelect> {
-    const uid = generateUUID();
-    const now = Math.floor(Date.now() / 1000);
-    const originalLanguage = movieValues.originalLanguage ?? 'en';
-    /* eslint-disable unicorn/no-null -- libSQL raw args require null, not undefined */
-    const year = typeof movieValues.year === 'number' ? movieValues.year : null;
-    const tmdbIdValue =
-      typeof movieValues.tmdbId === 'number' ? movieValues.tmdbId : null;
-    /* eslint-enable unicorn/no-null */
-
-    type LibsqlExecuteResult = {
-      rows?: Array<Record<string, unknown>>;
-    };
-    type LibsqlClient = {
-      execute: (input: {
-        sql: string;
-        args?: unknown[];
-      }) => Promise<LibsqlExecuteResult>;
-    };
-
-    const client = (
-      this.database as unknown as {
-        session?: {client?: LibsqlClient};
-      }
-    )?.session?.client;
-
-    if (!client?.execute) {
-      throw new Error('Database client does not support raw execute');
-    }
-
-    await client.execute({
-      sql: `
-        INSERT INTO movies (
-          uid,
-          original_language,
-          year,
-          imdb_id,
-          tmdb_id,
-          created_at,
-          updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-      `,
-      args: [uid, originalLanguage, year, imdbId, tmdbIdValue, now, now],
-    });
-
-    const inserted = await client.execute({
-      sql: `
-        SELECT
-          uid,
-          original_language,
-          year,
-          imdb_id,
-          tmdb_id,
-          created_at,
-          updated_at
-        FROM movies
-        WHERE uid = ?
-        LIMIT 1
-      `,
-      args: [uid],
-    });
-
-    const row = inserted.rows?.[0];
-
-    if (!row || typeof row.uid !== 'string') {
-      throw new Error('Failed to create movie');
-    }
-
-    const result: Partial<typeof movies.$inferSelect> = {
-      uid: row.uid as string,
-      originalLanguage:
-        typeof row.original_language === 'string'
-          ? (row.original_language as string)
-          : originalLanguage,
-      imdbId:
-        typeof row.imdb_id === 'string' ? (row.imdb_id as string) : imdbId,
-      createdAt:
-        typeof row.created_at === 'number' ? (row.created_at as number) : now,
-      updatedAt:
-        typeof row.updated_at === 'number' ? (row.updated_at as number) : now,
-    };
-
-    if (typeof row.year === 'number') {
-      result.year = row.year as number;
-    }
-
-    if (typeof row.tmdb_id === 'number') {
-      result.tmdbId = row.tmdb_id as number;
-    }
-
-    if (typeof (row as Record<string, unknown>).release_date === 'string') {
-      result.releaseDate = (row as Record<string, unknown>)
-        .release_date as string;
-    }
-
-    return result as typeof movies.$inferSelect;
   }
 }

--- a/apps/scrapers/src/__tests__/fetch-utilities.test.ts
+++ b/apps/scrapers/src/__tests__/fetch-utilities.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   buildUrl,
+  FetchHttpError,
   fetchJsonWithRetry,
   fetchWithRetry,
 } from '../common/fetch-utilities';
@@ -146,6 +147,21 @@ describe('Fetch Utilities', () => {
       ).rejects.toThrow('HTTP error! Status: 404');
 
       expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should expose the HTTP status on the thrown error', async () => {
+      const mockErrorResponse = {
+        ok: false,
+        status: 404,
+      };
+      vi.mocked(fetch).mockResolvedValue(
+        mockErrorResponse as unknown as Response,
+      );
+
+      const promise = fetchWithRetry('https://example.com', {}, 3, 10);
+
+      await expect(promise).rejects.toBeInstanceOf(FetchHttpError);
+      await expect(promise).rejects.toMatchObject({status: 404});
     });
 
     it('should respect Retry-After header (seconds) on 429', async () => {

--- a/apps/scrapers/src/academy-awards.ts
+++ b/apps/scrapers/src/academy-awards.ts
@@ -18,6 +18,7 @@ import {
   savePosterUrls,
   saveTMDBId,
 } from './common/tmdb-utilities';
+import {fetchWithRetry} from './common/fetch-utilities';
 
 const WIKIPEDIA_BASE_URL = 'https://en.wikipedia.org';
 const ACADEMY_AWARDS_URL = `${WIKIPEDIA_BASE_URL}/wiki/Academy_Award_for_Best_Picture`;
@@ -145,14 +146,7 @@ async function getOrCreateCeremony(
 export async function scrapeAcademyAwards() {
   try {
     console.log('Fetching data from Wikipedia...');
-    const response = await fetch(ACADEMY_AWARDS_URL);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch Academy Awards page: ${response.status}`,
-      );
-    }
-
-    const html = await response.text();
+    const html = await fetchWithRetry(ACADEMY_AWARDS_URL);
     const $ = cheerio.load(html);
 
     const allTables = [...$('table.wikitable.sortable')];

--- a/apps/scrapers/src/cannes-film-festival.ts
+++ b/apps/scrapers/src/cannes-film-festival.ts
@@ -16,6 +16,7 @@ import {
   searchTMDBMovie,
   type TMDBConfiguration,
 } from './common/tmdb-utilities';
+import {FetchHttpError, fetchWithRetry} from './common/fetch-utilities';
 
 const WIKIPEDIA_BASE_URL = 'https://en.wikipedia.org';
 
@@ -437,14 +438,18 @@ async function scrapeYearPage(year: number): Promise<MovieInfo[]> {
   const yearUrl = `${WIKIPEDIA_BASE_URL}/wiki/${year}_Cannes_Film_Festival`;
 
   console.log(`Fetching ${yearUrl}...`);
-  const response = await fetch(yearUrl);
+  let html: string;
+  try {
+    html = await fetchWithRetry(yearUrl);
+  } catch (error) {
+    if (error instanceof FetchHttpError && error.status === 404) {
+      console.log(`Page not found for ${year}, skipping...`);
+      return [];
+    }
 
-  if (!response.ok) {
-    console.log(`Page not found for ${year}, skipping...`);
-    return [];
+    throw error;
   }
 
-  const html = await response.text();
   const $ = cheerio.load(html);
 
   const movies: MovieInfo[] = [];
@@ -1009,14 +1014,18 @@ async function fetchPalmeDOrWinner(
   const yearUrl = `${WIKIPEDIA_BASE_URL}/wiki/${year}_Cannes_Film_Festival`;
 
   console.log(`Fetching ${yearUrl}...`);
-  const response = await fetch(yearUrl);
+  let html: string;
+  try {
+    html = await fetchWithRetry(yearUrl);
+  } catch (error) {
+    if (error instanceof FetchHttpError && error.status === 404) {
+      console.log(`Page not found for ${year}, skipping...`);
+      return undefined;
+    }
 
-  if (!response.ok) {
-    console.log(`Page not found for ${year}, skipping...`);
-    return undefined;
+    throw error;
   }
 
-  const html = await response.text();
   const $ = cheerio.load(html);
 
   return findPalmeDOrWinner($, year);

--- a/apps/scrapers/src/common/fetch-utilities.ts
+++ b/apps/scrapers/src/common/fetch-utilities.ts
@@ -4,6 +4,13 @@
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 
+export class FetchHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`HTTP error! Status: ${status}`);
+    this.name = 'FetchHttpError';
+  }
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise(resolve => {
     setTimeout(resolve, ms);
@@ -102,7 +109,7 @@ export async function fetchWithRetry(
       continue;
     }
 
-    throw new Error(`HTTP error! Status: ${status}`);
+    throw new FetchHttpError(status);
   }
 }
 

--- a/apps/scrapers/src/japan-academy-awards.ts
+++ b/apps/scrapers/src/japan-academy-awards.ts
@@ -16,6 +16,7 @@ import {
   savePosterUrls,
   saveTMDBId,
 } from './common/tmdb-utilities';
+import {fetchJsonWithRetry, fetchWithRetry} from './common/fetch-utilities';
 
 const WIKIPEDIA_BASE_URL = 'https://ja.wikipedia.org';
 const MAIN_AWARDS_URL = 'https://ja.wikipedia.org/wiki/日本アカデミー賞作品賞';
@@ -212,13 +213,7 @@ export async function scrapeJapanAcademyAwardsYear(year: number) {
 
 async function scrapeMainAwardsPage() {
   console.log(`Fetching ${MAIN_AWARDS_URL}...`);
-  const response = await fetch(MAIN_AWARDS_URL);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch main awards page: ${response.status}`);
-  }
-
-  const html = await response.text();
+  const html = await fetchWithRetry(MAIN_AWARDS_URL);
   const $ = cheerio.load(html);
 
   const movies = extractAllMoviesFromMainPage($);
@@ -279,13 +274,7 @@ async function scrapeMainAwardsPage() {
 
 async function scrapeMainAwardsPageForYear(targetYear: number) {
   console.log(`Fetching ${MAIN_AWARDS_URL}...`);
-  const response = await fetch(MAIN_AWARDS_URL);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch main awards page: ${response.status}`);
-  }
-
-  const html = await response.text();
+  const html = await fetchWithRetry(MAIN_AWARDS_URL);
   const $ = cheerio.load(html);
 
   const movies = extractAllMoviesFromMainPage($).filter(
@@ -779,14 +768,9 @@ async function fetchEnglishTitleFromTMDB(
     findUrl.searchParams.append('api_key', TMDB_API_KEY_LOCAL);
     findUrl.searchParams.append('external_source', 'imdb_id');
 
-    const response = await fetch(findUrl.toString());
-    if (!response.ok) {
-      return undefined;
-    }
-
-    const data: {
+    const data = await fetchJsonWithRetry<{
       movie_results?: Array<{title: string}>;
-    } = await response.json();
+    }>(findUrl.toString());
     const movieResults = data.movie_results;
 
     if (!movieResults || movieResults.length === 0) {


### PR DESCRIPTION
残っていた技術負債2件。

**スクレイパーのfetchをfetchWithRetryに統一**
- academy-awards / cannes-film-festival / japan-academy-awards の素の`fetch`を`fetchWithRetry`/`fetchJsonWithRetry`に置き換え。タイムアウト15秒・429のRetry-After尊重・5xxの指数バックオフが全スクレイパーに効くようになった
- `FetchHttpError`（statusを持つエラー型）を追加し、カンヌの「年ページ404は正常スキップ」の挙動を維持

**release_dateスキーマドリフトの解消**
- 本番の`movies`テーブルにはマイグレーション0008の`release_date`列が実在しなかった（履歴上は適用済み扱い）。`ALTER TABLE movies ADD release_date text`を本番に手動適用して解消済み
- これで`admin-service`の`insertMovieWithoutReleaseDate`フォールバック（drizzle内部の`session.client`に到達して生SQLを実行する実装）が不要になったため削除（-120行）