### PR TITLE
賞の年別ページ /awards/:slug/:year を追加

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -279,6 +279,87 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /awards:
+    get:
+      summary: List award pages
+      description: Returns all award and editorial list pages that have nominations
+      operationId: listAwards
+      tags:
+        - Awards
+      security: []
+      responses:
+        '200':
+          description: Successfully retrieved award pages
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [awards]
+                properties:
+                  awards:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AwardSummary'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /awards/{slug}:
+    get:
+      summary: Get an award page
+      description: Returns the movies of an award or editorial list grouped by ceremony year
+      operationId: getAwardBySlug
+      tags:
+        - Awards
+      security: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully retrieved the award page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AwardDetail'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /awards/{slug}/{year}:
+    get:
+      summary: Get a single ceremony year of an award
+      description: Returns one ceremony year of a year-grouped award, with neighboring ceremony years for navigation
+      operationId: getAwardYear
+      tags:
+        - Awards
+      security: []
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: year
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Successfully retrieved the award year
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AwardYearDetail'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /movies/{id}/article-links:
     get:
       summary: Get movie article links
@@ -1758,6 +1839,127 @@ components:
         - number
         - year
 
+    AwardMovieEntry:
+      type: object
+      properties:
+        uid:
+          type: string
+          format: uuid
+        title:
+          type: string
+        movieYear:
+          type: integer
+        posterUrl:
+          type: string
+          format: uri
+        isWinner:
+          type: boolean
+      required:
+        - uid
+        - isWinner
+
+    AwardYearGroup:
+      type: object
+      properties:
+        year:
+          type: integer
+        ceremonyNumber:
+          type: integer
+        movies:
+          type: array
+          items:
+            $ref: '#/components/schemas/AwardMovieEntry'
+      required:
+        - year
+        - movies
+
+    AwardSummary:
+      type: object
+      properties:
+        slug:
+          type: string
+        name:
+          type: string
+        organization:
+          type: string
+        description:
+          type: string
+        grouping:
+          type: string
+          enum: [year, list]
+        movieCount:
+          type: integer
+        firstYear:
+          type: integer
+        lastYear:
+          type: integer
+      required:
+        - slug
+        - name
+        - organization
+        - description
+        - grouping
+        - movieCount
+        - firstYear
+        - lastYear
+
+    AwardDetail:
+      type: object
+      properties:
+        slug:
+          type: string
+        name:
+          type: string
+        organization:
+          type: string
+        description:
+          type: string
+        grouping:
+          type: string
+          enum: [year, list]
+        years:
+          type: array
+          items:
+            $ref: '#/components/schemas/AwardYearGroup'
+      required:
+        - slug
+        - name
+        - organization
+        - description
+        - grouping
+        - years
+
+    AwardYearDetail:
+      type: object
+      properties:
+        slug:
+          type: string
+        name:
+          type: string
+        organization:
+          type: string
+        description:
+          type: string
+        year:
+          type: integer
+        ceremonyNumber:
+          type: integer
+        movies:
+          type: array
+          items:
+            $ref: '#/components/schemas/AwardMovieEntry'
+        previousYear:
+          type: integer
+        nextYear:
+          type: integer
+      required:
+        - slug
+        - name
+        - organization
+        - description
+        - year
+        - movies
+
     AwardOrganization:
       type: object
       properties:
@@ -2849,6 +3051,8 @@ components:
             code: 'INTERNAL_ERROR'
 
 tags:
+  - name: Awards
+    description: Award and editorial list pages
   - name: Movies
     description: Movie information and search operations
   - name: Articles

--- a/apps/api/src/routes/awards.ts
+++ b/apps/api/src/routes/awards.ts
@@ -35,3 +35,24 @@ awardsRoutes.get('/:slug', async c => {
 
   return createCachedResponse(award, AWARDS_CACHE_TTL, {ETag: etag});
 });
+
+awardsRoutes.get('/:slug/:year', async c => {
+  const year = Number.parseInt(c.req.param('year'), 10);
+  if (!Number.isInteger(year)) {
+    return c.json({error: 'Award not found'}, 404);
+  }
+
+  const service = new AwardsService(c.env);
+  const award = await service.getAwardYear(c.req.param('slug'), year);
+
+  if (!award) {
+    return c.json({error: 'Award not found'}, 404);
+  }
+
+  const etag = createETag(award);
+  if (checkETag(c.req, etag)) {
+    return new Response(undefined, {status: 304, headers: {ETag: etag}});
+  }
+
+  return createCachedResponse(award, AWARDS_CACHE_TTL, {ETag: etag});
+});

--- a/apps/api/src/services/__tests__/awards-service.test.ts
+++ b/apps/api/src/services/__tests__/awards-service.test.ts
@@ -341,3 +341,120 @@ describe('awardSlugForOrganizationName', () => {
     expect(awardSlugForOrganizationName('Unknown Org')).toBeUndefined();
   });
 });
+
+describe('AwardsService.getAwardYear', () => {
+  let environment: Environment;
+  let database: TestDatabase;
+  let service: AwardsService;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+    service = new AwardsService(environment);
+  });
+
+  async function seedThreeCannesYears(): Promise<void> {
+    await seedCannes(database);
+    await seedCannesCeremony(database, 'ceremony-2019', 2019, 72);
+    await seedCannesCeremony(database, 'ceremony-2021', 2021, 74);
+    await seedCannesCeremony(database, 'ceremony-2023', 2023, 76);
+    await seedMovie(database, 'movie-a', 'A Nominee');
+    await seedMovie(database, 'movie-b', 'B Winner');
+    await seedMovie(database, 'movie-c', 'C Other Year');
+    await seedMovie(database, 'movie-d', 'D Other Year');
+    await database.insert(nominations).values([
+      {
+        movieUid: 'movie-a',
+        ceremonyUid: 'ceremony-2021',
+        categoryUid: 'cat-palme',
+      },
+      {
+        movieUid: 'movie-b',
+        ceremonyUid: 'ceremony-2021',
+        categoryUid: 'cat-palme',
+        isWinner: 1,
+      },
+      {
+        movieUid: 'movie-c',
+        ceremonyUid: 'ceremony-2019',
+        categoryUid: 'cat-palme',
+      },
+      {
+        movieUid: 'movie-d',
+        ceremonyUid: 'ceremony-2023',
+        categoryUid: 'cat-palme',
+      },
+    ]);
+  }
+
+  it('returns the requested year with the winner first', async () => {
+    await seedThreeCannesYears();
+
+    const result = await service.getAwardYear('palme-dor', 2021);
+
+    expect(result).toMatchObject({
+      slug: 'palme-dor',
+      year: 2021,
+      ceremonyNumber: 74,
+    });
+    expect(result?.movies.map(movie => movie.uid)).toEqual([
+      'movie-b',
+      'movie-a',
+    ]);
+  });
+
+  it('returns the neighboring ceremony years across gaps', async () => {
+    await seedThreeCannesYears();
+
+    const result = await service.getAwardYear('palme-dor', 2021);
+
+    expect(result?.previousYear).toBe(2019);
+    expect(result?.nextYear).toBe(2023);
+  });
+
+  it('leaves neighbors undefined at the range edges', async () => {
+    await seedThreeCannesYears();
+
+    const oldest = await service.getAwardYear('palme-dor', 2019);
+    const newest = await service.getAwardYear('palme-dor', 2023);
+
+    expect(oldest?.previousYear).toBeUndefined();
+    expect(oldest?.nextYear).toBe(2021);
+    expect(newest?.previousYear).toBe(2021);
+    expect(newest?.nextYear).toBeUndefined();
+  });
+
+  it('returns undefined for a year without a ceremony', async () => {
+    await seedThreeCannesYears();
+
+    const result = await service.getAwardYear('palme-dor', 2020);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for a list-grouping award', async () => {
+    await database.insert(awardOrganizations).values({
+      uid: 'org-1001',
+      name: '1001 Movies You Must See Before You Die',
+    });
+    await database.insert(awardCategories).values({
+      uid: 'cat-1001',
+      organizationUid: 'org-1001',
+      name: 'Selected Films',
+    });
+    await database.insert(awardCeremonies).values({
+      uid: 'ceremony-1001',
+      organizationUid: 'org-1001',
+      year: 2021,
+    });
+    await seedMovie(database, 'movie-a', 'Movie A');
+    await database.insert(nominations).values({
+      movieUid: 'movie-a',
+      ceremonyUid: 'ceremony-1001',
+      categoryUid: 'cat-1001',
+    });
+
+    const result = await service.getAwardYear('1001-movies', 2021);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -5,7 +5,12 @@ import {awardOrganizations} from '@shine/database/schema/award-organizations';
 import {movies} from '@shine/database/schema/movies';
 import {nominations} from '@shine/database/schema/nominations';
 import {BaseService} from './base-service';
-import type {AwardDetail, AwardSummary, AwardYearGroup} from '@shine/types';
+import type {
+  AwardDetail,
+  AwardSummary,
+  AwardYearDetail,
+  AwardYearGroup,
+} from '@shine/types';
 
 export function awardSlugForOrganizationName(
   organizationName: string,
@@ -215,6 +220,40 @@ export class AwardsService extends BaseService {
       description: definition.description,
       grouping: definition.grouping,
       years,
+    };
+  }
+
+  async getAwardYear(
+    slug: string,
+    year: number,
+  ): Promise<AwardYearDetail | undefined> {
+    const definition = awardPageDefinitions.find(entry => entry.slug === slug);
+    if (!definition || definition.grouping !== 'year') {
+      return undefined;
+    }
+
+    const award = await this.getAwardBySlug(slug);
+    if (!award) {
+      return undefined;
+    }
+
+    const index = award.years.findIndex(group => group.year === year);
+    if (index === -1) {
+      return undefined;
+    }
+
+    const group = award.years[index];
+
+    return {
+      slug: award.slug,
+      name: award.name,
+      organization: award.organization,
+      description: award.description,
+      year: group.year,
+      ceremonyNumber: group.ceremonyNumber,
+      movies: group.movies,
+      previousYear: award.years[index + 1]?.year,
+      nextYear: award.years[index - 1]?.year,
     };
   }
 

--- a/apps/front/app/routes.ts
+++ b/apps/front/app/routes.ts
@@ -9,6 +9,7 @@ export default [
   route('monthly', 'routes/monthly.tsx'),
   route('awards', 'routes/awards.tsx'),
   route('awards/:slug', 'routes/awards.$slug.tsx'),
+  route('awards/:slug/:year', 'routes/awards.$slug.$year.tsx'),
   route('robots.txt', 'routes/robots.tsx'),
   route('feed.xml', 'routes/feed.tsx'),
   route('sitemap.xml', 'routes/sitemap-index.tsx'),

--- a/apps/front/app/routes/awards.$slug.$year.test.tsx
+++ b/apps/front/app/routes/awards.$slug.$year.test.tsx
@@ -1,0 +1,193 @@
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import AwardYearPage, {loader, meta} from './awards.$slug.$year';
+import type {Route} from './+types/awards.$slug.$year';
+
+globalThis.fetch = vi.fn();
+
+const createMockContext = (apiUrl = 'http://localhost:8787') => ({
+  cloudflare: {
+    env: {
+      PUBLIC_API_URL: apiUrl,
+    },
+  },
+});
+
+const mockAwardYear = {
+  slug: 'palme-dor',
+  name: 'パルム・ドール',
+  organization: 'カンヌ国際映画祭',
+  description:
+    'カンヌ国際映画祭の最高賞パルム・ドールの歴代受賞作と公式出品作の一覧。',
+  year: 2023,
+  ceremonyNumber: 76,
+  movies: [
+    {
+      uid: 'movie-winner',
+      title: '落下の解剖学',
+      movieYear: 2023,
+      posterUrl: 'https://example.com/poster.jpg',
+      isWinner: true,
+    },
+    {
+      uid: 'movie-nominee',
+      title: '怪物',
+      movieYear: 2023,
+      posterUrl: undefined,
+      isWinner: false,
+    },
+  ],
+  previousYear: 2022,
+  nextYear: undefined,
+};
+
+const cast = <T,>(value?: unknown): T => value as T;
+
+type LoaderArguments = Route.LoaderArgs;
+type ComponentProperties = Route.ComponentProps;
+type LoaderData = ComponentProperties['loaderData'];
+
+const createLoaderArguments = (
+  context: unknown,
+  request: Request,
+  parameters: Record<string, string>,
+): LoaderArguments =>
+  cast<LoaderArguments>({
+    context,
+    request,
+    params: parameters,
+    matches: [],
+  });
+
+const createComponentProperties = (
+  loaderData: LoaderData,
+): ComponentProperties =>
+  cast<ComponentProperties>({
+    loaderData,
+    params: {slug: 'palme-dor', year: '2023'},
+    matches: [],
+  });
+
+describe('Award year page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loader', () => {
+    it('APIから年別の賞データを取得する', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockAwardYear,
+      } as Response);
+
+      const request = new Request(
+        'http://localhost:3000/awards/palme-dor/2023',
+      );
+      const result = await loader(
+        createLoaderArguments(createMockContext(), request, {
+          slug: 'palme-dor',
+          year: '2023',
+        }),
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8787/awards/palme-dor/2023',
+        expect.anything(),
+      );
+      expect(result.award.year).toBe(2023);
+    });
+
+    it('APIが404を返したら404 Responseをthrowする', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({error: 'Award not found'}),
+      } as Response);
+
+      const request = new Request(
+        'http://localhost:3000/awards/palme-dor/1800',
+      );
+      await expect(
+        loader(
+          createLoaderArguments(createMockContext(), request, {
+            slug: 'palme-dor',
+            year: '1800',
+          }),
+        ),
+      ).rejects.toMatchObject({status: 404});
+    });
+
+    it('数字4桁でないyearはAPIを呼ばず404をthrowする', async () => {
+      const mockFetch = vi.mocked(fetch);
+
+      const request = new Request('http://localhost:3000/awards/palme-dor/abc');
+      await expect(
+        loader(
+          createLoaderArguments(createMockContext(), request, {
+            slug: 'palme-dor',
+            year: 'abc',
+          }),
+        ),
+      ).rejects.toMatchObject({status: 404});
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('meta', () => {
+    it('回数付きのタイトルと受賞作入りのdescriptionを組み立てる', () => {
+      const result = meta(
+        cast<Route.MetaArgs>({data: {award: mockAwardYear, locale: 'ja'}}),
+      );
+
+      const title = result.find(
+        entry => 'title' in entry && typeof entry.title === 'string',
+      ) as {title: string} | undefined;
+      expect(title?.title).toBe(
+        'カンヌ国際映画祭 パルム・ドール 2023年（第76回） | SHINE',
+      );
+
+      const description = result.find(
+        entry => 'name' in entry && entry.name === 'description',
+      ) as {content: string} | undefined;
+      expect(description?.content).toContain('落下の解剖学');
+    });
+  });
+
+  describe('component', () => {
+    it('年・回数・作品リストを描画する', () => {
+      render(
+        <AwardYearPage
+          {...createComponentProperties(
+            cast<LoaderData>({award: mockAwardYear, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      expect(screen.getByText('2023')).toBeInTheDocument();
+      expect(screen.getByText('第76回')).toBeInTheDocument();
+      expect(screen.getByText('落下の解剖学')).toBeInTheDocument();
+      expect(screen.getByText('怪物')).toBeInTheDocument();
+      expect(screen.getByText('WINNER')).toBeInTheDocument();
+    });
+
+    it('前年へのリンクを表示し、次年がなければ出さない', () => {
+      render(
+        <AwardYearPage
+          {...createComponentProperties(
+            cast<LoaderData>({award: mockAwardYear, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      expect(screen.getByRole('link', {name: '← 2022'})).toHaveAttribute(
+        'href',
+        '/awards/palme-dor/2022',
+      );
+      expect(screen.queryByText(/2024 →/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/front/app/routes/awards.$slug.$year.tsx
+++ b/apps/front/app/routes/awards.$slug.$year.tsx
@@ -1,0 +1,169 @@
+import type {Route} from './+types/awards.$slug.$year';
+import {Masthead} from '@/components/editorial/masthead';
+import {SiteFooter} from '@/components/editorial/site-footer';
+import {DEFAULT_LOCALE, getLocaleFromRequest, type Locale} from '@/lib/locale';
+import {SITE_URL, buildSocialMeta} from '@/lib/meta';
+import {awardHeading} from './awards';
+import {MovieRow, type AwardMovieEntryData} from './awards.$slug';
+
+export type AwardYearDetailData = {
+  slug: string;
+  name: string;
+  organization: string;
+  description: string;
+  year: number;
+  ceremonyNumber?: number;
+  movies: AwardMovieEntryData[];
+  previousYear?: number;
+  nextYear?: number;
+};
+
+function buildItemList(award: AwardYearDetailData): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `${awardHeading(award)} ${award.year}`,
+    itemListElement: award.movies.map((movie, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${SITE_URL}/movies/${movie.uid}`,
+      name: movie.title,
+    })),
+  };
+}
+
+export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
+  const {award, locale} = data as {award: AwardYearDetailData; locale?: Locale};
+  const heading = awardHeading(award);
+  const title = award.ceremonyNumber
+    ? `${heading} ${award.year}年（第${award.ceremonyNumber}回） | SHINE`
+    : `${heading} ${award.year}年 | SHINE`;
+  const winner = award.movies.find(movie => movie.isWinner);
+  const description = winner?.title
+    ? `${award.year}年の${heading}。受賞は『${winner.title}』。ノミネート含む全${award.movies.length}作品の一覧。`
+    : `${award.year}年の${heading}の受賞・ノミネート作品一覧。`;
+
+  return [
+    ...buildSocialMeta({
+      title,
+      description,
+      path: `/awards/${award.slug}/${award.year}`,
+      locale: locale ?? DEFAULT_LOCALE,
+      imageUrl: `${SITE_URL}/og/home.png`,
+      largeImage: true,
+    }),
+    {'script:ld+json': buildItemList(award)},
+  ];
+}
+
+export async function loader({context, request, params}: Route.LoaderArgs) {
+  const locale = getLocaleFromRequest(request);
+  const apiUrl =
+    (context.cloudflare as {env?: {PUBLIC_API_URL?: string}}).env
+      ?.PUBLIC_API_URL || 'http://localhost:8787';
+
+  if (!/^\d{4}$/.test(params.year ?? '')) {
+    throw new Response('Not Found', {status: 404});
+  }
+
+  const response = await fetch(
+    `${apiUrl}/awards/${params.slug}/${params.year}`,
+    {signal: request.signal},
+  );
+
+  if (response.status === 404) {
+    throw new Response('Not Found', {status: 404});
+  }
+
+  if (!response.ok) {
+    throw new Response('Failed to load award year', {status: 502});
+  }
+
+  const award = (await response.json()) as AwardYearDetailData;
+  return {award, locale};
+}
+
+function YearNavLink({
+  slug,
+  year,
+  label,
+}: {
+  slug: string;
+  year?: number;
+  label: 'PREV' | 'NEXT';
+}) {
+  if (!year) {
+    return <span className="w-24" />;
+  }
+
+  const text = label === 'PREV' ? `← ${year}` : `${year} →`;
+  return (
+    <a
+      href={`/awards/${slug}/${year}`}
+      className={`w-24 font-mono text-xs text-ink no-underline ${
+        label === 'NEXT' ? 'text-right' : ''
+      }`}>
+      {text}
+    </a>
+  );
+}
+
+export default function AwardYearPage({loaderData}: Route.ComponentProps) {
+  const {award} = loaderData as {award: AwardYearDetailData};
+  const locale = 'ja';
+  const heading = awardHeading(award);
+
+  return (
+    <div className="min-h-screen bg-paper text-ink">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <Masthead locale={locale} />
+
+        <nav className="font-mono text-[10px] text-ink-muted mb-4">
+          <a href="/awards" className="text-ink-muted">
+            AWARDS & LISTS
+          </a>
+          {' / '}
+          <a href={`/awards/${award.slug}`} className="text-ink-muted">
+            {heading}
+          </a>
+        </nav>
+
+        <div className="flex items-baseline gap-3 mb-2">
+          <h1 className="font-display font-black text-4xl md:text-5xl tracking-[-0.06em] leading-none">
+            {award.year}
+          </h1>
+          {award.ceremonyNumber && (
+            <span className="font-mono text-xs text-ink-muted">
+              第{award.ceremonyNumber}回
+            </span>
+          )}
+        </div>
+        <p className="font-mono text-xs text-ink-muted mb-8">
+          {heading} / {award.movies.length} FILMS
+        </p>
+
+        <div className="border-t-[3px] border-ink">
+          {award.movies.map(movie => (
+            <MovieRow key={movie.uid} movie={movie} />
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between border-t-2 border-ink mt-8 pt-3">
+          <YearNavLink
+            slug={award.slug}
+            year={award.previousYear}
+            label="PREV"
+          />
+          <a
+            href={`/awards/${award.slug}`}
+            className="font-mono text-[10px] text-ink-muted no-underline">
+            ALL YEARS
+          </a>
+          <YearNavLink slug={award.slug} year={award.nextYear} label="NEXT" />
+        </div>
+
+        <SiteFooter locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/apps/front/app/routes/awards.$slug.tsx
+++ b/apps/front/app/routes/awards.$slug.tsx
@@ -112,7 +112,7 @@ export async function loader({context, request, params}: Route.LoaderArgs) {
   return {award, locale};
 }
 
-function MovieRow({movie}: {movie: AwardMovieEntryData}) {
+export function MovieRow({movie}: {movie: AwardMovieEntryData}) {
   const title = movie.title ?? 'Unknown Title';
 
   if (movie.isWinner) {
@@ -200,7 +200,11 @@ export default function AwardDetailPage({loaderData}: Route.ComponentProps) {
               <section key={group.year}>
                 <div className="flex items-baseline gap-3 border-t-[3px] border-ink pt-2 mb-2">
                   <h2 className="font-display font-black text-3xl md:text-4xl tracking-[-0.06em] leading-none">
-                    {group.year}
+                    <a
+                      href={`/awards/${award.slug}/${group.year}`}
+                      className="text-ink no-underline">
+                      {group.year}
+                    </a>
                   </h2>
                   {group.ceremonyNumber && (
                     <span className="font-mono text-[10px] text-ink-muted">

--- a/apps/front/app/routes/sitemap-awards.tsx
+++ b/apps/front/app/routes/sitemap-awards.tsx
@@ -2,34 +2,73 @@ import type {Route} from './+types/sitemap-awards';
 import {buildUrlSet, type SitemapEntry} from '@/lib/sitemap';
 import {resolveApiUrl, sitemapResponse} from '@/lib/sitemap-source';
 
-async function fetchAwardSlugs(
+type AwardListing = {
+  slug: string;
+  grouping: 'year' | 'list';
+};
+
+async function fetchAwards(
   context: unknown,
   signal?: AbortSignal,
-): Promise<string[]> {
+): Promise<AwardListing[]> {
   try {
     const response = await fetch(`${resolveApiUrl(context)}/awards`, {signal});
     if (!response.ok) {
       return [];
     }
 
-    const body = (await response.json()) as {awards?: Array<{slug: string}>};
-    return (body.awards ?? []).map(award => award.slug);
+    const body = (await response.json()) as {awards?: AwardListing[]};
+    return body.awards ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function fetchAwardYears(
+  context: unknown,
+  slug: string,
+  signal?: AbortSignal,
+): Promise<number[]> {
+  try {
+    const response = await fetch(`${resolveApiUrl(context)}/awards/${slug}`, {
+      signal,
+    });
+    if (!response.ok) {
+      return [];
+    }
+
+    const body = (await response.json()) as {years?: Array<{year: number}>};
+    return (body.years ?? []).map(group => group.year);
   } catch {
     return [];
   }
 }
 
 export async function loader({context, request}: Route.LoaderArgs) {
-  const slugs = await fetchAwardSlugs(context, request.signal);
+  const awards = await fetchAwards(context, request.signal);
+  const yearAwards = awards.filter(award => award.grouping === 'year');
+  const yearLists = await Promise.all(
+    yearAwards.map(async award => ({
+      slug: award.slug,
+      years: await fetchAwardYears(context, award.slug, request.signal),
+    })),
+  );
+
   const entries: SitemapEntry[] = [
     {path: '/awards', changefreq: 'weekly'},
     {path: '/daily', changefreq: 'daily'},
     {path: '/weekly', changefreq: 'weekly'},
     {path: '/monthly', changefreq: 'monthly'},
-    ...slugs.map(slug => ({
-      path: `/awards/${slug}`,
+    ...awards.map(award => ({
+      path: `/awards/${award.slug}`,
       changefreq: 'weekly' as const,
     })),
+    ...yearLists.flatMap(({slug, years}) =>
+      years.map(year => ({
+        path: `/awards/${slug}/${year}`,
+        changefreq: 'monthly' as const,
+      })),
+    ),
   ];
 
   return sitemapResponse(buildUrlSet(entries));

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -88,6 +88,18 @@ export type AwardDetail = {
   years: AwardYearGroup[];
 };
 
+export type AwardYearDetail = {
+  slug: string;
+  name: string;
+  organization: string;
+  description: string;
+  year: number;
+  ceremonyNumber: number | undefined;
+  movies: AwardMovieEntry[];
+  previousYear: number | undefined;
+  nextYear: number | undefined;
+};
+
 export type AwardSummary = {
   slug: string;
   name: string;


### PR DESCRIPTION
カンヌ・アカデミー賞・日本アカデミー賞（yearグルーピングの3賞）に開催年ごとのページを追加。「カンヌ 2023」のような年指定の検索クエリの受け皿になる。

- API: `GET /awards/:slug/:year`。その年の受賞・ノミネート一覧（受賞作先頭）と、開催がなかった年を飛ばした前後の開催年を返す。listグルーピングの賞は404
- front: `/awards/:slug/:year` ページ。回数表示・前後年ナビ・ALL YEARSリンク付き。metaは「パルム・ドール 2023年（第76回）」形式で、descriptionに受賞作タイトルを含める。ItemListのJSON-LD入り
- 既存の賞ページの年見出しを年別ページへのリンクに変更
- sitemap/awards.xml に年別ページを登録（約220ページ）
- openapi.yml に従来未記載だった公開 /awards 系3エンドポイントをまとめて記載