### PR TITLE
relatedキャッシュのTTLを30日に延長

### DIFF
--- a/apps/api/src/utils/cache.ts
+++ b/apps/api/src/utils/cache.ts
@@ -254,7 +254,7 @@ export const getCacheTTL = {
   movie: {
     basic: 3600, // 1 hour
     full: 86_400, // 24 hours
-    related: 604_800, // 1 week
+    related: 2_592_000, // 30 days
   },
   search: {
     common: 1800, // 30 minutes


### PR DESCRIPTION
KV移行後の残コストは各キー初回ミスのウォームアップ（related約4.5千キー×数千行）で、7日TTLだと月内に再ウォームがもう一巡来る。関連映画リストの実質的な変更頻度は低いので30日に延長し、再ウォームを月1回に抑える。