### PR TITLE
nominationsにcategory_uid先頭のインデックスを追加

### DIFF
--- a/packages/database/migrations/0016_dear_peter_parker.sql
+++ b/packages/database/migrations/0016_dear_peter_parker.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `nominations_category_movie_idx` ON `nominations` (`category_uid`,`movie_uid`);

--- a/packages/database/migrations/meta/0016_snapshot.json
+++ b/packages/database/migrations/meta/0016_snapshot.json
@@ -1,0 +1,1136 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1c51b219-a305-49fe-91b7-62d92d22e1c5",
+  "prevId": "6ad32bcb-b06e-4350-b25f-06a23867a21c",
+  "tables": {
+    "article_links": {
+      "name": "article_links",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_uid": {
+          "name": "movie_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submitter_ip": {
+          "name": "submitter_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_spam": {
+          "name": "is_spam",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_flagged": {
+          "name": "is_flagged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_links_movie_uid_movies_uid_fk": {
+          "name": "article_links_movie_uid_movies_uid_fk",
+          "tableFrom": "article_links",
+          "tableTo": "movies",
+          "columnsFrom": ["movie_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "award_categories": {
+      "name": "award_categories",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_uid": {
+          "name": "organization_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_local": {
+          "name": "name_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_awarded_year": {
+          "name": "first_awarded_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discontinued_year": {
+          "name": "discontinued_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "award_categories_organizationUid_name_unique": {
+          "name": "award_categories_organizationUid_name_unique",
+          "columns": ["organization_uid", "name"],
+          "isUnique": true
+        },
+        "award_categories_organizationUid_shortName_unique": {
+          "name": "award_categories_organizationUid_shortName_unique",
+          "columns": ["organization_uid", "short_name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "award_categories_organization_uid_award_organizations_uid_fk": {
+          "name": "award_categories_organization_uid_award_organizations_uid_fk",
+          "tableFrom": "award_categories",
+          "tableTo": "award_organizations",
+          "columnsFrom": ["organization_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "award_ceremonies": {
+      "name": "award_ceremonies",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_uid": {
+          "name": "organization_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ceremony_number": {
+          "name": "ceremony_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imdb_event_url": {
+          "name": "imdb_event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "award_ceremonies_organizationUid_year_unique": {
+          "name": "award_ceremonies_organizationUid_year_unique",
+          "columns": ["organization_uid", "year"],
+          "isUnique": true
+        },
+        "award_ceremonies_organizationUid_ceremonyNumber_unique": {
+          "name": "award_ceremonies_organizationUid_ceremonyNumber_unique",
+          "columns": ["organization_uid", "ceremony_number"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "award_ceremonies_organization_uid_award_organizations_uid_fk": {
+          "name": "award_ceremonies_organization_uid_award_organizations_uid_fk",
+          "tableFrom": "award_ceremonies",
+          "tableTo": "award_organizations",
+          "columnsFrom": ["organization_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "award_organizations": {
+      "name": "award_organizations",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "established_year": {
+          "name": "established_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "award_organizations_name_unique": {
+          "name": "award_organizations_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "award_organizations_shortName_unique": {
+          "name": "award_organizations_shortName_unique",
+          "columns": ["short_name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_availability_checks": {
+      "name": "movie_availability_checks",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_uid": {
+          "name": "movie_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "movie_availability_checks_movie_uid_idx": {
+          "name": "movie_availability_checks_movie_uid_idx",
+          "columns": ["movie_uid"],
+          "isUnique": false
+        },
+        "movie_availability_checks_movie_source_checked_idx": {
+          "name": "movie_availability_checks_movie_source_checked_idx",
+          "columns": ["movie_uid", "source", "checked_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "movie_availability_checks_movie_uid_movies_uid_fk": {
+          "name": "movie_availability_checks_movie_uid_movies_uid_fk",
+          "tableFrom": "movie_availability_checks",
+          "tableTo": "movies",
+          "columnsFrom": ["movie_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_selections": {
+      "name": "movie_selections",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selection_type": {
+          "name": "selection_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "selection_date": {
+          "name": "selection_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "movie_selections_selection_type_idx": {
+          "name": "movie_selections_selection_type_idx",
+          "columns": ["selection_type"],
+          "isUnique": false
+        },
+        "movie_selections_selection_date_idx": {
+          "name": "movie_selections_selection_date_idx",
+          "columns": ["selection_date"],
+          "isUnique": false
+        },
+        "movie_selections_movie_id_idx": {
+          "name": "movie_selections_movie_id_idx",
+          "columns": ["movie_id"],
+          "isUnique": false
+        },
+        "movie_selections_type_date_unique_idx": {
+          "name": "movie_selections_type_date_unique_idx",
+          "columns": ["selection_type", "selection_date"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "movie_selections_movie_id_movies_uid_fk": {
+          "name": "movie_selections_movie_id_movies_uid_fk",
+          "tableFrom": "movie_selections",
+          "tableTo": "movies",
+          "columnsFrom": ["movie_id"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_language": {
+          "name": "original_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'movie'"
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_imdbId_unique": {
+          "name": "movies_imdbId_unique",
+          "columns": ["imdb_id"],
+          "isUnique": true
+        },
+        "movies_tmdbId_unique": {
+          "name": "movies_tmdbId_unique",
+          "columns": ["tmdb_id"],
+          "isUnique": true
+        },
+        "movies_year_idx": {
+          "name": "movies_year_idx",
+          "columns": ["year"],
+          "isUnique": false
+        },
+        "movies_original_language_idx": {
+          "name": "movies_original_language_idx",
+          "columns": ["original_language"],
+          "isUnique": false
+        },
+        "movies_created_at_idx": {
+          "name": "movies_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "movies_deleted_at_idx": {
+          "name": "movies_deleted_at_idx",
+          "columns": ["deleted_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "nominations": {
+      "name": "nominations",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_uid": {
+          "name": "movie_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ceremony_uid": {
+          "name": "ceremony_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_uid": {
+          "name": "category_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_winner": {
+          "name": "is_winner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "special_mention": {
+          "name": "special_mention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "nominations_ceremony_category_idx": {
+          "name": "nominations_ceremony_category_idx",
+          "columns": ["ceremony_uid", "category_uid"],
+          "isUnique": false
+        },
+        "nominations_category_movie_idx": {
+          "name": "nominations_category_movie_idx",
+          "columns": ["category_uid", "movie_uid"],
+          "isUnique": false
+        },
+        "nominations_movieUid_ceremonyUid_categoryUid_unique": {
+          "name": "nominations_movieUid_ceremonyUid_categoryUid_unique",
+          "columns": ["movie_uid", "ceremony_uid", "category_uid"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "nominations_movie_uid_movies_uid_fk": {
+          "name": "nominations_movie_uid_movies_uid_fk",
+          "tableFrom": "nominations",
+          "tableTo": "movies",
+          "columnsFrom": ["movie_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "nominations_ceremony_uid_award_ceremonies_uid_fk": {
+          "name": "nominations_ceremony_uid_award_ceremonies_uid_fk",
+          "tableFrom": "nominations",
+          "tableTo": "award_ceremonies",
+          "columnsFrom": ["ceremony_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "nominations_category_uid_award_categories_uid_fk": {
+          "name": "nominations_category_uid_award_categories_uid_fk",
+          "tableFrom": "nominations",
+          "tableTo": "award_categories",
+          "columnsFrom": ["category_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "poster_urls": {
+      "name": "poster_urls",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_uid": {
+          "name": "movie_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "poster_urls_movie_idx": {
+          "name": "poster_urls_movie_idx",
+          "columns": ["movie_uid"],
+          "isUnique": false
+        },
+        "poster_urls_primary_idx": {
+          "name": "poster_urls_primary_idx",
+          "columns": ["movie_uid", "is_primary"],
+          "isUnique": false
+        },
+        "poster_urls_unique_idx": {
+          "name": "poster_urls_unique_idx",
+          "columns": [
+            "movie_uid",
+            "width",
+            "height",
+            "language_code",
+            "country_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "poster_urls_movie_uid_movies_uid_fk": {
+          "name": "poster_urls_movie_uid_movies_uid_fk",
+          "tableFrom": "poster_urls",
+          "tableTo": "movies",
+          "columnsFrom": ["movie_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reference_urls": {
+      "name": "reference_urls",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "movie_uid": {
+          "name": "movie_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "reference_urls_movie_language_idx": {
+          "name": "reference_urls_movie_language_idx",
+          "columns": ["movie_uid", "language_code"],
+          "isUnique": false
+        },
+        "reference_urls_movieUid_sourceType_languageCode_unique": {
+          "name": "reference_urls_movieUid_sourceType_languageCode_unique",
+          "columns": ["movie_uid", "source_type", "language_code"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reference_urls_movie_uid_movies_uid_fk": {
+          "name": "reference_urls_movie_uid_movies_uid_fk",
+          "tableFrom": "reference_urls",
+          "tableTo": "movies",
+          "columnsFrom": ["movie_uid"],
+          "columnsTo": ["uid"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translations": {
+      "name": "translations",
+      "columns": {
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_uid": {
+          "name": "resource_uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "translations_resource_type_idx": {
+          "name": "translations_resource_type_idx",
+          "columns": ["resource_type"],
+          "isUnique": false
+        },
+        "translations_resource_uid_idx": {
+          "name": "translations_resource_uid_idx",
+          "columns": ["resource_uid"],
+          "isUnique": false
+        },
+        "translations_language_code_idx": {
+          "name": "translations_language_code_idx",
+          "columns": ["language_code"],
+          "isUnique": false
+        },
+        "translations_resourceType_resourceUid_languageCode_unique": {
+          "name": "translations_resourceType_resourceUid_languageCode_unique",
+          "columns": ["resource_type", "resource_uid", "language_code"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1786503176401,
       "tag": "0015_mature_stryfe",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1786668674680,
+      "tag": "0016_dear_peter_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/nominations.ts
+++ b/packages/database/src/schema/nominations.ts
@@ -42,5 +42,9 @@ export const nominations = sqliteTable(
       table.ceremonyUid,
       table.categoryUid,
     ),
+    index('nominations_category_movie_idx').on(
+      table.categoryUid,
+      table.movieUid,
+    ),
   ],
 );


### PR DESCRIPTION
Turso読み取り削減の続き。related候補・awards系・listAwardsが使う「category_uidでの絞り込み」に効くインデックスが存在せず、毎回nominationsテーブル（約5千行）のフルスキャンになっていた。

`nominations(category_uid, movie_uid)`を追加（migration 0016、本番適用済み）。EXPLAIN QUERY PLANでフルスキャン→covering indexのレンジスキャンに変わることを確認済み。KVキャッシュのウォームアップ中の残りミス（related約7,700キー）のコストを下げる。