### PR TITLE
カンヌのceremonyNumber計算を修正

### DIFF
--- a/apps/scrapers/src/__tests__/cannes-ceremony-number.test.ts
+++ b/apps/scrapers/src/__tests__/cannes-ceremony-number.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from 'vitest';
+import {cannesCeremonyNumber} from '../cannes-film-festival';
+
+describe('cannesCeremonyNumber', () => {
+  it('第1回は1946年', () => {
+    expect(cannesCeremonyNumber(1946)).toBe(1);
+  });
+
+  it('第2回は1947年', () => {
+    expect(cannesCeremonyNumber(1947)).toBe(2);
+  });
+
+  it('1948年は未開催で第3回は1949年', () => {
+    expect(cannesCeremonyNumber(1949)).toBe(3);
+  });
+
+  it('1950年は未開催で第4回は1951年', () => {
+    expect(cannesCeremonyNumber(1951)).toBe(4);
+  });
+
+  it('2023年は第76回', () => {
+    expect(cannesCeremonyNumber(2023)).toBe(76);
+  });
+
+  it('中止された2020年も第73回として数える', () => {
+    expect(cannesCeremonyNumber(2020)).toBe(73);
+  });
+
+  it('未開催年はundefined', () => {
+    expect(cannesCeremonyNumber(1948)).toBeUndefined();
+    expect(cannesCeremonyNumber(1950)).toBeUndefined();
+    expect(cannesCeremonyNumber(1945)).toBeUndefined();
+  });
+});

--- a/apps/scrapers/src/cannes-film-festival.ts
+++ b/apps/scrapers/src/cannes-film-festival.ts
@@ -187,6 +187,23 @@ async function fetchMainData(): Promise<MainData> {
   return mainData;
 }
 
+// 1946年開始、1948年と1950年は未開催（2020年は中止だが第73回として数える）
+export function cannesCeremonyNumber(year: number): number | undefined {
+  if (year === 1946 || year === 1947) {
+    return year - 1945;
+  }
+
+  if (year === 1949) {
+    return 3;
+  }
+
+  if (year >= 1951) {
+    return year - 1947;
+  }
+
+  return undefined;
+}
+
 async function getOrCreateCeremony(
   year: number,
   organizationUid: string,
@@ -197,12 +214,12 @@ async function getOrCreateCeremony(
     .values({
       organizationUid,
       year,
-      ceremonyNumber: year - 1946 + 1, // カンヌ映画祭は1946年開始
+      ceremonyNumber: cannesCeremonyNumber(year),
     })
     .onConflictDoUpdate({
       target: [awardCeremonies.organizationUid, awardCeremonies.year],
       set: {
-        ceremonyNumber: year - 1946 + 1,
+        ceremonyNumber: cannesCeremonyNumber(year),
       },
     })
     .returning();


### PR DESCRIPTION
年別ページで「2023年 第78回」と表示されていた（実際は第76回）。スクレイパーの`year - 1945`計算が1948年・1950年の未開催をカウントしていたのが原因。

- `cannesCeremonyNumber()`に切り出して未開催年を考慮（中止の2020年は第73回として数える公式カウントに一致）
- 本番データは修正済み（1951年以降の75件を`year - 1947`に一括更新。unique制約があるため負数経由の2段階更新）
- ついでに検算したアカデミー賞・日本アカデミー賞は全件正しく、NULLだった2026年の2件（第98回・第49回）だけ補完した