### PR TITLE
重いエンドポイントのキャッシュをWorkers KVに移行

### DIFF
--- a/apps/api/src/routes/awards.ts
+++ b/apps/api/src/routes/awards.ts
@@ -11,9 +11,9 @@ import {
 export const awardsRoutes = new Hono<{Bindings: Environment}>();
 
 const AWARDS_CACHE_TTL = 604_800;
-const cache = new EdgeCache();
 
 awardsRoutes.get('/', async c => {
+  const cache = new EdgeCache(undefined, c.env.CACHE_KV);
   const cacheKey = 'awards:list:v1';
   const cached = await cache.get(cacheKey);
   const result = (cached?.data as {awards: unknown[]} | undefined) ?? {
@@ -33,6 +33,7 @@ awardsRoutes.get('/', async c => {
 });
 
 awardsRoutes.get('/:slug', async c => {
+  const cache = new EdgeCache(undefined, c.env.CACHE_KV);
   const slug = c.req.param('slug');
   const cacheKey = `awards:${slug}:v1`;
   const cached = await cache.get(cacheKey);
@@ -56,6 +57,7 @@ awardsRoutes.get('/:slug', async c => {
 });
 
 awardsRoutes.get('/:slug/:year', async c => {
+  const cache = new EdgeCache(undefined, c.env.CACHE_KV);
   const year = Number.parseInt(c.req.param('year'), 10);
   if (!Number.isInteger(year)) {
     return c.json({error: 'Award not found'}, 404);

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -220,8 +220,9 @@ moviesRoutes.get('/:id/related', async c => {
         ? Math.min(limitParameter, 12)
         : 6;
 
+    const relatedCache = new EdgeCache(undefined, c.env.CACHE_KV);
     const cacheKey = `movie:${movieId}:related:${locale}:${limit}:v1`;
-    const cached = await cache.get(cacheKey);
+    const cached = await relatedCache.get(cacheKey);
     if (cached) {
       return c.json(cached.data as Record<string, unknown>);
     }
@@ -304,7 +305,7 @@ moviesRoutes.get('/:id/related', async c => {
     });
 
     const result = {movies: relatedMovies};
-    await cache.set(cacheKey, result, getCacheTTL.movie.related);
+    await relatedCache.set(cacheKey, result, getCacheTTL.movie.related);
 
     return createCachedResponse(result, getCacheTTL.movie.related);
   } catch (error) {

--- a/apps/api/src/routes/selections.ts
+++ b/apps/api/src/routes/selections.ts
@@ -29,8 +29,6 @@ import {simpleHash} from '../utils/hash';
 
 export const selectionsRoutes = new Hono<{Bindings: Environment}>();
 
-const historyCache = new EdgeCache();
-
 function getSelectionDate(
   date: Date,
   type: 'daily' | 'weekly' | 'monthly',
@@ -247,6 +245,7 @@ selectionsRoutes.get('/selections/:type/history', async c => {
         : 14;
     const today = getSelectionDate(new Date(), type);
 
+    const historyCache = new EdgeCache(undefined, c.env.CACHE_KV);
     const cacheKey = `selections:history:${type}:${locale}:${limit}:${today}:v1`;
     const cached = await historyCache.get(cacheKey);
     if (cached) {

--- a/apps/api/src/utils/__tests__/edge-cache.test.ts
+++ b/apps/api/src/utils/__tests__/edge-cache.test.ts
@@ -65,3 +65,59 @@ describe('EdgeCache', () => {
     expect(ja?.data).toEqual({title: '映画'});
   });
 });
+
+function createKvStub() {
+  const store = new Map<string, {value: string; expirationTtl?: number}>();
+  return {
+    store,
+    async get(key: string) {
+      const entry = store.get(key);
+      // eslint-disable-next-line unicorn/no-null -- KVの実APIはミス時にnullを返す
+      return entry ? (JSON.parse(entry.value) as unknown) : null;
+    },
+    async put(key: string, value: string, options?: {expirationTtl?: number}) {
+      store.set(key, {value, expirationTtl: options?.expirationTtl});
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  };
+}
+
+describe('EdgeCache with KV backend', () => {
+  it('stores and returns data through KV', async () => {
+    const kv = createKvStub();
+    const cache = new EdgeCache(undefined, kv as unknown as KVNamespace);
+
+    await cache.set('kv:key', {value: 42}, 600);
+    const cached = await cache.get('kv:key');
+
+    expect(cached?.data).toEqual({value: 42});
+  });
+
+  it('passes the TTL to KV as expirationTtl', async () => {
+    const kv = createKvStub();
+    const cache = new EdgeCache(undefined, kv as unknown as KVNamespace);
+
+    await cache.set('kv:ttl', {value: 1}, 600);
+
+    expect(kv.store.get('kv:ttl')?.expirationTtl).toBe(600);
+  });
+
+  it('returns undefined for keys that were never set', async () => {
+    const kv = createKvStub();
+    const cache = new EdgeCache(undefined, kv as unknown as KVNamespace);
+
+    expect(await cache.get('kv:none')).toBeUndefined();
+  });
+
+  it('deletes cached entries', async () => {
+    const kv = createKvStub();
+    const cache = new EdgeCache(undefined, kv as unknown as KVNamespace);
+
+    await cache.set('kv:gone', {value: 1}, 600);
+    await cache.delete('kv:gone');
+
+    expect(await cache.get('kv:gone')).toBeUndefined();
+  });
+});

--- a/apps/api/src/utils/cache.ts
+++ b/apps/api/src/utils/cache.ts
@@ -11,12 +11,17 @@ export type CacheMetrics = {
 };
 
 export class EdgeCache {
-  private readonly cache: Cache;
+  private readonly cacheStorage?: Cache;
+  private readonly kv?: KVNamespace;
   private readonly metrics: CacheMetrics = {hits: 0, misses: 0, hitRate: 0};
 
-  constructor(cacheStorage?: Cache) {
-    this.cache =
-      cacheStorage ?? (caches as unknown as {default: Cache}).default;
+  constructor(cacheStorage?: Cache, kv?: KVNamespace) {
+    this.cacheStorage = cacheStorage;
+    this.kv = kv;
+  }
+
+  private get cache(): Cache {
+    return this.cacheStorage ?? (caches as unknown as {default: Cache}).default;
   }
 
   // Cache API keys must be valid request URLs; map logical keys onto one
@@ -67,6 +72,13 @@ export class EdgeCache {
 
   async set(key: string, data: unknown, ttl = 3600): Promise<void> {
     try {
+      if (this.kv) {
+        await this.kv.put(key, JSON.stringify({data, cachedAt: Date.now()}), {
+          expirationTtl: ttl,
+        });
+        return;
+      }
+
       const response = Response.json(
         {data, cachedAt: Date.now()},
         {
@@ -86,6 +98,16 @@ export class EdgeCache {
     key: string,
   ): Promise<{data: unknown; cachedAt: number} | undefined> {
     try {
+      if (this.kv) {
+        const cached = (await this.kv.get(key, 'json')) as {
+          data: unknown;
+          cachedAt: number;
+        } | null;
+        this.metrics[cached ? 'hits' : 'misses']++;
+        this.updateHitRate();
+        return cached ?? undefined;
+      }
+
       const cached = await this.cache.match(this.keyToUrl(key));
       if (cached) {
         const result: {
@@ -110,6 +132,11 @@ export class EdgeCache {
 
   async delete(key: string): Promise<boolean> {
     try {
+      if (this.kv) {
+        await this.kv.delete(key);
+        return true;
+      }
+
       return await this.cache.delete(this.keyToUrl(key));
     } catch (error) {
       console.error('Cache delete error:', error);

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -13,11 +13,19 @@ name = "shine-api"
 [env.development.browser]
 binding = "BROWSER"
 
+[[env.development.kv_namespaces]]
+binding = "CACHE_KV"
+id = "62b23e51b6614819adbc5454a0930687"
+
 [env.production]
 name = "shine-api"
 
 [env.production.browser]
 binding = "BROWSER"
+
+[[env.production.kv_namespaces]]
+binding = "CACHE_KV"
+id = "62b23e51b6614819adbc5454a0930687"
 # TURSO_DATABASE_URL and TURSO_AUTH_TOKEN should be set via:
 # wrangler secret put TURSO_DATABASE_URL --env production
 # wrangler secret put TURSO_AUTH_TOKEN --env production

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -25,6 +25,7 @@ export type Environment = {
   JWT_SECRET?: string;
   TURNSTILE_SECRET_KEY?: string;
   BROWSER?: Fetcher;
+  CACHE_KV?: KVNamespace;
 };
 
 export const getDatabase = (environment: Environment) => {


### PR DESCRIPTION
Turso読み取り削減の最終手。#270でCache APIに乗せたが、Cache APIはコロケーション単位＋evictionありのため、関連映画4.5千キー＋年別ページ220キーへの広いクロールではミスが止まらなかった（計測: 差分の53%がrelated候補クエリ、47%がgetAwardYear）。

- `EdgeCache`にKVバックエンドを追加（第2引数に`KVNamespace`。未指定なら従来のCache APIにフォールバックするので、テスト・他ルートは無変更）
- related・awards×3・historyの5ルートを`c.env.CACHE_KV`利用に切り替え。KVはグローバル＋TTLまで保持されるため、キーごとの初回ミス以外はTursoに到達しない
- KV namespace `CACHE_KV`（62b23e51…）を作成済み、wrangler.tomlのdevelopment/productionにバインディング追加

KVは結果整合（伝播〜60秒）だが読み取り専用キャッシュ用途では問題ない。