### PR TITLE
重い公開エンドポイントをEdgeCacheに乗せてTurso読み取りを削減

### DIFF
--- a/apps/api/src/routes/awards.ts
+++ b/apps/api/src/routes/awards.ts
@@ -10,7 +10,7 @@ import {
 
 export const awardsRoutes = new Hono<{Bindings: Environment}>();
 
-const AWARDS_CACHE_TTL = 21_600;
+const AWARDS_CACHE_TTL = 86_400;
 const cache = new EdgeCache();
 
 awardsRoutes.get('/', async c => {

--- a/apps/api/src/routes/awards.ts
+++ b/apps/api/src/routes/awards.ts
@@ -1,16 +1,28 @@
 import type {Environment} from '@shine/database';
 import {Hono} from 'hono';
 import {AwardsService} from '../services';
-import {checkETag, createCachedResponse, createETag} from '../utils/cache';
+import {
+  checkETag,
+  createCachedResponse,
+  createETag,
+  EdgeCache,
+} from '../utils/cache';
 
 export const awardsRoutes = new Hono<{Bindings: Environment}>();
 
 const AWARDS_CACHE_TTL = 21_600;
+const cache = new EdgeCache();
 
 awardsRoutes.get('/', async c => {
-  const service = new AwardsService(c.env);
-  const awards = await service.listAwards();
-  const result = {awards};
+  const cacheKey = 'awards:list:v1';
+  const cached = await cache.get(cacheKey);
+  const result = (cached?.data as {awards: unknown[]} | undefined) ?? {
+    awards: await new AwardsService(c.env).listAwards(),
+  };
+
+  if (!cached) {
+    await cache.set(cacheKey, result, AWARDS_CACHE_TTL);
+  }
 
   const etag = createETag(result);
   if (checkETag(c.req, etag)) {
@@ -21,11 +33,18 @@ awardsRoutes.get('/', async c => {
 });
 
 awardsRoutes.get('/:slug', async c => {
-  const service = new AwardsService(c.env);
-  const award = await service.getAwardBySlug(c.req.param('slug'));
+  const slug = c.req.param('slug');
+  const cacheKey = `awards:${slug}:v1`;
+  const cached = await cache.get(cacheKey);
+  const award =
+    cached?.data ?? (await new AwardsService(c.env).getAwardBySlug(slug));
 
   if (!award) {
     return c.json({error: 'Award not found'}, 404);
+  }
+
+  if (!cached) {
+    await cache.set(cacheKey, award, AWARDS_CACHE_TTL);
   }
 
   const etag = createETag(award);
@@ -42,11 +61,18 @@ awardsRoutes.get('/:slug/:year', async c => {
     return c.json({error: 'Award not found'}, 404);
   }
 
-  const service = new AwardsService(c.env);
-  const award = await service.getAwardYear(c.req.param('slug'), year);
+  const slug = c.req.param('slug');
+  const cacheKey = `awards:${slug}:${year}:v1`;
+  const cached = await cache.get(cacheKey);
+  const award =
+    cached?.data ?? (await new AwardsService(c.env).getAwardYear(slug, year));
 
   if (!award) {
     return c.json({error: 'Award not found'}, 404);
+  }
+
+  if (!cached) {
+    await cache.set(cacheKey, award, AWARDS_CACHE_TTL);
   }
 
   const etag = createETag(award);

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -219,6 +219,12 @@ moviesRoutes.get('/:id/related', async c => {
         ? Math.min(limitParameter, 12)
         : 6;
 
+    const cacheKey = `movie:${movieId}:related:${locale}:${limit}:v1`;
+    const cached = await cache.get(cacheKey);
+    if (cached) {
+      return c.json(cached.data as Record<string, unknown>);
+    }
+
     const target = await database
       .select({uid: movies.uid, year: movies.year})
       .from(movies)
@@ -281,10 +287,10 @@ moviesRoutes.get('/:id/related', async c => {
       posterUrl: row.posterUrl ?? undefined,
     }));
 
-    return createCachedResponse(
-      {movies: relatedMovies},
-      getCacheTTL.movie.full,
-    );
+    const result = {movies: relatedMovies};
+    await cache.set(cacheKey, result, getCacheTTL.movie.full);
+
+    return createCachedResponse(result, getCacheTTL.movie.full);
   } catch (error) {
     console.error('Error fetching related movies:', error);
     return c.json({error: 'Internal server error'}, 500);

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -288,9 +288,9 @@ moviesRoutes.get('/:id/related', async c => {
     }));
 
     const result = {movies: relatedMovies};
-    await cache.set(cacheKey, result, getCacheTTL.movie.full);
+    await cache.set(cacheKey, result, getCacheTTL.movie.related);
 
-    return createCachedResponse(result, getCacheTTL.movie.full);
+    return createCachedResponse(result, getCacheTTL.movie.related);
   } catch (error) {
     console.error('Error fetching related movies:', error);
     return c.json({error: 'Internal server error'}, 500);

--- a/apps/api/src/routes/selections.ts
+++ b/apps/api/src/routes/selections.ts
@@ -22,11 +22,14 @@ import {
   checkETag,
   createCachedResponse,
   createETag,
+  EdgeCache,
   getCacheTTL,
 } from '../utils/cache';
 import {simpleHash} from '../utils/hash';
 
 export const selectionsRoutes = new Hono<{Bindings: Environment}>();
+
+const historyCache = new EdgeCache();
 
 function getSelectionDate(
   date: Date,
@@ -244,6 +247,12 @@ selectionsRoutes.get('/selections/:type/history', async c => {
         : 14;
     const today = getSelectionDate(new Date(), type);
 
+    const cacheKey = `selections:history:${type}:${locale}:${limit}:${today}:v1`;
+    const cached = await historyCache.get(cacheKey);
+    if (cached) {
+      return c.json(cached.data as Record<string, unknown>);
+    }
+
     const rows = await database
       .select({
         uid: movies.uid,
@@ -282,6 +291,8 @@ selectionsRoutes.get('/selections/:type/history', async c => {
       year: row.year ?? undefined,
       selectionDate: row.selectionDate,
     }));
+
+    await historyCache.set(cacheKey, {items}, getCacheTTL.selections[type]);
 
     return createCachedResponse({items}, getCacheTTL.selections[type]);
   } catch (error) {

--- a/apps/api/src/utils/cache.ts
+++ b/apps/api/src/utils/cache.ts
@@ -227,6 +227,7 @@ export const getCacheTTL = {
   movie: {
     basic: 3600, // 1 hour
     full: 86_400, // 24 hours
+    related: 604_800, // 1 week
   },
   search: {
     common: 1800, // 30 minutes


### PR DESCRIPTION
Tursoの月間読み取りが450M/500M（90%）に達していた対応。shine単体で436M行。overage無効なので枯渇するとサイトのDB読み取りが月末まで全部失敗する。

原因: `createCachedResponse`はCache-Controlヘッダを付けるだけで、Workersのレスポンスはエッジにキャッシュされない。以下の5ルートが毎リクエストDB直撃だった（Tursoはスキャン行数で課金）。

- `/movies/:id/related` — 同カテゴリのノミネート全走査＋行ごとサブクエリ×3。1001 Movies収録作だと1リクエスト数千行。Googlebotが映画ページ約3,500件をクロール中で最大の発生源
- `/awards` `/awards/:slug` `/awards/:slug/:year` — 賞の全ノミネート走査。年別ページ220件をsitemapに載せた直後からクロール対象
- `/selections/:type/history` — アーカイブ・RSSから定期的に叩かれる

それぞれ既存の`EdgeCache`（Cache API）パターンでキャッシュ（awards 6h・related 24h・history typeごとのTTL、historyのキーは日付入りで日次自動失効）。賞データの更新はキャッシュを能動パージしないが、6hの遅延は許容範囲。