### PR TITLE
映画詳細のAwardTreeヘッダを年別ページへリンク

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -1976,6 +1976,9 @@ components:
         slug:
           type: [string, 'null']
           description: Slug of the award page on the frontend (/awards/{slug}), if one exists
+        hasYearPages:
+          type: boolean
+          description: Whether per-year pages (/awards/{slug}/{year}) exist for this organization's award
       required:
         - uid
         - name

--- a/apps/api/src/services/__tests__/awards-service.test.ts
+++ b/apps/api/src/services/__tests__/awards-service.test.ts
@@ -12,7 +12,10 @@ import {posterUrls} from '@shine/database/schema/poster-urls';
 import {translations} from '@shine/database/schema/translations';
 import {migrate} from 'drizzle-orm/libsql/migrator';
 import {beforeEach, describe, expect, it} from 'vitest';
-import {AwardsService, awardSlugForOrganizationName} from '../awards-service';
+import {
+  AwardsService,
+  awardPageLinkForOrganizationName,
+} from '../awards-service';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(
@@ -330,15 +333,26 @@ describe('AwardsService.listAwards', () => {
   });
 });
 
-describe('awardSlugForOrganizationName', () => {
-  it('returns the slug for an organization with an award page', () => {
-    expect(awardSlugForOrganizationName('Cannes Film Festival')).toBe(
-      'palme-dor',
-    );
+describe('awardPageLinkForOrganizationName', () => {
+  it('returns the slug and year-page availability for a year-grouped award', () => {
+    expect(awardPageLinkForOrganizationName('Cannes Film Festival')).toEqual({
+      slug: 'palme-dor',
+      hasYearPages: true,
+    });
   });
 
-  it('returns undefined for an organization without an award page', () => {
-    expect(awardSlugForOrganizationName('Unknown Org')).toBeUndefined();
+  it('returns hasYearPages false for a list-grouped award', () => {
+    expect(awardPageLinkForOrganizationName('Variety')).toEqual({
+      slug: 'variety-top-100',
+      hasYearPages: false,
+    });
+  });
+
+  it('returns no slug for an organization without an award page', () => {
+    expect(awardPageLinkForOrganizationName('Unknown Org')).toEqual({
+      slug: undefined,
+      hasYearPages: false,
+    });
   });
 });
 

--- a/apps/api/src/services/__tests__/movies-service-nominations.test.ts
+++ b/apps/api/src/services/__tests__/movies-service-nominations.test.ts
@@ -82,6 +82,7 @@ describe('MoviesService.getMovieDetails nominations', () => {
     expect(details?.nominations[0].organization.slug).toBe(
       'academy-best-picture',
     );
+    expect(details?.nominations[0].organization.hasYearPages).toBe(true);
   });
 
   it('leaves the slug undefined for organizations without an award page', async () => {
@@ -91,5 +92,6 @@ describe('MoviesService.getMovieDetails nominations', () => {
     const details = await service.getMovieDetails('movie-a', 'en');
 
     expect(details?.nominations[0].organization.slug).toBeUndefined();
+    expect(details?.nominations[0].organization.hasYearPages).toBe(false);
   });
 });

--- a/apps/api/src/services/__tests__/selections-service.test.ts
+++ b/apps/api/src/services/__tests__/selections-service.test.ts
@@ -243,6 +243,7 @@ describe('SelectionsService nomination payload', () => {
     );
 
     expect(movie.nominations[0].organization.slug).toBe('palme-dor');
+    expect(movie.nominations[0].organization.hasYearPages).toBe(true);
   });
 
   it('leaves the slug undefined for organizations without an award page', async () => {

--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -12,12 +12,18 @@ import type {
   AwardYearGroup,
 } from '@shine/types';
 
-export function awardSlugForOrganizationName(
-  organizationName: string,
-): string | undefined {
-  return awardPageDefinitions.find(
-    definition => definition.organizationName === organizationName,
-  )?.slug;
+export function awardPageLinkForOrganizationName(organizationName: string): {
+  slug: string | undefined;
+  hasYearPages: boolean;
+} {
+  const definition = awardPageDefinitions.find(
+    entry => entry.organizationName === organizationName,
+  );
+
+  return {
+    slug: definition?.slug,
+    hasYearPages: definition?.grouping === 'year',
+  };
 }
 
 type AwardPageDefinition = {

--- a/apps/api/src/services/movies-service.ts
+++ b/apps/api/src/services/movies-service.ts
@@ -14,7 +14,7 @@ import {
   getMovieCacheKeysForAllLocales,
   normalizeCacheLocale,
 } from '../utils/cache';
-import {awardSlugForOrganizationName} from './awards-service';
+import {awardPageLinkForOrganizationName} from './awards-service';
 import {BaseService} from './base-service';
 import type {MovieSelection, SearchOptions} from '@shine/types';
 
@@ -322,7 +322,7 @@ export class MoviesService extends BaseService {
           uid: nom.organizationUid,
           name: nom.organizationName,
           shortName: nom.organizationShortName ?? undefined,
-          slug: awardSlugForOrganizationName(nom.organizationName),
+          ...awardPageLinkForOrganizationName(nom.organizationName),
         },
       })),
       articleLinks: topArticles.map(article => ({

--- a/apps/api/src/services/selections-service.ts
+++ b/apps/api/src/services/selections-service.ts
@@ -24,7 +24,7 @@ import {
   normalizeCacheLocale,
 } from '../utils/cache';
 import {simpleHash} from '../utils/hash';
-import {awardSlugForOrganizationName} from './awards-service';
+import {awardPageLinkForOrganizationName} from './awards-service';
 import {BaseService} from './base-service';
 import type {DateSeedOptions, MovieSelection} from '@shine/types';
 
@@ -541,7 +541,7 @@ export class SelectionsService extends BaseService {
           uid: nom.organizationUid,
           name: nom.organizationName,
           shortName: nom.organizationShortName ?? undefined,
-          slug: awardSlugForOrganizationName(nom.organizationName),
+          ...awardPageLinkForOrganizationName(nom.organizationName),
         },
       })),
       articleLinks: topArticles.map(article => ({

--- a/apps/front/app/components/editorial/award-tree.test.tsx
+++ b/apps/front/app/components/editorial/award-tree.test.tsx
@@ -14,6 +14,7 @@ const noms: AwardNomination[] = [
       name: 'Some New Award',
       shortName: 'SNA',
       slug: 'some-new-award',
+      hasYearPages: true,
     },
   },
   {
@@ -26,6 +27,7 @@ const noms: AwardNomination[] = [
       name: 'Some New Award',
       shortName: 'SNA',
       slug: 'some-new-award',
+      hasYearPages: true,
     },
   },
 ];
@@ -48,11 +50,36 @@ describe('AwardTree', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('slugを持つ組織のヘッダは /awards/:slug へリンクする', () => {
+  it('年別ページを持つ組織のヘッダは /awards/:slug/:year へリンクする', () => {
     render(<AwardTree nominations={noms} />);
     expect(screen.getByRole('link', {name: /SNA · 1995/})).toHaveAttribute(
       'href',
-      '/awards/some-new-award',
+      '/awards/some-new-award/1995',
+    );
+  });
+
+  it('年別ページがない組織のヘッダは /awards/:slug へリンクする', () => {
+    render(
+      <AwardTree
+        nominations={[
+          {
+            uid: 'n4',
+            isWinner: false,
+            category: {name: 'Top 100'},
+            ceremony: {uid: 'c3', year: 2022},
+            organization: {
+              uid: 'o3',
+              name: 'Variety',
+              slug: 'variety-top-100',
+              hasYearPages: false,
+            },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('link', {name: /Variety · 2022/})).toHaveAttribute(
+      'href',
+      '/awards/variety-top-100',
     );
   });
 

--- a/apps/front/app/components/editorial/award-tree.tsx
+++ b/apps/front/app/components/editorial/award-tree.tsx
@@ -3,7 +3,13 @@ export type AwardNomination = {
   isWinner: boolean;
   category: {name: string};
   ceremony: {uid: string; year: number; number?: number};
-  organization: {uid: string; name: string; shortName?: string; slug?: string};
+  organization: {
+    uid: string;
+    name: string;
+    shortName?: string;
+    slug?: string;
+    hasYearPages?: boolean;
+  };
 };
 
 type Grouped = {
@@ -47,9 +53,13 @@ export function AwardTree({nominations}: {nominations: AwardNomination[]}) {
                 group.organization.shortName ?? group.organization.name
               } · ${ceremony.year}`;
               const slug = group.organization.slug;
-              return slug ? (
+              const href =
+                slug && group.organization.hasYearPages
+                  ? `/awards/${slug}/${ceremony.year}`
+                  : slug && `/awards/${slug}`;
+              return href ? (
                 <a
-                  href={`/awards/${slug}`}
+                  href={href}
                   className="block bg-ink px-3 py-1 font-display text-xs font-extrabold uppercase text-paper no-underline">
                   {headerText}
                 </a>

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -50,6 +50,7 @@ export type MovieSelection = {
       name: string;
       shortName: string | undefined;
       slug: string | undefined;
+      hasYearPages: boolean;
     };
   }>;
   articleLinks: Array<{


### PR DESCRIPTION
映画詳細ページの受賞ツリーの「組織 · 年」ヘッダを、PR #267で追加した年別ページ（/awards/:slug/:year）に向ける。

- APIのnominationの`organization`に`hasYearPages`を追加（賞ページ定義のgroupingから導出）。ヘルパーは`awardPageLinkForOrganizationName`に統合し、旧`awardSlugForOrganizationName`は削除
- AwardTreeは`hasYearPages`がtrueなら`/awards/:slug/:ceremony年`へ、falseなら従来どおり`/awards/:slug`へリンク（Variety等のlist系は年別ページがないため）