### PR TITLE
ヴェネツィア国際映画祭（金獅子賞）を追加

### DIFF
--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -49,6 +49,16 @@ export const awardPageDefinitions: AwardPageDefinition[] = [
     grouping: 'year',
   },
   {
+    slug: 'venice-golden-lion',
+    organizationName: 'Venice Film Festival',
+    categoryNames: ['Golden Lion'],
+    name: '金獅子賞',
+    organization: 'ヴェネツィア国際映画祭',
+    description:
+      'ヴェネツィア国際映画祭の最高賞・金獅子賞の歴代受賞作とコンペティション部門出品作の一覧。',
+    grouping: 'year',
+  },
+  {
     slug: 'academy-best-picture',
     organizationName: 'Academy Awards',
     categoryNames: ['Academy Award for Best Picture'],

--- a/apps/scrapers/data/venice-golden-lion.json
+++ b/apps/scrapers/data/venice-golden-lion.json
@@ -1,0 +1,19290 @@
+{
+  "collectedAt": "2026-08-14",
+  "source": "https://www.imdb.com/event/ev0000681/",
+  "editions": [
+    {
+      "year": 1932,
+      "awardNames": ["Audience Referendum"],
+      "goldenLion": []
+    },
+    {
+      "year": 1934,
+      "awardNames": [
+        "Mussolini Cup",
+        "Special Recommendation",
+        "Best Short Film",
+        "Best Director",
+        "Best Cinematography",
+        "Special Prize",
+        "Golden Medal",
+        "Honorary Diploma",
+        "Best World Premiere",
+        "Corporations Ministry Cup"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1935,
+      "awardNames": [
+        "Mussolini Cup",
+        "Volpi Cup",
+        "Special Mention",
+        "Best Director",
+        "Best Screenplay",
+        "Best Cinematography",
+        "Best Music",
+        "Jury Special Mention",
+        "Best Color Film",
+        "Best Foreign Documentary",
+        "Fascist Party Cup",
+        "Propaganda Ministry Cup",
+        "Best Italian Comedy",
+        "Education Ministry Cup",
+        "Best Animation",
+        "Best Psychological Film",
+        "Fascist Industry Confederation Cup",
+        "Tourism Supervision Cup",
+        "Best Italian Documentary"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1936,
+      "awardNames": [
+        "Mussolini Cup",
+        "Volpi Cup",
+        "Special Recommendation",
+        "Best Director",
+        "Best Cinematography",
+        "Best Musical Film",
+        "Best Scientific Film",
+        "Best Foreign Documentary",
+        "Fascist Party Cup",
+        "Propaganda Ministry Cup"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1937,
+      "awardNames": [
+        "Mussolini Cup",
+        "Volpi Cup",
+        "Special Recommendation",
+        "Honorable Mention",
+        "Best Cinematography",
+        "Best Scientific Film",
+        "Best Overall Artistic Contribution",
+        "Fascist Party Cup",
+        "Best Animation",
+        "Best Colonial Film",
+        "Best Foreign Screenplay",
+        "Best World Premiere",
+        "Popular Culture Ministry Cup"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1938,
+      "awardNames": [
+        "Mussolini Cup",
+        "Volpi Cup",
+        "Special Recommendation",
+        "Medal",
+        "Plate",
+        "Grand Biennale Art Trophy",
+        "Fascist Party Cup",
+        "Education Ministry Cup",
+        "Popular Culture Ministry Cup"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1939,
+      "awardNames": [
+        "Mussolini Cup",
+        "Volpi Cup",
+        "Bronze Medal",
+        "Fascist Party Cup",
+        "Agriculture Ministry Cup"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1940,
+      "awardNames": ["Mussolini Cup", "Volpi Cup"],
+      "goldenLion": []
+    },
+    {
+      "year": 1941,
+      "awardNames": [
+        "Mussolini Cup",
+        "Volpi Cup",
+        "Biennale Cup",
+        "Best Director",
+        "Golden Medal",
+        "Plate",
+        "Biennale Trophy",
+        "Fascist Party Cup",
+        "Popular Culture Ministry Cup"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1942,
+      "awardNames": [
+        "Mussolini Cup",
+        "Volpi Cup",
+        "Biennale Award",
+        "Biennale Medal",
+        "Bronze Medal",
+        "Medal",
+        "International Film Chamber Award"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1946,
+      "awardNames": [
+        "ANICA Cup",
+        "Best Italian Documentary",
+        "International Critics Award",
+        "International Critics Award - Special Mention"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1947,
+      "awardNames": [
+        "International Award",
+        "Best Italian Film",
+        "Biennale Award",
+        "ENIC Cup",
+        "Grand International Award"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1948,
+      "awardNames": [
+        "International Award",
+        "Best Italian Film",
+        "ENIC Cup",
+        "Cinecittà Cup",
+        "ANICA Cup",
+        "CIDALC Award",
+        "ENIC Medal",
+        "Grand International Award",
+        "International Award - Animated Film",
+        "International Award - Documentary",
+        "International Award - Short Film"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1949,
+      "awardNames": [
+        "Golden Lion",
+        "International Award",
+        "Best Italian Film",
+        "OCIC Award",
+        "International Award - Documentary",
+        "International Award - Short Film"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041634",
+                      "title": "Jôfu Manon",
+                      "originalTitle": "Manon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041579",
+                      "title": "The Last Days of Dolwyn",
+                      "originalTitle": "The Last Days of Dolwyn"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042432",
+                      "title": "The Elusive Pimpernel",
+                      "originalTitle": "The Elusive Pimpernel"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050410",
+                      "title": "I fratelli Dinamite",
+                      "originalTitle": "I fratelli Dinamite"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0214940",
+                      "title": "Meera",
+                      "originalTitle": "Meera"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041408",
+                      "title": "Geheimnisvolle Tiefe",
+                      "originalTitle": "Geheimnisvolle Tiefe"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0038166",
+                      "title": "Sannin no kishi",
+                      "originalTitle": "The Three Caballeros"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0143110",
+                      "title": "Apenas un delincuente",
+                      "originalTitle": "Apenas un delincuente"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041184",
+                      "title": "L'Équateur aux cent visages",
+                      "originalTitle": "L'Équateur aux cent visages"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041736",
+                      "title": "Passione secondo S. Matteo",
+                      "originalTitle": "Passione secondo S. Matteo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042002",
+                      "title": "Un homme et son péché",
+                      "originalTitle": "Un homme et son péché"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040619",
+                      "title": "Il mulino del Po",
+                      "originalTitle": "Il mulino del Po"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041137",
+                      "title": "Au royaume des cieux",
+                      "originalTitle": "Au royaume des cieux"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0197908",
+                      "title": "Le sorcier du ciel",
+                      "originalTitle": "Le sorcier du ciel"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041678",
+                      "title": "Mädchen hinter Gittern",
+                      "originalTitle": "Mädchen hinter Gittern"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0133731",
+                      "title": "Ein Breira",
+                      "originalTitle": "Ein Breira"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0033623",
+                      "title": "The Forgotten Village",
+                      "originalTitle": "The Forgotten Village"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041599",
+                      "title": "Look for the Silver Lining",
+                      "originalTitle": "Look for the Silver Lining"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041739",
+                      "title": "Patto col diavolo",
+                      "originalTitle": "Patto col diavolo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041356",
+                      "title": "Fiamma che non si spegne",
+                      "originalTitle": "Fiamma che non si spegne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0180180",
+                      "title": "Sofka",
+                      "originalTitle": "Sofka"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042405",
+                      "title": "Dom na pustkowiu",
+                      "originalTitle": "Dom na pustkowiu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041190",
+                      "title": "The Blue Lagoon",
+                      "originalTitle": "The Blue Lagoon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040363",
+                      "title": "The Fool and the Princess",
+                      "originalTitle": "The Fool and the Princess"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040761",
+                      "title": "Scott of the Antarctic",
+                      "originalTitle": "Scott of the Antarctic"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040826",
+                      "title": "Aux yeux du souvenir",
+                      "originalTitle": "Aux yeux du souvenir"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040156",
+                      "title": "Berliner Ballade",
+                      "originalTitle": "Berliner Ballade"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041239",
+                      "title": "Champion",
+                      "originalTitle": "Champion"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041248",
+                      "title": "Cielo sulla palude",
+                      "originalTitle": "Cielo sulla palude"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040330",
+                      "title": "Eva",
+                      "originalTitle": "Eva"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040495",
+                      "title": "Johnny Belinda",
+                      "originalTitle": "Johnny Belinda"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040497",
+                      "title": "Jour de fête",
+                      "originalTitle": "Jour de fête"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041546",
+                      "title": "Kind Hearts and Coronets",
+                      "originalTitle": "Kind Hearts and Coronets"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041624",
+                      "title": "La malquerida",
+                      "originalTitle": "La malquerida"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040705",
+                      "title": "Portrait of Jennie",
+                      "originalTitle": "Portrait of Jennie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040717",
+                      "title": "The Quiet One",
+                      "originalTitle": "The Quiet One"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040806",
+                      "title": "The Snake Pit",
+                      "originalTitle": "The Snake Pit"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1950,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "International Award",
+        "Best Italian Film",
+        "OCIC Award",
+        "Pasinetti Award",
+        "International Award - Documentary",
+        "International Award - Short Film"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042625",
+                      "title": "Justice est faite",
+                      "originalTitle": "Justice est faite"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042477",
+                      "title": "Francesco, giullare di Dio",
+                      "originalTitle": "Francesco, giullare di Dio"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0205804",
+                      "title": "Ce siècle a cinquante ans",
+                      "originalTitle": "Ce siècle a cinquante ans"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042513",
+                      "title": "Gone to Earth",
+                      "originalTitle": "Gone to Earth"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042480",
+                      "title": "Frauenarzt Dr. Prätorius",
+                      "originalTitle": "Frauenarzt Dr. Prätorius"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0039644",
+                      "title": "My Father's House",
+                      "originalTitle": "My Father's House"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042437",
+                      "title": "Epilog - Das Geheimnis der Orplid",
+                      "originalTitle": "Epilog - Das Geheimnis der Orplid"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042906",
+                      "title": "La ronde",
+                      "originalTitle": "La ronde"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0140679",
+                      "title": "La vie commence demain",
+                      "originalTitle": "La vie commence demain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041416",
+                      "title": "Give Us This Day",
+                      "originalTitle": "Give Us This Day"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042908",
+                      "title": "Rosauro Castro",
+                      "originalTitle": "Rosauro Castro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041302",
+                      "title": "Domani è troppo tardi",
+                      "originalTitle": "Domani è troppo tardi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0170768",
+                      "title": "Das vierte Gebot",
+                      "originalTitle": "Das vierte Gebot"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040266",
+                      "title": "The Dancing Years",
+                      "originalTitle": "The Dancing Years"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042810",
+                      "title": "Morning Departure",
+                      "originalTitle": "Morning Departure"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0151548",
+                      "title": "Mi Klalah L'Brahah",
+                      "originalTitle": "Mi Klalah L'Brahah"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043162",
+                      "title": "È più facile che un cammello...",
+                      "originalTitle": "È più facile che un cammello..."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043647",
+                      "title": "El hombre sin rostro",
+                      "originalTitle": "El hombre sin rostro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042983",
+                      "title": "Sobre las olas",
+                      "originalTitle": "Sobre las olas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042406",
+                      "title": "Don Juan",
+                      "originalTitle": "Don Juan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042793",
+                      "title": "La noche del sábado",
+                      "originalTitle": "La noche del sábado"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041719",
+                      "title": "Orphée",
+                      "originalTitle": "Orphée"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041155",
+                      "title": "Bara en mor",
+                      "originalTitle": "Bara en mor"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042807",
+                      "title": "Once a Thief",
+                      "originalTitle": "Once a Thief"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042947",
+                      "title": "September Affair",
+                      "originalTitle": "September Affair"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043016",
+                      "title": "Surcos de sangre",
+                      "originalTitle": "Surcos de sangre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0331331",
+                      "title": "Saint-Louis, ange de la paix",
+                      "originalTitle": "Saint-Louis, ange de la paix"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0156153",
+                      "title": "Une sortie du 'Rubis'",
+                      "originalTitle": "Une sortie du 'Rubis'"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0039629",
+                      "title": "Caccia all'uomo",
+                      "originalTitle": "Caccia all'uomo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0040405",
+                      "title": "Guarany",
+                      "originalTitle": "Guarany"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3097918",
+                      "title": "Tempesta su Parigi",
+                      "originalTitle": "Tempesta su Parigi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041113",
+                      "title": "All the King's Men",
+                      "originalTitle": "All the King's Men"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042208",
+                      "title": "The Asphalt Jungle",
+                      "originalTitle": "The Asphalt Jungle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042265",
+                      "title": "The Blue Lamp",
+                      "originalTitle": "The Blue Lamp"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042296",
+                      "title": "Caged",
+                      "originalTitle": "Caged"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042332",
+                      "title": "Shinderera",
+                      "originalTitle": "Cinderella"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042401",
+                      "title": "Dieu a besoin des hommes",
+                      "originalTitle": "Dieu a besoin des hommes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042832",
+                      "title": "Ankoku no kyofu",
+                      "originalTitle": "Panic in the Streets"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042859",
+                      "title": "Prima comunione",
+                      "originalTitle": "Prima comunione"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041799",
+                      "title": "Rendez-vous avec la chance",
+                      "originalTitle": "Rendez-vous avec la chance"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042949",
+                      "title": "Seven Days to Noon",
+                      "originalTitle": "Seven Days to Noon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042522",
+                      "title": "State Secret",
+                      "originalTitle": "State Secret"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0041931",
+                      "title": "Stromboli (Terra di Dio)",
+                      "originalTitle": "Stromboli (Terra di Dio)"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1951,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "International Award",
+        "Best Italian Film",
+        "OCIC Award",
+        "Italian Film Critics Award",
+        "Volpi Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042876",
+                      "title": "Rashômon",
+                      "originalTitle": "Rashômon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043412",
+                      "title": "La città si difende",
+                      "originalTitle": "La città si difende"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043902",
+                      "title": "Parigi è sempre Parigi",
+                      "originalTitle": "Parigi è sempre Parigi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042294",
+                      "title": "Café Paradis",
+                      "originalTitle": "Café Paradis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0177519",
+                      "title": "Ângela",
+                      "originalTitle": "Ângela"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042227",
+                      "title": "Barbe-Bleue",
+                      "originalTitle": "Barbe-Bleue"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045122",
+                      "title": "Le garçon sauvage",
+                      "originalTitle": "Le garçon sauvage"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044385",
+                      "title": "Avec André Gide",
+                      "originalTitle": "Avec André Gide"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0202483",
+                      "title": "Murder in the Cathedral",
+                      "originalTitle": "Murder in the Cathedral"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0251301",
+                      "title": "No Resting Place",
+                      "originalTitle": "No Resting Place"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044214",
+                      "title": "White Corridors",
+                      "originalTitle": "White Corridors"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042409",
+                      "title": "Das doppelte Lottchen",
+                      "originalTitle": "Das doppelte Lottchen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042683",
+                      "title": "Lockende Gefahr",
+                      "originalTitle": "Lockende Gefahr"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044188",
+                      "title": "Der Verlorene",
+                      "originalTitle": "Der Verlorene"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042346",
+                      "title": "La corona negra",
+                      "originalTitle": "La corona negra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043851",
+                      "title": "Niebla y sol",
+                      "originalTitle": "Niebla y sol"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043878",
+                      "title": "Ombre sul Canal Grande",
+                      "originalTitle": "Ombre sul Canal Grande"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042781",
+                      "title": "Native Son",
+                      "originalTitle": "Native Son"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042402",
+                      "title": "De dijk is dicht",
+                      "originalTitle": "De dijk is dicht"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0179759",
+                      "title": "Decak Mita",
+                      "originalTitle": "Decak Mita"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043274",
+                      "title": "Fushigi no Kuni no Arisu",
+                      "originalTitle": "Alice in Wonderland"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043338",
+                      "title": "Ace in the Hole",
+                      "originalTitle": "Ace in the Hole"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042276",
+                      "title": "Born Yesterday",
+                      "originalTitle": "Born Yesterday"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043560",
+                      "title": "Fourteen Hours",
+                      "originalTitle": "Fourteen Hours"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0042619",
+                      "title": "Journal d'un curé de campagne",
+                      "originalTitle": "Journal d'un curé de campagne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044829",
+                      "title": "The Lavender Hill Mob",
+                      "originalTitle": "The Lavender Hill Mob"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0151785",
+                      "title": "La nuit est mon royaume",
+                      "originalTitle": "La nuit est mon royaume"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043972",
+                      "title": "The River",
+                      "originalTitle": "The River"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044081",
+                      "title": "Yokubo toiu na no densha",
+                      "originalTitle": "A Streetcar Named Desire"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044112",
+                      "title": "Teresa",
+                      "originalTitle": "Teresa"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1952,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "International Award",
+        "FIPRESCI Prize",
+        "FIPRESCI Prize - Honorable Mention",
+        "OCIC Award",
+        "Pasinetti Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043686",
+                      "title": "Jeux interdits",
+                      "originalTitle": "Jeux interdits"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044414",
+                      "title": "La bergère et le ramoneur",
+                      "originalTitle": "La bergère et le ramoneur"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044409",
+                      "title": "Les belles de nuit",
+                      "originalTitle": "Les belles de nuit"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0193835",
+                      "title": "Les conquérants solitaires",
+                      "originalTitle": "Les conquérants solitaires"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045060",
+                      "title": "La p... respectueuse",
+                      "originalTitle": "La p... respectueuse"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044000",
+                      "title": "Lo sceicco bianco",
+                      "originalTitle": "Lo sceicco bianco"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044345",
+                      "title": "Altri tempi - Zibaldone n. 1",
+                      "originalTitle": "Altri tempi - Zibaldone n. 1"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044450",
+                      "title": "Il brigante di Tacca del Lupo",
+                      "originalTitle": "Il brigante di Tacca del Lupo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044060",
+                      "title": "Sommarlek",
+                      "originalTitle": "Sommarlek"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044772",
+                      "title": "El Judas",
+                      "originalTitle": "El Judas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044985",
+                      "title": "Los ojos dejan huellas",
+                      "originalTitle": "Los ojos dejan huellas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044099",
+                      "title": "Sündige Grenze",
+                      "originalTitle": "Sündige Grenze"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044760",
+                      "title": "Ivanhoe",
+                      "originalTitle": "Ivanhoe"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045102",
+                      "title": "Room for One More",
+                      "originalTitle": "Room for One More"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045230",
+                      "title": "The Thief",
+                      "originalTitle": "The Thief"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044905",
+                      "title": "The Miracle of Our Lady of Fatima",
+                      "originalTitle": "The Miracle of Our Lady of Fatima"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0201561",
+                      "title": "Deshonra",
+                      "originalTitle": "Deshonra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044335",
+                      "title": "Las aguas bajan turbias",
+                      "originalTitle": "Las aguas bajan turbias"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0261538",
+                      "title": "Areião",
+                      "originalTitle": "Areião"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0137508",
+                      "title": "The Faithful City",
+                      "originalTitle": "The Faithful City"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0132464",
+                      "title": "El rebozo de Soledad",
+                      "originalTitle": "El rebozo de Soledad"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0154106",
+                      "title": "Aandhiyan",
+                      "originalTitle": "Aandhiyan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0291939",
+                      "title": "Genghis Khan",
+                      "originalTitle": "Genghis Khan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0216541",
+                      "title": "Andrine og Kjell",
+                      "originalTitle": "Andrine og Kjell"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044443",
+                      "title": "The Brave Don't Cry",
+                      "originalTitle": "The Brave Don't Cry"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044486",
+                      "title": "Carrie",
+                      "originalTitle": "Carrie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043458",
+                      "title": "Death of a Salesman",
+                      "originalTitle": "Death of a Salesman"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0043511",
+                      "title": "Europa '51",
+                      "originalTitle": "Europa '51"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044744",
+                      "title": "The Importance of Being Earnest",
+                      "originalTitle": "The Importance of Being Earnest"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045654",
+                      "title": "Mandy",
+                      "originalTitle": "Mandy"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045029",
+                      "title": "Phone Call from a Stranger",
+                      "originalTitle": "Phone Call from a Stranger"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045061",
+                      "title": "Shizuka naru otoko",
+                      "originalTitle": "The Quiet Man"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045112",
+                      "title": "Saikaku ichidai onna",
+                      "originalTitle": "Saikaku ichidai onna"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1953,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Volpi Cup",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Bronze Lion"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Not awarded.",
+                  "titles": []
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046250",
+                      "title": "Roman Holiday",
+                      "originalTitle": "Roman Holiday"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046429",
+                      "title": "Thérèse Raquin",
+                      "originalTitle": "Thérèse Raquin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045510",
+                      "title": "Anni facili",
+                      "originalTitle": "Anni facili"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046120",
+                      "title": "Napoletani a Milano",
+                      "originalTitle": "Napoletani a Milano"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044391",
+                      "title": "The Bad and the Beautiful",
+                      "originalTitle": "The Bad and the Beautiful"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044811",
+                      "title": "Kvinnors väntan",
+                      "originalTitle": "Kvinnors väntan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045294",
+                      "title": "I vinti",
+                      "originalTitle": "I vinti"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046712",
+                      "title": "Anatahan",
+                      "originalTitle": "Anatahan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046396",
+                      "title": "Tajemství krve",
+                      "originalTitle": "Tajemství krve"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045010",
+                      "title": "La pasión desnuda",
+                      "originalTitle": "La pasión desnuda"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044676",
+                      "title": "Die große Versuchung",
+                      "originalTitle": "Die große Versuchung"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046502",
+                      "title": "Vergiß die Liebe nicht",
+                      "originalTitle": "Vergiß die Liebe nicht"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045929",
+                      "title": "Jara gospoda",
+                      "originalTitle": "Jara gospoda"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044769",
+                      "title": "Jhansi Ki Rani",
+                      "originalTitle": "Jhansi Ki Rani"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046149",
+                      "title": "Les orgueilleux",
+                      "originalTitle": "Les orgueilleux"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0194385",
+                      "title": "Sinhá Moça",
+                      "originalTitle": "Sinhá Moça"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045799",
+                      "title": "Föltámadott a tenger",
+                      "originalTitle": "Föltámadott a tenger"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046521",
+                      "title": "I vitelloni",
+                      "originalTitle": "I vitelloni"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045843",
+                      "title": "La guerra de Dios",
+                      "originalTitle": "La guerra de Dios"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045569",
+                      "title": "Le bon Dieu sans confession",
+                      "originalTitle": "Le bon Dieu sans confession"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046004",
+                      "title": "Little Fugitive",
+                      "originalTitle": "Little Fugitive"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044911",
+                      "title": "若き日のショパン",
+                      "originalTitle": "Mlodosc Chopina"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044926",
+                      "title": "Moulin Rouge",
+                      "originalTitle": "Moulin Rouge"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046187",
+                      "title": "Hirotta onna",
+                      "originalTitle": "Pickup on South Street"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045089",
+                      "title": "Rimskiy-Korsakov",
+                      "originalTitle": "Rimskiy-Korsakov"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046264",
+                      "title": "Sadko",
+                      "originalTitle": "Sadko"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044631",
+                      "title": "The Four Poster",
+                      "originalTitle": "The Four Poster"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046478",
+                      "title": "Ugetsu monogatari",
+                      "originalTitle": "Ugetsu monogatari"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045301",
+                      "title": "Vozvrashchenie Vasiliya Bortnikova",
+                      "originalTitle": "Vozvrashchenie Vasiliya Bortnikova"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1954,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "Pasinetti Award",
+        "Absolute Grand Prize"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047029",
+                      "title": "Romeo and Juliet",
+                      "originalTitle": "Romeo and Juliet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046451",
+                      "title": "Touchez pas au grisbi",
+                      "originalTitle": "Touchez pas au grisbi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047396",
+                      "title": "Uramado",
+                      "originalTitle": "Rear Window"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046816",
+                      "title": "The Caine Mutiny",
+                      "originalTitle": "The Caine Mutiny"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047580",
+                      "title": "Three Coins in the Fountain",
+                      "originalTitle": "Three Coins in the Fountain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047435",
+                      "title": "El río y la muerte",
+                      "originalTitle": "El río y la muerte"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0044386",
+                      "title": "Robinson Crusoe",
+                      "originalTitle": "Robinson Crusoe"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045593",
+                      "title": "Camelia",
+                      "originalTitle": "Camelia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047397",
+                      "title": "La rebelión de los colgados",
+                      "originalTitle": "La rebelión de los colgados"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046051",
+                      "title": "Martin Luther",
+                      "originalTitle": "Martin Luther"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045980",
+                      "title": "Königliche Hoheit",
+                      "originalTitle": "Königliche Hoheit"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046769",
+                      "title": "El beso de Judas",
+                      "originalTitle": "El beso de Judas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047489",
+                      "title": "Sierra maldita",
+                      "originalTitle": "Sierra maldita"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0135534",
+                      "title": "Magiki polis",
+                      "originalTitle": "Magiki polis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047315",
+                      "title": "Ôsaka no yado",
+                      "originalTitle": "Ôsaka no yado"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0180721",
+                      "title": "Guacho",
+                      "originalTitle": "Guacho"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0186473",
+                      "title": "La quintrala",
+                      "originalTitle": "La quintrala"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046299",
+                      "title": "Sesto continente",
+                      "originalTitle": "Sesto continente"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0196063",
+                      "title": "O Saci",
+                      "originalTitle": "O Saci"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0234455",
+                      "title": "Pesen za choveka",
+                      "originalTitle": "Pesen za choveka"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047513",
+                      "title": "Som i drömmar",
+                      "originalTitle": "Som i drömmar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0148440",
+                      "title": "Maftayach Hazahav",
+                      "originalTitle": "Maftayach Hazahav"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046218",
+                      "title": "Pünktchen und Anton",
+                      "originalTitle": "Pünktchen und Anton"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0293679",
+                      "title": "Unsterblicher Mozart",
+                      "originalTitle": "Unsterblicher Mozart"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047496",
+                      "title": "Simon Menyhért születése",
+                      "originalTitle": "Simon Menyhért születése"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046963",
+                      "title": "Executive Suite",
+                      "originalTitle": "Executive Suite"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046970",
+                      "title": "Father Brown",
+                      "originalTitle": "Father Brown"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0046690",
+                      "title": "L'air de Paris",
+                      "originalTitle": "L'air de Paris"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047427",
+                      "title": "La romana",
+                      "originalTitle": "La romana"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047528",
+                      "title": "La strada",
+                      "originalTitle": "La strada"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047296",
+                      "title": "On the Waterfront",
+                      "originalTitle": "On the Waterfront"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047445",
+                      "title": "Sanshô dayû",
+                      "originalTitle": "Sanshô dayû"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047469",
+                      "title": "Natsu no arashi",
+                      "originalTitle": "Senso"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047478",
+                      "title": "Shichinin no samurai",
+                      "originalTitle": "Shichinin no samurai"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1955,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Volpi Cup",
+        "Best Short Film",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "Pasinetti Award",
+        "Most Promising New Director"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048452",
+                      "title": "Ordet",
+                      "originalTitle": "Ordet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047572",
+                      "title": "Des Teufels General",
+                      "originalTitle": "Des Teufels General"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047913",
+                      "title": "Chiens perdus sans collier",
+                      "originalTitle": "Chiens perdus sans collier"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048361",
+                      "title": "Les Mauvaises Rencontres",
+                      "originalTitle": "Les Mauvaises Rencontres"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047281",
+                      "title": "Nijûshi no hitomi",
+                      "originalTitle": "Nijûshi no hitomi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0203902",
+                      "title": "Shuzenji monogatari",
+                      "originalTitle": "Shuzenji monogatari"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048689",
+                      "title": "Takekurabe",
+                      "originalTitle": "Takekurabe"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0045802",
+                      "title": "Gan",
+                      "originalTitle": "Gan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048210",
+                      "title": "Interrupted Melody",
+                      "originalTitle": "Interrupted Melody"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048001",
+                      "title": "Watashi no o isha sama",
+                      "originalTitle": "Doctor at Sea"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048231",
+                      "title": "John and Julie",
+                      "originalTitle": "John and Julie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048585",
+                      "title": "Gli sbandati",
+                      "originalTitle": "Gli sbandati"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0242410",
+                      "title": "Después de la tormenta",
+                      "originalTitle": "Después de la tormenta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048721",
+                      "title": "La Tierra del Fuego se apaga",
+                      "originalTitle": "La Tierra del Fuego se apaga"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0137119",
+                      "title": "Mãos Sangrentas",
+                      "originalTitle": "Mãos Sangrentas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0145856",
+                      "title": "Jhanak Jhanak Payal Baaje",
+                      "originalTitle": "Jhanak Jhanak Payal Baaje"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0173471",
+                      "title": "Z mého zivota",
+                      "originalTitle": "Z mého zivota"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0052642",
+                      "title": "Boris Godunov",
+                      "originalTitle": "Boris Godunov"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0172640",
+                      "title": "Uz jauno krastu",
+                      "originalTitle": "Uz jauno krastu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0253307",
+                      "title": "Nespokoen pat",
+                      "originalTitle": "Nespokoen pat"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048746",
+                      "title": "Trenutki odlocitve",
+                      "originalTitle": "Trenutki odlocitve"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047886",
+                      "title": "Blekitny krzyz",
+                      "originalTitle": "Blekitny krzyz"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047916",
+                      "title": "El canto del gallo",
+                      "originalTitle": "El canto del gallo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048453",
+                      "title": "Orgullo",
+                      "originalTitle": "Orgullo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048411",
+                      "title": "The Naked Dawn",
+                      "originalTitle": "The Naked Dawn"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0122855",
+                      "title": "8 X 8: A Chess Sonata in 8 Movements",
+                      "originalTitle": "8 X 8: A Chess Sonata in 8 Movements"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047821",
+                      "title": "Le amiche",
+                      "originalTitle": "Le amiche"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047822",
+                      "title": "Amici per la pelle",
+                      "originalTitle": "Amici per la pelle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047876",
+                      "title": "Il bidone",
+                      "originalTitle": "Il bidone"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047880",
+                      "title": "The Big Knife",
+                      "originalTitle": "The Big Knife"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047940",
+                      "title": "Ciske de Rat",
+                      "originalTitle": "Ciske de Rat"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0047978",
+                      "title": "The Deep Blue Sea",
+                      "originalTitle": "The Deep Blue Sea"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048187",
+                      "title": "Les héros sont fatigués",
+                      "originalTitle": "Les héros sont fatigués"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048248",
+                      "title": "The Kentuckian",
+                      "originalTitle": "The Kentuckian"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048504",
+                      "title": "Poprygunya",
+                      "originalTitle": "Poprygunya"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048728",
+                      "title": "Dorobô narikin",
+                      "originalTitle": "To Catch a Thief"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048820",
+                      "title": "Yôkihi",
+                      "originalTitle": "Yôkihi"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1956,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Volpi Cup",
+        "Special Mention",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "Pasinetti Award",
+        "Best Foreign Documentary"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Not awarded.",
+                  "titles": []
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051029",
+                      "title": "Suor Letizia",
+                      "originalTitle": "Suor Letizia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048200",
+                      "title": "L'impero del sole",
+                      "originalTitle": "L'impero del sole"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049293",
+                      "title": "Der Hauptmann von Köpenick",
+                      "originalTitle": "Der Hauptmann von Köpenick"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049001",
+                      "title": "Bessmertnyy garnizon",
+                      "originalTitle": "Bessmertnyy garnizon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0124437",
+                      "title": "O Drakos",
+                      "originalTitle": "O Drakos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049038",
+                      "title": "Bus Stop",
+                      "originalTitle": "Bus Stop"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0174320",
+                      "title": "Veliki i mali",
+                      "originalTitle": "Veliki i mali"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048933",
+                      "title": "Akasen chitai",
+                      "originalTitle": "Akasen chitai"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048966",
+                      "title": "Kôgeki",
+                      "originalTitle": "Attack"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049010",
+                      "title": "Bigger Than Life",
+                      "originalTitle": "Bigger Than Life"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049012",
+                      "title": "Biruma no tategoto",
+                      "originalTitle": "Biruma no tategoto"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049042",
+                      "title": "Calabuch",
+                      "originalTitle": "Calabuch"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049043",
+                      "title": "Calle Mayor",
+                      "originalTitle": "Calle Mayor"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049259",
+                      "title": "Gervaise",
+                      "originalTitle": "Gervaise"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051099",
+                      "title": "Torero",
+                      "originalTitle": "Torero"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049877",
+                      "title": "La traversée de Paris",
+                      "originalTitle": "La traversée de Paris"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1957,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Volpi Cup",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Best Short Film - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0048956",
+                      "title": "Aparajito",
+                      "originalTitle": "Aparajito"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049773",
+                      "title": "I sogni nel cassetto",
+                      "originalTitle": "I sogni nel cassetto"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0366205",
+                      "title": "Ubaguruma",
+                      "originalTitle": "Ubaguruma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051237",
+                      "title": "Un angelo è sceso a Brooklyn",
+                      "originalTitle": "Un angelo è sceso a Brooklyn"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0274780",
+                      "title": "Los salvajes",
+                      "originalTitle": "Los salvajes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050932",
+                      "title": "Samo ljudi",
+                      "originalTitle": "Samo ljudi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0165926",
+                      "title": "Rendez-vous à Melbourne",
+                      "originalTitle": "Rendez-vous à Melbourne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050126",
+                      "title": "Bitter Victory",
+                      "originalTitle": "Bitter Victory"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049569",
+                      "title": "Oeil pour oeil",
+                      "originalTitle": "Oeil pour oeil"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050487",
+                      "title": "A Hatful of Rain",
+                      "originalTitle": "A Hatful of Rain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050613",
+                      "title": "Kumonosu-jô",
+                      "originalTitle": "Kumonosu-jô"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0049466",
+                      "title": "Malwa",
+                      "originalTitle": "Malwa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050782",
+                      "title": "Byakuya",
+                      "originalTitle": "Le notti bianche"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050993",
+                      "title": "Something of Value",
+                      "originalTitle": "Something of Value"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051015",
+                      "title": "The Story of Esther Costello",
+                      "originalTitle": "The Story of Esther Costello"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050850",
+                      "title": "Porte des Lilas",
+                      "originalTitle": "Porte des Lilas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0342825",
+                      "title": "Nesaa Fi Hayati",
+                      "originalTitle": "Nesaa Fi Hayati"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1958,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Italian Cinema Clubs Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051955",
+                      "title": "Muhômatsu no isshô",
+                      "originalTitle": "Muhômatsu no isshô"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051579",
+                      "title": "En cas de malheur",
+                      "originalTitle": "En cas de malheur"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0052339",
+                      "title": "Une vie",
+                      "originalTitle": "Une vie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051980",
+                      "title": "Narayama bushikô",
+                      "originalTitle": "Narayama bushikô"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0052036",
+                      "title": "Ósmy dzien tygodnia",
+                      "originalTitle": "Ósmy dzien tygodnia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0050756",
+                      "title": "Nattens ljus",
+                      "originalTitle": "Nattens ljus"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0052556",
+                      "title": "恋人たち",
+                      "originalTitle": "Les Amants"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0052631",
+                      "title": "The Black Orchid",
+                      "originalTitle": "The Black Orchid"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051666",
+                      "title": "God's Little Acre",
+                      "originalTitle": "God's Little Acre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051739",
+                      "title": "The Horse's Mouth",
+                      "originalTitle": "The Horse's Mouth"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051963",
+                      "title": "Das Mädchen Rosemarie",
+                      "originalTitle": "Das Mädchen Rosemarie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051530",
+                      "title": "La sfida",
+                      "originalTitle": "La sfida"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051170",
+                      "title": "Vlcí jáma",
+                      "originalTitle": "Vlcí jáma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0170344",
+                      "title": "Otaraant qvrivi",
+                      "originalTitle": "Otaraant qvrivi"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1959,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Special Mention",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Golden Plate"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Tied with La grande guerra (1959).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0053856",
+                      "title": "Il generale Della Rovere",
+                      "originalTitle": "Il generale Della Rovere"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Il generale Della Rovere (1959).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0052861",
+                      "title": "La grande guerra",
+                      "originalTitle": "La grande guerra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0192734",
+                      "title": "V tvoikh rukakh zhizn",
+                      "originalTitle": "V tvoikh rukakh zhizn"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053130",
+                      "title": "La nuit des espions",
+                      "originalTitle": "La nuit des espions"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053176",
+                      "title": "Pociag",
+                      "originalTitle": "Pociag"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051595",
+                      "title": "Esterina",
+                      "originalTitle": "Esterina"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051749",
+                      "title": "Hunde, wollt ihr ewig leben",
+                      "originalTitle": "Hunde, wollt ihr ewig leben"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0173511",
+                      "title": "Álmatlan évek",
+                      "originalTitle": "Álmatlan évek"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051584",
+                      "title": "The Temple of the Golden Pavilion",
+                      "originalTitle": "Enjô"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053291",
+                      "title": "O atsui no ga o suki",
+                      "originalTitle": "Some Like It Hot"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0051365",
+                      "title": "Majutsushi",
+                      "originalTitle": "Ansiktet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0052561",
+                      "title": "Aru satsujin",
+                      "originalTitle": "Anatomy of a Murder"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053473",
+                      "title": "À double tour",
+                      "originalTitle": "À double tour"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053294",
+                      "title": "Sonatas",
+                      "originalTitle": "Sonatas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0052645",
+                      "title": "The Boy and the Bridge",
+                      "originalTitle": "The Boy and the Bridge"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1960,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Best First Work",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054161",
+                      "title": "Le passage du Rhin",
+                      "originalTitle": "Le passage du Rhin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053114",
+                      "title": "Ningen no jôken",
+                      "originalTitle": "Ningen no jôken"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054272",
+                      "title": "Schachnovelle",
+                      "originalTitle": "Schachnovelle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053570",
+                      "title": "Adua e le compagne",
+                      "originalTitle": "Adua e le compagne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053756",
+                      "title": "Taiyô no yûwaku",
+                      "originalTitle": "I delfini"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0175743",
+                      "title": "Holubice",
+                      "originalTitle": "Holubice"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054004",
+                      "title": "Krzyzacy",
+                      "originalTitle": "Krzyzacy"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053628",
+                      "title": "Baltiyskoe nebo",
+                      "originalTitle": "Baltiyskoe nebo"
+                    },
+                    {
+                      "imdbId": "tt0053628",
+                      "title": "Baltiyskoe nebo",
+                      "originalTitle": "Baltiyskoe nebo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053604",
+                      "title": "Apâto no kagi kashimasu",
+                      "originalTitle": "The Apartment"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054039",
+                      "title": "La lunga notte del '43",
+                      "originalTitle": "La lunga notte del '43"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054229",
+                      "title": "Rat",
+                      "originalTitle": "Rat"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054248",
+                      "title": "Wakamono no subete",
+                      "originalTitle": "Rocco e i suoi fratelli"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054412",
+                      "title": "Tunes of Glory",
+                      "originalTitle": "Tunes of Glory"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056667",
+                      "title": "Le voyage en ballon",
+                      "originalTitle": "Le voyage en ballon"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1961,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Best First Work",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Italian Cinema Clubs Award",
+        "Award of the City of Imola",
+        "Award of the City of Venice"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054632",
+                      "title": "L'année dernière à Marienbad",
+                      "originalTitle": "L'année dernière à Marienbad"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054931",
+                      "title": "Il giudizio universale",
+                      "originalTitle": "Il giudizio universale"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0172649",
+                      "title": "Kde reky mají slunce",
+                      "originalTitle": "Kde reky mají slunce"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054928",
+                      "title": "La fille aux yeux d'or",
+                      "originalTitle": "La fille aux yeux d'or"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054701",
+                      "title": "Bridge to the Sun",
+                      "originalTitle": "Bridge to the Sun"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0053632",
+                      "title": "Banditi a Orgosolo",
+                      "originalTitle": "Banditi a Orgosolo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0054702",
+                      "title": "Il brigante",
+                      "originalTitle": "Il brigante"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0055401",
+                      "title": "Samson",
+                      "originalTitle": "Samson"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0055489",
+                      "title": "Summer and Smoke",
+                      "originalTitle": "Summer and Smoke"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0055244",
+                      "title": "Tu ne tueras point",
+                      "originalTitle": "Tu ne tueras point"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0055585",
+                      "title": "Vanina Vanini",
+                      "originalTitle": "Vanina Vanini"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0055597",
+                      "title": "Victim",
+                      "originalTitle": "Victim"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0055630",
+                      "title": "Bodyguard",
+                      "originalTitle": "Yôjinbô"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": "There were two recipients of this nomination.",
+                  "titles": [
+                    {
+                      "imdbId": "tt0055181",
+                      "title": "Souzetu! tekityuu toppa",
+                      "originalTitle": "Mir vkhodyashchemu"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1962,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Best First Work",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Italian Cinema Clubs Award",
+        "Award of the City of Imola",
+        "Award of the City of Imola - Special Mention",
+        "Cinema 60 Award",
+        "Award of the City of Venice",
+        "Catholic Cinema Clubs Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Cronaca familiare (1962).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0056111",
+                      "title": "Ivan's Childhood",
+                      "originalTitle": "Ivanovo detstvo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Ivan's Childhood (1962).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0056966",
+                      "title": "Cronaca familiare",
+                      "originalTitle": "Cronaca familiare"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056502",
+                      "title": "Smog",
+                      "originalTitle": "Smog"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056205",
+                      "title": "Lyudi i zveri",
+                      "originalTitle": "Lyudi i zveri"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056076",
+                      "title": "Homenaje a la hora de la siesta",
+                      "originalTitle": "Homenaje a la hora de la siesta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0203629",
+                      "title": "Koiya koi nasu na koi",
+                      "originalTitle": "Koiya koi nasu na koi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0055798",
+                      "title": "Birdman of Alcatraz",
+                      "originalTitle": "Birdman of Alcatraz"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056193",
+                      "title": "Lolita",
+                      "originalTitle": "Lolita"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056215",
+                      "title": "Mamma Roma",
+                      "originalTitle": "Mamma Roma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056568",
+                      "title": "Term of Trial",
+                      "originalTitle": "Term of Trial"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056581",
+                      "title": "Thérèse Desqueyroux",
+                      "originalTitle": "Thérèse Desqueyroux"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056663",
+                      "title": "Onna to Otoko no Iru Hodô",
+                      "originalTitle": "Vivre sa vie: film en douze tableaux"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057427",
+                      "title": "Le Procès",
+                      "originalTitle": "Le Procès"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059160",
+                      "title": "Eva no nioi",
+                      "originalTitle": "Eva"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1963,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Best First Work",
+        "New Cinema Award",
+        "Best Short Film",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "UNICRIT Award",
+        "Pasinetti Award",
+        "Lion of San Marco - Grand Prize",
+        "Award of the City of Venice"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Unanimously.",
+                  "titles": [
+                    {
+                      "imdbId": "tt0057286",
+                      "title": "Le mani sulla città",
+                      "originalTitle": "Le mani sulla città"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057289",
+                      "title": "Mare matto",
+                      "originalTitle": "Mare matto"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057013",
+                      "title": "Dragées au poivre",
+                      "originalTitle": "Dragées au poivre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0403353",
+                      "title": "人間",
+                      "originalTitle": "Ningen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0191326",
+                      "title": "Omicron",
+                      "originalTitle": "Omicron"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057308",
+                      "title": "Milczenie",
+                      "originalTitle": "Milczenie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056881",
+                      "title": "Bolshaya doroga",
+                      "originalTitle": "Bolshaya doroga"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056952",
+                      "title": "The Cool World",
+                      "originalTitle": "The Cool World"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0056868",
+                      "title": "Billy Liar",
+                      "originalTitle": "Billy Liar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057058",
+                      "title": "Le Feu follet",
+                      "originalTitle": "Le Feu follet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057163",
+                      "title": "Hud",
+                      "originalTitle": "Hud"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057336",
+                      "title": "Muriel ou le Temps d'un retour",
+                      "originalTitle": "Muriel ou le Temps d'un retour"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057370",
+                      "title": "Nunca pasa nada",
+                      "originalTitle": "Nunca pasa nada"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057490",
+                      "title": "Meshitsukai",
+                      "originalTitle": "The Servant"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057565",
+                      "title": "Tengoku to jigoku",
+                      "originalTitle": "Tengoku to jigoku"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057590",
+                      "title": "Tomu Jônzu no karei na bôken",
+                      "originalTitle": "Tom Jones"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057643",
+                      "title": "El verdugo",
+                      "originalTitle": "El verdugo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0175312",
+                      "title": "Vstuplenie",
+                      "originalTitle": "Vstuplenie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0176345",
+                      "title": "Zlaté kapradí",
+                      "originalTitle": "Zlaté kapradí"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1964,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Best First Work",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Biennale Award",
+        "Lion of San Marco - Grand Prize",
+        "Award of the City of Venice"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058003",
+                      "title": "Akai Sabaku",
+                      "originalTitle": "Il deserto rosso"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057842",
+                      "title": "Les amitiés particulières",
+                      "originalTitle": "Les amitiés particulières"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058414",
+                      "title": "Nothing But a Man",
+                      "originalTitle": "Nothing But a Man"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058277",
+                      "title": "Kradetzat na praskovi",
+                      "originalTitle": "Kradetzat na praskovi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0057861",
+                      "title": "Att älska",
+                      "originalTitle": "Att älska"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058126",
+                      "title": "Gamlet",
+                      "originalTitle": "Gamlet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058142",
+                      "title": "Midori no hitomi",
+                      "originalTitle": "Girl with Green Eyes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058263",
+                      "title": "King & Country",
+                      "originalTitle": "King & Country"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058670",
+                      "title": "Tonio Kröger",
+                      "originalTitle": "Tonio Kröger"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058701",
+                      "title": "Koibito no iru jikan",
+                      "originalTitle": "Une femme mariée : Suite de fragments d'un film tourné en 1964"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058715",
+                      "title": "Kiseki no Oka",
+                      "originalTitle": "Il vangelo secondo Matteo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059874",
+                      "title": "La vie à l'envers",
+                      "originalTitle": "La vie à l'envers"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1965,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Best First Work",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "UNICRIT Award",
+        "Lion of San Marco - Grand Prize",
+        "Lion of San Marco",
+        "Silver Medal",
+        "San Michele Award",
+        "Golden Rudder",
+        "Award of the City of Imola",
+        "Plaque Lion St. Marc"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059856",
+                      "title": "Kumaza no awaki hoshikage",
+                      "originalTitle": "Vaghe stelle dell'Orsa..."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0144017",
+                      "title": "Good Times, Wonderful Times",
+                      "originalTitle": "Good Times, Wonderful Times"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0176285",
+                      "title": "Vernost",
+                      "originalTitle": "Vernost"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058888",
+                      "title": "Akahige",
+                      "originalTitle": "Akahige"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059348",
+                      "title": "Kapurush",
+                      "originalTitle": "Kapurush"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059415",
+                      "title": "Lásky jedné plavovlásky",
+                      "originalTitle": "Lásky jedné plavovlásky"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059447",
+                      "title": "Mickey One",
+                      "originalTitle": "Mickey One"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058361",
+                      "title": "Mne dvadtsat let",
+                      "originalTitle": "Mne dvadtsat let"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059592",
+                      "title": "Kichigai Piero",
+                      "originalTitle": "Pierrot le fou"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059719",
+                      "title": "Sabaku no Shimon",
+                      "originalTitle": "Simón del desierto"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0179492",
+                      "title": "Trois chambres à Manhattan",
+                      "originalTitle": "Trois chambres à Manhattan"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059229",
+                      "title": "魂のジュリエッタ",
+                      "originalTitle": "Giulietta degli spiriti"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1966,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Special Mention",
+        "New Cinema Award",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "Italian Cinema Clubs Award",
+        "Special Prize",
+        "Lion of San Marco - Grand Prize",
+        "Lion of San Marco",
+        "Plate 'Lion of San Marco'",
+        "Plate",
+        "Honorary Diploma",
+        "Premio per la migliore interpretazione",
+        "Luis Buñuel Award",
+        "CIDALC Award",
+        "Cinema 60 Award",
+        "Award of the City of Venice",
+        "Cineforum 66 Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058946",
+                      "title": "アルジェの戦い",
+                      "originalTitle": "La battaglia di Algeri"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060197",
+                      "title": "La busca",
+                      "originalTitle": "La busca"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060138",
+                      "title": "Balthazar Doko e Yuku",
+                      "originalTitle": "Au hasard Balthazar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060263",
+                      "title": "Les créatures",
+                      "originalTitle": "Les créatures"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0058925",
+                      "title": "Atithi",
+                      "originalTitle": "Atithi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060063",
+                      "title": "Abschied von gestern - (Anita G.)",
+                      "originalTitle": "Abschied von gestern - (Anita G.)"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059025",
+                      "title": "Chappaqua",
+                      "originalTitle": "Chappaqua"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060271",
+                      "title": "La curée",
+                      "originalTitle": "La curée"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060390",
+                      "title": "Kashi 451",
+                      "originalTitle": "Fahrenheit 451"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060740",
+                      "title": "Nattlek",
+                      "originalTitle": "Nattlek"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059585",
+                      "title": "最初の教師",
+                      "originalTitle": "Pervyy uchitel"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0059850",
+                      "title": "Un uomo a metà",
+                      "originalTitle": "Un uomo a metà"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061189",
+                      "title": "The Wild Angels",
+                      "originalTitle": "The Wild Angels"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0253002",
+                      "title": "Comédie",
+                      "originalTitle": "Comédie"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1967,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Best First Work",
+        "New Cinema Award",
+        "Best Short Film",
+        "San Giorgio Prize",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Golden Rudder"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061395",
+                      "title": "Belle de jour",
+                      "originalTitle": "Belle de jour"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062293",
+                      "title": "Sovversivi",
+                      "originalTitle": "Sovversivi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063406",
+                      "title": "Il padre di famiglia",
+                      "originalTitle": "Il padre di famiglia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061493",
+                      "title": "Col cuore in gola",
+                      "originalTitle": "Col cuore in gola"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062048",
+                      "title": "Noc nevesty",
+                      "originalTitle": "Noc nevesty"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063535",
+                      "title": "O Salto",
+                      "originalTitle": "O Salto"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061616",
+                      "title": "Egy szerelem három éjszakája",
+                      "originalTitle": "Egy szerelem három éjszakája"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061084",
+                      "title": "Oi voskoi",
+                      "originalTitle": "Oi voskoi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1817125",
+                      "title": "Desert People",
+                      "originalTitle": "Desert People"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0166894",
+                      "title": "Otklonenie",
+                      "originalTitle": "Otklonenie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061473",
+                      "title": "La Chinoise",
+                      "originalTitle": "La Chinoise"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061483",
+                      "title": "La Cina è vicina",
+                      "originalTitle": "La Cina è vicina"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060358",
+                      "title": "Dutchman",
+                      "originalTitle": "Dutchman"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061613",
+                      "title": "Aporon no jigoku",
+                      "originalTitle": "Edipo Re"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061854",
+                      "title": "Jutro",
+                      "originalTitle": "Jutro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0060653",
+                      "title": "Mahlzeiten",
+                      "originalTitle": "Mahlzeiten"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062089",
+                      "title": "Our Mother's House",
+                      "originalTitle": "Our Mother's House"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062310",
+                      "title": "Ihôjin",
+                      "originalTitle": "Lo straniero"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061146",
+                      "title": "Utószezon",
+                      "originalTitle": "Utószezon"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1968,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Volpi Cup",
+        "Honorable Mention",
+        "Pasinetti Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062679",
+                      "title": "Die Artisten in der Zirkuskuppel: ratlos",
+                      "originalTitle": "Die Artisten in der Zirkuskuppel: ratlos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0272473",
+                      "title": "Ballade pour un chien",
+                      "originalTitle": "Ballade pour un chien"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061536",
+                      "title": "Csend és kiáltás",
+                      "originalTitle": "Csend és kiáltás"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063563",
+                      "title": "Das Schloß",
+                      "originalTitle": "Das Schloß"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0064228",
+                      "title": "Después del diluvio",
+                      "originalTitle": "Después del diluvio"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062889",
+                      "title": "Diario di una schizofrenica",
+                      "originalTitle": "Diario di una schizofrenica"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0061641",
+                      "title": "Falak",
+                      "originalTitle": "Falak"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0173870",
+                      "title": "Fuoco!",
+                      "originalTitle": "Fuoco!"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062998",
+                      "title": "Galileo",
+                      "originalTitle": "Galileo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063182",
+                      "title": "Kierion",
+                      "originalTitle": "Kierion"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0155415",
+                      "title": "L'écume des jours",
+                      "originalTitle": "L'écume des jours"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0065695",
+                      "title": "L'enfance nue",
+                      "originalTitle": "L'enfance nue"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063286",
+                      "title": "Me and My Brother",
+                      "originalTitle": "Me and My Brother"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0064689",
+                      "title": "Monterey Pop",
+                      "originalTitle": "Monterey Pop"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063414",
+                      "title": "Partner.",
+                      "originalTitle": "Partner."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063444",
+                      "title": "Podne",
+                      "originalTitle": "Podne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0188194",
+                      "title": "Sept jours ailleurs",
+                      "originalTitle": "Sept jours ailleurs"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063651",
+                      "title": "Stress-es tres-tres",
+                      "originalTitle": "Stress-es tres-tres"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0166371",
+                      "title": "Summit",
+                      "originalTitle": "Summit"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063675",
+                      "title": "Tell Me Lies",
+                      "originalTitle": "Tell Me Lies"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0229039",
+                      "title": "Wheel of Ashes",
+                      "originalTitle": "Wheel of Ashes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063808",
+                      "title": "Wild in the Streets",
+                      "originalTitle": "Wild in the Streets"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0171940",
+                      "title": "Zbehovia a pútnici",
+                      "originalTitle": "Zbehovia a pútnici"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0062952",
+                      "title": "Faces",
+                      "originalTitle": "Faces"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063366",
+                      "title": "Nostra signora dei turchi",
+                      "originalTitle": "Nostra signora dei turchi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0128558",
+                      "title": "Le Socrate",
+                      "originalTitle": "Le Socrate"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0063678",
+                      "title": "Teorema",
+                      "originalTitle": "Teorema"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1969,
+      "awardNames": [
+        "Career Golden Lion",
+        "Pasinetti Award",
+        "Golden Rudder",
+        "Luis Buñuel Award",
+        "CIDALC Award"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1970,
+      "awardNames": [
+        "Career Golden Lion",
+        "Pasinetti Award",
+        "\"Lino Miccichè\" First Feature Award",
+        "Silver Medal"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1971,
+      "awardNames": [
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Special Award",
+        "Golden Rudder",
+        "CIDALC Award"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1972,
+      "awardNames": [
+        "Silver Lion",
+        "Career Golden Lion",
+        "Best Short Film",
+        "FIPRESCI Prize",
+        "Pasinetti Award",
+        "Italian Film Critics Award",
+        "Young Venice Award - Special Mention",
+        "Best Color Film",
+        "Venezia Giovani Prize"
+      ],
+      "goldenLion": []
+    },
+    {
+      "year": 1979,
+      "awardNames": [
+        "Golden Lion",
+        "FIPRESCI Prize",
+        "FIPRESCI Prize - Honorable Mention",
+        "Pasinetti Award",
+        "Pietro Bianchi Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0078978",
+                      "title": "Clair de femme",
+                      "originalTitle": "Clair de femme"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1980,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Best First Work",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Special Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "UNICEF Award - Special Mention",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Special Jury Citation",
+        "AGIS Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Gloria (1980).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0080388",
+                      "title": "Atlantic City",
+                      "originalTitle": "Atlantic City"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Atlantic City (1980).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0080798",
+                      "title": "Gloria",
+                      "originalTitle": "Gloria"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0079219",
+                      "title": "Going in Style",
+                      "originalTitle": "Going in Style"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0081330",
+                      "title": "La petite sirène",
+                      "originalTitle": "La petite sirène"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0080619",
+                      "title": "Deux lions au soleil",
+                      "originalTitle": "Deux lions au soleil"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0230686",
+                      "title": "Rasskaz neizvestnogo cheloveka",
+                      "originalTitle": "Rasskaz neizvestnogo cheloveka"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082993",
+                      "title": "Richard's Things",
+                      "originalTitle": "Richard's Things"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0080910",
+                      "title": "A Idade da Terra",
+                      "originalTitle": "A Idade da Terra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0081150",
+                      "title": "Melvin and Howard",
+                      "originalTitle": "Melvin and Howard"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0081148",
+                      "title": "O Megalexandros",
+                      "originalTitle": "O Megalexandros"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1981,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Honorable Mention",
+        "Special Mention",
+        "Best First Work",
+        "New Cinema Award",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Golden Phoenix",
+        "AGIS Award",
+        "Alitalia Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082081",
+                      "title": "Die bleierne Zeit",
+                      "originalTitle": "Die bleierne Zeit"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082317",
+                      "title": "Eles Não Usam Black-Tie",
+                      "originalTitle": "Eles Não Usam Black-Tie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0081363",
+                      "title": "Postriziny",
+                      "originalTitle": "Postriziny"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082154",
+                      "title": "Chaalchitra",
+                      "originalTitle": "Chaalchitra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0132762",
+                      "title": "Beyroutou el lika",
+                      "originalTitle": "Beyroutou el lika"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0158510",
+                      "title": "Bosco d'amore",
+                      "originalTitle": "Bosco d'amore"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084505",
+                      "title": "Piso pisello",
+                      "originalTitle": "Piso pisello"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083102",
+                      "title": "Sogni d'oro",
+                      "originalTitle": "Sogni d'oro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082876",
+                      "title": "Pad Italije",
+                      "originalTitle": "Pad Italije"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082401",
+                      "title": "Forfølgelsen",
+                      "originalTitle": "Forfølgelsen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082945",
+                      "title": "Prince of the City",
+                      "originalTitle": "Prince of the City"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083232",
+                      "title": "True Confessions",
+                      "originalTitle": "True Confessions"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083367",
+                      "title": "A zsarnok szíve, avagy Boccaccio Magyarországon",
+                      "originalTitle": "A zsarnok szíve, avagy Boccaccio Magyarországon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083145",
+                      "title": "Zvezdopad",
+                      "originalTitle": "Zvezdopad"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0080957",
+                      "title": "Les jeux de la comtesse Dolingen de Gratz",
+                      "originalTitle": "Les jeux de la comtesse Dolingen de Gratz"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082834",
+                      "title": "Le occasioni di Rosa",
+                      "originalTitle": "Le occasioni di Rosa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083706",
+                      "title": "La caduta degli angeli ribelli",
+                      "originalTitle": "La caduta degli angeli ribelli"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083089",
+                      "title": "Sjecas li se, Dolly Bell",
+                      "originalTitle": "Sjecas li se, Dolly Bell"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083082",
+                      "title": "Silvestre",
+                      "originalTitle": "Silvestre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0080985",
+                      "title": "Kargus",
+                      "originalTitle": "Kargus"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1982,
+      "awardNames": [
+        "Golden Lion",
+        "Special Jury Prize",
+        "Best First Work",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Venice Authors Prize - Special Mention",
+        "Best Overall Artistic Contribution",
+        "Golden Phoenix",
+        "Best Artistic Collaboration"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084725",
+                      "title": "Der Stand der Dinge",
+                      "originalTitle": "Der Stand der Dinge"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": "Marcel Carné (President of the Jury) withdrew after releasing the following statement, \"I would love to make a personal statement. While being President of the Jury, I would love to express my disappointment in not having been able to convince my colleagues to place R.W. Fassbinder's \"Querelle\" among the winners. As a matter of fact, I've found myself alone in defending the Movie. Nevertheless, I keep on thinking that, although controversial, R.W. Fassbinder final movie, want it or not, love it or hate it, will one day find its place in the history of cinema.\"",
+                  "titles": [
+                    {
+                      "imdbId": "tt0084565",
+                      "title": "Querelle",
+                      "originalTitle": "Querelle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084123",
+                      "title": "Imperativ",
+                      "originalTitle": "Imperativ"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084136",
+                      "title": "Ingenjör Andrées luftfärd",
+                      "originalTitle": "Ingenjör Andrées luftfärd"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084776",
+                      "title": "Tempest",
+                      "originalTitle": "Tempest"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083732",
+                      "title": "Chastnaya zhizn",
+                      "originalTitle": "Chastnaya zhizn"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083851",
+                      "title": "Eikoku shiki teien satsujin jiken",
+                      "originalTitle": "The Draughtsman's Contract"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084042",
+                      "title": "Hadduta misrija",
+                      "originalTitle": "Hadduta misrija"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082053",
+                      "title": "Utsukushiki kekkon",
+                      "originalTitle": "Le Beau Mariage"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084019",
+                      "title": "Le grand frère",
+                      "originalTitle": "Le grand frère"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084558",
+                      "title": "Qu'est-ce qu'on attend pour être heureux!",
+                      "originalTitle": "Qu'est-ce qu'on attend pour être heureux!"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084829",
+                      "title": "La truite",
+                      "originalTitle": "La truite"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084065",
+                      "title": "Hero",
+                      "originalTitle": "Hero"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0258587",
+                      "title": "To fragma",
+                      "originalTitle": "To fragma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084027",
+                      "title": "Grihajuddha",
+                      "originalTitle": "Grihajuddha"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0158532",
+                      "title": "Il buon soldato",
+                      "originalTitle": "Il buon soldato"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083744",
+                      "title": "Colpire al cuore",
+                      "originalTitle": "Colpire al cuore"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084030",
+                      "title": "Grog",
+                      "originalTitle": "Grog"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084432",
+                      "title": "Gli occhi, la bocca",
+                      "originalTitle": "Gli occhi, la bocca"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0194234",
+                      "title": "Il pianeta azzurro",
+                      "originalTitle": "Il pianeta azzurro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0184883",
+                      "title": "Sciopèn",
+                      "originalTitle": "Sciopèn"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084697",
+                      "title": "De smaak van water",
+                      "originalTitle": "De smaak van water"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083904",
+                      "title": "A Estrangeira",
+                      "originalTitle": "A Estrangeira"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0082066",
+                      "title": "Die Beunruhigung",
+                      "originalTitle": "Die Beunruhigung"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083984",
+                      "title": "Fünf letzte Tage",
+                      "originalTitle": "Fünf letzte Tage"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083903",
+                      "title": "Estoy en crisis",
+                      "originalTitle": "Estoy en crisis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0164621",
+                      "title": "Guernica",
+                      "originalTitle": "Guernica"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084012",
+                      "title": "Golos",
+                      "originalTitle": "Golos"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084808",
+                      "title": "Toute une nuit",
+                      "originalTitle": "Toute une nuit"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1983,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Best Actor",
+        "Best Actress",
+        "Best First Work",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "De Sica Award",
+        "Technical Prize"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086153",
+                      "title": "Prénom Carmen",
+                      "originalTitle": "Prénom Carmen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086968",
+                      "title": "Biquefarre",
+                      "originalTitle": "Biquefarre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086213",
+                      "title": "Rue Cases Nègres",
+                      "originalTitle": "Rue Cases Nègres"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086447",
+                      "title": "Tisícrocná vcela",
+                      "originalTitle": "Tisícrocná vcela"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085597",
+                      "title": "Una gita scolastica",
+                      "originalTitle": "Una gita scolastica"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090996",
+                      "title": "Ediths Tagebuch",
+                      "originalTitle": "Ediths Tagebuch"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0253134",
+                      "title": "Hotel Central",
+                      "originalTitle": "Hotel Central"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085901",
+                      "title": "Maria Chapdelaine",
+                      "originalTitle": "Maria Chapdelaine"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086542",
+                      "title": "La vie est un roman",
+                      "originalTitle": "La vie est un roman"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085642",
+                      "title": "Hanna K.",
+                      "originalTitle": "Hanna K."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085444",
+                      "title": "Il disertore",
+                      "originalTitle": "Il disertore"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085843",
+                      "title": "Eine Liebe in Deutschland",
+                      "originalTitle": "Eine Liebe in Deutschland"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085759",
+                      "title": "Jogo de Mão",
+                      "originalTitle": "Jogo de Mão"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0083594",
+                      "title": "Der Aufenthalt",
+                      "originalTitle": "Der Aufenthalt"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085950",
+                      "title": "Mitten ins Herz",
+                      "originalTitle": "Mitten ins Herz"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089210",
+                      "title": "Glut",
+                      "originalTitle": "Glut"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084311",
+                      "title": "Mat Mariya",
+                      "originalTitle": "Mat Mariya"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085295",
+                      "title": "Careful, He Might Hear You",
+                      "originalTitle": "Careful, He Might Hear You"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086242",
+                      "title": "Sasameyuki",
+                      "originalTitle": "Sasameyuki"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0085882",
+                      "title": "Die Macht der Gefühle",
+                      "originalTitle": "Die Macht der Gefühle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086377",
+                      "title": "Streamers",
+                      "originalTitle": "Streamers"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1984,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Best Actor",
+        "Best Actress",
+        "Best First Work",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Critics' Week Award",
+        "Young Venice Award",
+        "De Sica Award",
+        "Venice TV Prize",
+        "Venezia Genti - Best Feature Film",
+        "Venezia Genti - Best Short Film",
+        "Technical Prize"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Unanimously.",
+                  "titles": [
+                    {
+                      "imdbId": "tt0088009",
+                      "title": "Rok spokojnego slonca",
+                      "originalTitle": "Rok spokojnego slonca"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086951",
+                      "title": "Bereg",
+                      "originalTitle": "Bereg"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087813",
+                      "title": "Noi tre",
+                      "originalTitle": "Noi tre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086897",
+                      "title": "Angelan sota",
+                      "originalTitle": "Angelan sota"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087310",
+                      "title": "Il futuro è donna",
+                      "originalTitle": "Il futuro è donna"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0138811",
+                      "title": "Sister Stella L.",
+                      "originalTitle": "Sister Stella L."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0122241",
+                      "title": "Uno scandalo perbene",
+                      "originalTitle": "Uno scandalo perbene"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087868",
+                      "title": "渡河",
+                      "originalTitle": "Paar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0843460",
+                      "title": "Ybris",
+                      "originalTitle": "Ybris"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087365",
+                      "title": "Greystoke: The Legend of Tarzan, Lord of the Apes",
+                      "originalTitle": "Greystoke: The Legend of Tarzan, Lord of the Apes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0123381",
+                      "title": "Angyali üdvözlet",
+                      "originalTitle": "Angyali üdvözlet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0084710",
+                      "title": "Der Spiegel",
+                      "originalTitle": "Der Spiegel"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090214",
+                      "title": "Tukuma",
+                      "originalTitle": "Tukuma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087682",
+                      "title": "Maria's Lovers",
+                      "originalTitle": "Maria's Lovers"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087246",
+                      "title": "Les Favoris de la lune",
+                      "originalTitle": "Les Favoris de la lune"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0088151",
+                      "title": "Sonatine",
+                      "originalTitle": "Sonatine"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086890",
+                      "title": "L'amour à mort",
+                      "originalTitle": "L'amour à mort"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0086889",
+                      "title": "L'amour par terre",
+                      "originalTitle": "L'amour par terre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087821",
+                      "title": "Les Nuits de la pleine lune",
+                      "originalTitle": "Les Nuits de la pleine lune"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0210003",
+                      "title": "Dionysos",
+                      "originalTitle": "Dionysos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0088443",
+                      "title": "Los zancos",
+                      "originalTitle": "Los zancos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087804",
+                      "title": "Ninguém Duas Vezes",
+                      "originalTitle": "Ninguém Duas Vezes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087064",
+                      "title": "Kuraretta Petacchi no densetsu",
+                      "originalTitle": "Claretta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093610",
+                      "title": "La neve nel bicchiere",
+                      "originalTitle": "La neve nel bicchiere"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0356499",
+                      "title": "Da qiao xia mian",
+                      "originalTitle": "Da qiao xia mian"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1985,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Special Jury Prize",
+        "Best Actor",
+        "Best Actress",
+        "Special Mention",
+        "Best First Work",
+        "Career Golden Lion",
+        "Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Young Venice Award",
+        "Young Venice Award - Special Mention",
+        "De Sica Award",
+        "Sergio Trasatti Award",
+        "Sergio Trasatti Award - Special Mention",
+        "Venice TV Prize",
+        "Venice TV Prize - Special Mention",
+        "Special Prize",
+        "Venezia Genti - Best Feature Film",
+        "Venezia Genti - Best Short Film",
+        "Special Lion for the Overall Work"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089960",
+                      "title": "Fuyu no Tabi",
+                      "originalTitle": "Sans toit ni loi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0376779",
+                      "title": "Bekçi",
+                      "originalTitle": "Bekçi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090338",
+                      "title": "La donna delle meraviglie",
+                      "originalTitle": "La donna delle meraviglie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089061",
+                      "title": "Dust",
+                      "originalTitle": "Dust"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089800",
+                      "title": "Perinbaba",
+                      "originalTitle": "Perinbaba"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089209",
+                      "title": "Glissando",
+                      "originalTitle": "Glissando"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089469",
+                      "title": "Legend",
+                      "originalTitle": "Legend"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089491",
+                      "title": "The Lightship",
+                      "originalTitle": "The Lightship"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089542",
+                      "title": "Mamma Ebe",
+                      "originalTitle": "Mamma Ebe"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089693",
+                      "title": "No Man's Land",
+                      "originalTitle": "No Man's Land"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0087878",
+                      "title": "Parad planet",
+                      "originalTitle": "Parad planet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089774",
+                      "title": "Los paraísos perdidos",
+                      "originalTitle": "Los paraísos perdidos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089802",
+                      "title": "Pervola, sporen in de sneeuw",
+                      "originalTitle": "Pervola, sporen in de sneeuw"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089804",
+                      "title": "Petrina hronia",
+                      "originalTitle": "Petrina hronia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089821",
+                      "title": "Police",
+                      "originalTitle": "Police"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089841",
+                      "title": "Onna to Otoko no Meiyo",
+                      "originalTitle": "Prizzi's Honor"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089946",
+                      "title": "Réquiem por un campesino español",
+                      "originalTitle": "Réquiem por un campesino español"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0122709",
+                      "title": "Shokutaku no nai ie",
+                      "originalTitle": "Shokutaku no nai ie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090052",
+                      "title": "Le soulier de satin",
+                      "originalTitle": "Le soulier de satin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090124",
+                      "title": "Mer mankutyan tangon",
+                      "originalTitle": "Mer mankutyan tangon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090253",
+                      "title": "Vergeßt Mozart",
+                      "originalTitle": "Vergeßt Mozart"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090125",
+                      "title": "El exilio de Gardel: Tangos",
+                      "originalTitle": "El exilio de Gardel: Tangos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090374",
+                      "title": "Zivot je lep",
+                      "originalTitle": "Zivot je lep"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0088810",
+                      "title": "Biruma no tategoto",
+                      "originalTitle": "Biruma no tategoto"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1986,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Special Jury Prize",
+        "Best Actor",
+        "Best Actress",
+        "Best First Work",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Golden Ciak",
+        "FIPRESCI Prize",
+        "FIPRESCI Prize - Honorable Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "De Sica Award",
+        "Venice TV Prize",
+        "Venice Authors Prize",
+        "Venice Authors Prize - Special Mention",
+        "De Sica Award - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091830",
+                      "title": "Le Rayon vert",
+                      "originalTitle": "Le Rayon vert"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091506",
+                      "title": "O melissokomos",
+                      "originalTitle": "O melissokomos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091837",
+                      "title": "Regalo di Natale",
+                      "originalTitle": "Regalo di Natale"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091335",
+                      "title": "Khrani menya, moy talisman",
+                      "originalTitle": "Khrani menya, moy talisman"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091712",
+                      "title": "Oviri",
+                      "originalTitle": "Oviri"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091801",
+                      "title": "La puritaine",
+                      "originalTitle": "La puritaine"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092244",
+                      "title": "X",
+                      "originalTitle": "X"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091253",
+                      "title": "Idö van",
+                      "originalTitle": "Idö van"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091676",
+                      "title": "On Valentine's Day",
+                      "originalTitle": "On Valentine's Day"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091839",
+                      "title": "Die Reise",
+                      "originalTitle": "Die Reise"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091867",
+                      "title": "Nagame no ii heya",
+                      "originalTitle": "A Room with a View"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093930",
+                      "title": "Das Schweigen des Dichters",
+                      "originalTitle": "Das Schweigen des Dichters"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091035",
+                      "title": "Fatherland",
+                      "originalTitle": "Fatherland"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092017",
+                      "title": "Storia d'amore",
+                      "originalTitle": "Storia d'amore"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0200055",
+                      "title": "Romance",
+                      "originalTitle": "Romance"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092200",
+                      "title": "Werther",
+                      "originalTitle": "Werther"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0137912",
+                      "title": "Linna",
+                      "originalTitle": "Linna"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091196",
+                      "title": "El hermano bastardo de Dios",
+                      "originalTitle": "El hermano bastardo de Dios"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090845",
+                      "title": "Chuzhaya belaya i ryaboy",
+                      "originalTitle": "Chuzhaya belaya i ryaboy"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0089794",
+                      "title": "La película del rey",
+                      "originalTitle": "La película del rey"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090557",
+                      "title": "'Round Midnight",
+                      "originalTitle": "'Round Midnight"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093348",
+                      "title": "Kinema no tenchi",
+                      "originalTitle": "Kinema no tenchi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0090637",
+                      "title": "Amorosa",
+                      "originalTitle": "Amorosa"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1987,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Best Actor",
+        "Best Actress",
+        "Honorable Mention",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Golden Ciak",
+        "Special Golden Ciak",
+        "'Commendatore al merito della Repubblica' Medal",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Elvira Notari Prize",
+        "Sergio Trasatti Award",
+        "Cinecritica Award",
+        "Award of the Society for Psychology"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092593",
+                      "title": "Sayonara kodomotachi",
+                      "originalTitle": "Au revoir les enfants"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091769",
+                      "title": "Plyumbum, ili Opasnaya igra",
+                      "originalTitle": "Plyumbum, ili Opasnaya igra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093807",
+                      "title": "Quartiere",
+                      "originalTitle": "Quartiere"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091695",
+                      "title": "Oridathu",
+                      "originalTitle": "Oridathu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093205",
+                      "title": "L'homme voilé",
+                      "originalTitle": "L'homme voilé"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092694",
+                      "title": "Un ragazzo di Calabria",
+                      "originalTitle": "Un ragazzo di Calabria"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0133211",
+                      "title": "Le sourd dans la ville",
+                      "originalTitle": "Le sourd dans la ville"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092774",
+                      "title": "Comédie!",
+                      "originalTitle": "Comédie!"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092901",
+                      "title": "Divinas palabras",
+                      "originalTitle": "Divinas palabras"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093965",
+                      "title": "Si le soleil ne revenait pas",
+                      "originalTitle": "Si le soleil ne revenait pas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093194",
+                      "title": "Hip hip hurra!",
+                      "originalTitle": "Hip hip hurra!"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0091953",
+                      "title": "Shibaji",
+                      "originalTitle": "Sibaji"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093502",
+                      "title": "Marusa no onna",
+                      "originalTitle": "Marusa no onna"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093512",
+                      "title": "Maurice",
+                      "originalTitle": "Maurice"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0094094",
+                      "title": "Szörnyek évadja",
+                      "originalTitle": "Szörnyek évadja"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092558",
+                      "title": "Anayurt Oteli",
+                      "originalTitle": "Anayurt Oteli"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093223",
+                      "title": "House of Games",
+                      "originalTitle": "House of Games"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093453",
+                      "title": "Gli occhiali d'oro",
+                      "originalTitle": "Gli occhiali d'oro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093454",
+                      "title": "Lunga vita alla signora!",
+                      "originalTitle": "Lunga vita alla signora!"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092875",
+                      "title": "O Desejado",
+                      "originalTitle": "O Desejado"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0093467",
+                      "title": "Made in Heaven",
+                      "originalTitle": "Made in Heaven"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096217",
+                      "title": "The Tale of Ruby Rose",
+                      "originalTitle": "The Tale of Ruby Rose"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0094239",
+                      "title": "La vallée fantôme",
+                      "originalTitle": "La vallée fantôme"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1988,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "Special Mention",
+        "The President of the Italian Senate's Gold Medal",
+        "New Cinema Award",
+        "New Cinema Award - Special Mention",
+        "Career Golden Lion",
+        "Prize of the Students of the University 'La Sapienza'",
+        "Golden Ciak",
+        "Special Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "C.I.C.A.E. Award",
+        "C.I.C.A.E. Award - Special Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Elvira Notari Prize",
+        "Elvira Notari Prize - Special Mention",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Filmcritica \"Bastone Bianco\" Award - Special Mention",
+        "Sergio Trasatti Award",
+        "Sergio Trasatti Award - Special Mention",
+        "Children and Cinema Award",
+        "Children and Cinema Award - Special Mention",
+        "Cinecritica Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095513",
+                      "title": "Seinaru yopparai no densetsu",
+                      "originalTitle": "La leggenda del santo bevitore"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0094836",
+                      "title": "Caro Gorbaciov",
+                      "originalTitle": "Caro Gorbaciov"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095729",
+                      "title": "Niezwykla podróz Baltazara Kobera",
+                      "originalTitle": "Niezwykla podróz Baltazara Kobera"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095649",
+                      "title": "The Moderns",
+                      "originalTitle": "The Moderns"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095279",
+                      "title": "Tempos Difíceis",
+                      "originalTitle": "Tempos Difíceis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096288",
+                      "title": "Kiri no Naka no Fûkei",
+                      "originalTitle": "Topio stin omihli"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096259",
+                      "title": "Things Change",
+                      "originalTitle": "Things Change"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095086",
+                      "title": "Eldorádó",
+                      "originalTitle": "Eldorádó"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096336",
+                      "title": "Shufu Marî ga Shita Koto",
+                      "originalTitle": "Une affaire de femmes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0159402",
+                      "title": "Dedé Mamata",
+                      "originalTitle": "Dedé Mamata"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095555",
+                      "title": "Luces y sombras",
+                      "originalTitle": "Luces y sombras"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096516",
+                      "title": "À corps perdu",
+                      "originalTitle": "À corps perdu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095564",
+                      "title": "Madame Sousatzka",
+                      "originalTitle": "Madame Sousatzka"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095675",
+                      "title": "Shinkei suijaku girigiri no onna tachi",
+                      "originalTitle": "Mujeres al borde de un ataque de \"nervios\""
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095097",
+                      "title": "Once More",
+                      "originalTitle": "Once More"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0179884",
+                      "title": "Gli invisibili",
+                      "originalTitle": "Gli invisibili"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092754",
+                      "title": "Chyornyy monakh",
+                      "originalTitle": "Chyornyy monakh"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0095280",
+                      "title": "Haunted Summer",
+                      "originalTitle": "Haunted Summer"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0092716",
+                      "title": "Camp de Thiaroye",
+                      "originalTitle": "Camp de Thiaroye"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0094816",
+                      "title": "Burning Secret",
+                      "originalTitle": "Burning Secret"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096077",
+                      "title": "Un señor muy viejo con unas alas enormes",
+                      "originalTitle": "Un señor muy viejo con unas alas enormes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0340925",
+                      "title": "Qi wang",
+                      "originalTitle": "Qi wang"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1989,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Golden Ciak",
+        "Special Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Little Golden Lion",
+        "Elvira Notari Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Filmcritica \"Bastone Bianco\" Award - Special Mention",
+        "Sergio Trasatti Award",
+        "Children and Cinema Award",
+        "Kodak-Cinecritica Award",
+        "La Navicella Venezia Cinema Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096908",
+                      "title": "Hijô jôshi",
+                      "originalTitle": "Beiqing chengshi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0263677",
+                      "title": "M' agapas?",
+                      "originalTitle": "M' agapas?"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097297",
+                      "title": "Et la lumière fut",
+                      "originalTitle": "Et la lumière fut"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0098175",
+                      "title": "Recordações da Casa Amarela",
+                      "originalTitle": "Recordações da Casa Amarela"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0098287",
+                      "title": "Sen no Rikyû: Honkakubô ibun",
+                      "originalTitle": "Sen no Rikyû: Honkakubô ibun"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097051",
+                      "title": "Che ora è",
+                      "originalTitle": "Che ora è"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": "For episode \"She's Been Away (#1.5)",
+                  "titles": [
+                    {
+                      "imdbId": "tt0297625",
+                      "title": "Screen One",
+                      "originalTitle": "Screen One"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097555",
+                      "title": "I Want to Go Home",
+                      "originalTitle": "I Want to Go Home"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0098271",
+                      "title": "Scugnizzi",
+                      "originalTitle": "Scugnizzi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096854",
+                      "title": "Australia",
+                      "originalTitle": "Australia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097268",
+                      "title": "Ek Din Achanak",
+                      "originalTitle": "Ek Din Achanak"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0096942",
+                      "title": "Blauäugig",
+                      "originalTitle": "Blauäugig"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0133410",
+                      "title": "Berlin-Yerushalaim",
+                      "originalTitle": "Berlin-Yerushalaim"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0307203",
+                      "title": "Muzh i doch' Tamary Aleksandrovny",
+                      "originalTitle": "Muzh i doch' Tamary Aleksandrovny"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0098280",
+                      "title": "Sedím na konári a je mi dobre",
+                      "originalTitle": "Sedím na konári a je mi dobre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097325",
+                      "title": "Fallgropen",
+                      "originalTitle": "Fallgropen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097574",
+                      "title": "ムーンリットナイト",
+                      "originalTitle": "In una notte di chiaro di luna"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097347",
+                      "title": "La femme de Rose Hill",
+                      "originalTitle": "La femme de Rose Hill"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0125695",
+                      "title": "Christian",
+                      "originalTitle": "Christian"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0098407",
+                      "title": "El sueño del mono loco",
+                      "originalTitle": "El sueño del mono loco"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0116842",
+                      "title": "Majnoun Layla",
+                      "originalTitle": "Majnoun Layla"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097964",
+                      "title": "New Year's Day",
+                      "originalTitle": "New Year's Day"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097597",
+                      "title": "Island",
+                      "originalTitle": "Island"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1990,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Silver Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Audience Award (Arena)",
+        "Golden Ciak",
+        "Special Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Little Golden Lion",
+        "Elvira Notari Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Filmcritica \"Bastone Bianco\" Award - Special Mention",
+        "Kodak-Cinecritica Award",
+        "UCCA Venticittà Award",
+        "UCCA Venticittà Award - Special Mention",
+        "Gingerly Award",
+        "Photographers Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100519",
+                      "title": "Rosencrantz & Guildenstern Are Dead",
+                      "originalTitle": "Rosencrantz & Guildenstern Are Dead"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0099040",
+                      "title": "An Angel at My Table",
+                      "originalTitle": "An Angel at My Table"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0099685",
+                      "title": "GoodFellas",
+                      "originalTitle": "GoodFellas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100627",
+                      "title": "Sirup",
+                      "originalTitle": "Sirup"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100075",
+                      "title": "La luna en el espejo",
+                      "originalTitle": "La luna en el espejo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100297",
+                      "title": "Edinstveniyat svidetel",
+                      "originalTitle": "Edinstveniyat svidetel"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100454",
+                      "title": "Ragazzi fuori",
+                      "originalTitle": "Ragazzi fuori"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100536",
+                      "title": "S'en fout la mort",
+                      "originalTitle": "S'en fout la mort"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105220",
+                      "title": "Raspad",
+                      "originalTitle": "Raspad"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100200",
+                      "title": "Mr. & Mrs. Bridge",
+                      "originalTitle": "Mr. & Mrs. Bridge"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100115",
+                      "title": "Martha et moi",
+                      "originalTitle": "Martha et moi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0097851",
+                      "title": "Mathilukal",
+                      "originalTitle": "Mathilukal"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0098991",
+                      "title": "L'africana",
+                      "originalTitle": "L'africana"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100168",
+                      "title": "Mo' Better Blues",
+                      "originalTitle": "Mo' Better Blues"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0099818",
+                      "title": "I Hired a Contract Killer",
+                      "originalTitle": "I Hired a Contract Killer"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0098972",
+                      "title": "A-ge-man",
+                      "originalTitle": "Ageman"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100807",
+                      "title": "Tracce di vita amorosa",
+                      "originalTitle": "Tracce di vita amorosa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0249982",
+                      "title": "Spieler",
+                      "originalTitle": "Spieler"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0133343",
+                      "title": "Ahavata Ha'ahronah Shel Laura Adler",
+                      "originalTitle": "Ahavata Ha'ahronah Shel Laura Adler"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0200762",
+                      "title": "Karartma Geceleri",
+                      "originalTitle": "Karartma Geceleri"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0100400",
+                      "title": "Pozegnanie jesieni",
+                      "originalTitle": "Pozegnanie jesieni"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0099827",
+                      "title": "Il y a des jours... et des lunes",
+                      "originalTitle": "Il y a des jours... et des lunes"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1991,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Critics' Week Award",
+        "Audience Award (Critics' Week)",
+        "Little Golden Lion",
+        "Elvira Notari Prize",
+        "Photographers Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0103176",
+                      "title": "Urga",
+                      "originalTitle": "Urga"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101307",
+                      "title": "Allemagne année 90 neuf zéro",
+                      "originalTitle": "Allemagne année 90 neuf zéro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101337",
+                      "title": "L'amore necessario",
+                      "originalTitle": "L'amore necessario"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102855",
+                      "title": "Cerro Torre: Schrei aus Stein",
+                      "originalTitle": "Cerro Torre: Schrei aus Stein"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101567",
+                      "title": "Chatarra",
+                      "originalTitle": "Chatarra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101640",
+                      "title": "Kômu",
+                      "originalTitle": "Da hong denglong gaogao gua"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101739",
+                      "title": "A Divina Comédia",
+                      "originalTitle": "A Divina Comédia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101798",
+                      "title": "Edward II",
+                      "originalTitle": "Edward II"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104252",
+                      "title": "30 Door Key",
+                      "originalTitle": "30 Door Key"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101889",
+                      "title": "The Fisher King",
+                      "originalTitle": "The Fisher King"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101956",
+                      "title": "Gizli Yüz",
+                      "originalTitle": "Gizli Yüz"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102137",
+                      "title": "J'entends plus la guitare",
+                      "originalTitle": "J'entends plus la guitare"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102153",
+                      "title": "Jeszcze tylko ten las",
+                      "originalTitle": "Jeszcze tylko ten las"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102428",
+                      "title": "Meeting Venus",
+                      "originalTitle": "Meeting Venus"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102456",
+                      "title": "Mississippi Masala",
+                      "originalTitle": "Mississippi Masala"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102487",
+                      "title": "Il muro di gomma",
+                      "originalTitle": "Il muro di gomma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102494",
+                      "title": "My Private Idaho",
+                      "originalTitle": "My Own Private Idaho"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102566",
+                      "title": "Nuit et jour",
+                      "originalTitle": "Nuit et jour"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102678",
+                      "title": "Chateh al aftal ad-daï'ne",
+                      "originalTitle": "Chateh al aftal ad-daï'ne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102722",
+                      "title": "Prospero's Books",
+                      "originalTitle": "Prospero's Books"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102987",
+                      "title": "Una storia semplice",
+                      "originalTitle": "Una storia semplice"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1992,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Audience Award",
+        "Golden Ciak",
+        "Special Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Little Golden Lion",
+        "Elvira Notari Prize",
+        "Kodak-Cinecritica Award",
+        "Special Prize on Occasion of the Festival's Jubilee"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105197",
+                      "title": "Qiu Ju da guan si",
+                      "originalTitle": "Qiu Ju da guan si"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105127",
+                      "title": "La peste",
+                      "originalTitle": "La peste"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0103967",
+                      "title": "Chuvstvitelnyy militsioner",
+                      "originalTitle": "Chuvstvitelnyy militsioner"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0102583",
+                      "title": "Olivier, Olivier",
+                      "originalTitle": "Olivier, Olivier"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0103943",
+                      "title": "La Chasse aux papillons",
+                      "originalTitle": "La Chasse aux papillons"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105682",
+                      "title": "Un coeur en hiver",
+                      "originalTitle": "Un coeur en hiver"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104658",
+                      "title": "L.627",
+                      "originalTitle": "L.627"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0103615",
+                      "title": "L'absence",
+                      "originalTitle": "L'absence"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0107756",
+                      "title": "Orlando",
+                      "originalTitle": "Orlando"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0101913",
+                      "title": "Fratelli e sorelle",
+                      "originalTitle": "Fratelli e sorelle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104111",
+                      "title": "La discesa di Aclà a Floristella",
+                      "originalTitle": "La discesa di Aclà a Floristella"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104918",
+                      "title": "Morte di un matematico napoletano",
+                      "originalTitle": "Morte di un matematico napoletano"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105924",
+                      "title": "O Último Mergulho",
+                      "originalTitle": "O Último Mergulho"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104445",
+                      "title": "Hotel de lux",
+                      "originalTitle": "Hotel de lux"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104373",
+                      "title": "Guelwaar",
+                      "originalTitle": "Guelwaar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104545",
+                      "title": "Jamón Jamón",
+                      "originalTitle": "Jamón Jamón"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104348",
+                      "title": "Matenro wo Yume mite",
+                      "originalTitle": "Glengarry Glen Ross"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104503",
+                      "title": "In the Soup",
+                      "originalTitle": "In the Soup"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105217",
+                      "title": "Raising Cain",
+                      "originalTitle": "Raising Cain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104833",
+                      "title": "Me and Veronica",
+                      "originalTitle": "Me and Veronica"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105182",
+                      "title": "Prorva",
+                      "originalTitle": "Prorva"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105723",
+                      "title": "Valsi Pechoraze",
+                      "originalTitle": "Valsi Pechoraze"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0104588",
+                      "title": "Kaivo",
+                      "originalTitle": "Kaivo"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1993,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Golden Ciak",
+        "Special Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Little Golden Lion",
+        "Elvira Notari Prize",
+        "Grand Prize of the European Academy",
+        "AIACE Award",
+        "Special Volpi Cup"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Torikorôru: Ao no Ai (1993).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0108122",
+                      "title": "Short Cuts",
+                      "originalTitle": "Short Cuts"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Short Cuts (1993).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0108394",
+                      "title": "Torikorôru: Ao no Ai",
+                      "originalTitle": "Trois couleurs : Bleu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0108435",
+                      "title": "Un, deux, trois, soleil",
+                      "originalTitle": "Un, deux, trois, soleil"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106678",
+                      "title": "De eso no se habla",
+                      "originalTitle": "De eso no se habla"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106299",
+                      "title": "Aqui na Terra",
+                      "originalTitle": "Aqui na Terra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0107891",
+                      "title": "La prossima volta il fuoco",
+                      "originalTitle": "La prossima volta il fuoco"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106765",
+                      "title": "Dove siete? Io sono qui",
+                      "originalTitle": "Dove siete? Io sono qui"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106341",
+                      "title": "Bad Boy Bubby",
+                      "originalTitle": "Bad Boy Bubby"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106660",
+                      "title": "Snake Eyes",
+                      "originalTitle": "Snake Eyes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0107175",
+                      "title": "Hélas pour moi",
+                      "originalTitle": "Hélas pour moi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0105342",
+                      "title": "L'ombre du doute",
+                      "originalTitle": "L'ombre du doute"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106834",
+                      "title": "Even Cowgirls Get the Blues",
+                      "originalTitle": "Even Cowgirls Get the Blues"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106286",
+                      "title": "Un'anima divisa in due",
+                      "originalTitle": "Un'anima divisa in due"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0108630",
+                      "title": "You Seng",
+                      "originalTitle": "You Seng"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0107340",
+                      "title": "Kosh ba kosh",
+                      "originalTitle": "Kosh ba kosh"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0107997",
+                      "title": "Rozmowa z czlowiekiem z szafy",
+                      "originalTitle": "Rozmowa z czlowiekiem z szafy"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0108670",
+                      "title": "¡Dispara!",
+                      "originalTitle": "¡Dispara!"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0197110",
+                      "title": "Za zui zi",
+                      "originalTitle": "Za zui zi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0106489",
+                      "title": "A Bronx Tale",
+                      "originalTitle": "A Bronx Tale"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1994,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "Special Mention",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Audience Award",
+        "Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Anicaflash Prize",
+        "Elvira Notari Prize",
+        "'CinemAvvenire' Award",
+        "Kodak Award",
+        "AIACE Award",
+        "UCCA Venticittà Award",
+        "Telepiù Award",
+        "Telepiù Award - Special Mention",
+        "Award of the City of Venice",
+        "Catholic Cinema Clubs Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "FIPRESCI Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Ai qing wan sui (1994).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0110882",
+                      "title": "Pred dozhdot",
+                      "originalTitle": "Pred dozhdot"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": true,
+                  "notes": "Tied with Pred dozhdot (1994).",
+                  "titles": [
+                    {
+                      "imdbId": "tt0109066",
+                      "title": "Ai qing wan sui",
+                      "originalTitle": "Ai qing wan sui"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111459",
+                      "title": "Il toro",
+                      "originalTitle": "Il toro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0110005",
+                      "title": "Otome no inori",
+                      "originalTitle": "Heavenly Creatures"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0110365",
+                      "title": "Ritoru Odessa",
+                      "originalTitle": "Little Odessa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111508",
+                      "title": "Três Irmãos",
+                      "originalTitle": "Três Irmãos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0110632",
+                      "title": "Natural Born Killers",
+                      "originalTitle": "Natural Born Killers"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0110299",
+                      "title": "Lamerica",
+                      "originalTitle": "Lamerica"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111786",
+                      "title": "Yang guang can lan de ri zi",
+                      "originalTitle": "Yang guang can lan de ri zi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111856",
+                      "title": "À la folie",
+                      "originalTitle": "À la folie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0110348",
+                      "title": "Zivot a neobycejna dobrodruzstvi vojaka Ivana Conkina",
+                      "originalTitle": "Zivot a neobycejna dobrodruzstvi vojaka Ivana Conkina"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111236",
+                      "title": "Una sombra ya pronto serás",
+                      "originalTitle": "Una sombra ya pronto serás"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0109499",
+                      "title": "Le Cri du coeur",
+                      "originalTitle": "Le Cri du coeur"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111237",
+                      "title": "Somebody to Love",
+                      "originalTitle": "Somebody to Love"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0110761",
+                      "title": "Il branco",
+                      "originalTitle": "Il branco"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0110834",
+                      "title": "Pigalle",
+                      "originalTitle": "Pigalle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111403",
+                      "title": "La teta y la luna",
+                      "originalTitle": "La teta y la luna"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0109356",
+                      "title": "Büvös vadász",
+                      "originalTitle": "Büvös vadász"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0109688",
+                      "title": "Rakuen no kizu",
+                      "originalTitle": "Dung che sai duk"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1995,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Career Golden Lion",
+        "Golden Ciak",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Elvira Notari Prize",
+        "Elvira Notari Prize - Special Mention",
+        "AIACE Award",
+        "Telepiù Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0112767",
+                      "title": "Cyclo",
+                      "originalTitle": "Xich Lo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0129872",
+                      "title": "Det Yani Dokhtar",
+                      "originalTitle": "Det Yani Dokhtar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0113403",
+                      "title": "In the Bleak Midwinter",
+                      "originalTitle": "In the Bleak Midwinter"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0111198",
+                      "title": "Sin remitente",
+                      "originalTitle": "Sin remitente"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0112769",
+                      "title": "La cérémonie",
+                      "originalTitle": "La cérémonie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0114096",
+                      "title": "Pasolini, un delitto italiano",
+                      "originalTitle": "Pasolini, un delitto italiano"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0109949",
+                      "title": "Guantanamera",
+                      "originalTitle": "Guantanamera"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0114704",
+                      "title": "Der Totmacher",
+                      "originalTitle": "Der Totmacher"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0113725",
+                      "title": "Maboroshi no hikari",
+                      "originalTitle": "Maboroshi no hikari"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0112688",
+                      "title": "Clockers",
+                      "originalTitle": "Clockers"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0112710",
+                      "title": "A Comédia de Deus",
+                      "originalTitle": "A Comédia de Deus"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0116746",
+                      "title": "Kardiogramma",
+                      "originalTitle": "Kardiogramma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0114007",
+                      "title": "Nothing Personal",
+                      "originalTitle": "Nothing Personal"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0112744",
+                      "title": "The Crossing Guard",
+                      "originalTitle": "The Crossing Guard"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0114294",
+                      "title": "Romanzo di un giovane povero",
+                      "originalTitle": "Romanzo di un giovane povero"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0114864",
+                      "title": "De vliegende Hollander",
+                      "originalTitle": "De vliegende Hollander"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0114808",
+                      "title": "L'uomo delle stelle",
+                      "originalTitle": "L'uomo delle stelle"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1996,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Honorable Mention",
+        "The President of the Italian Senate's Gold Medal",
+        "Luigi De Laurentiis Award",
+        "Career Golden Lion",
+        "Audience Award",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Special Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "CICT-IFTC Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Elvira Notari Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Sergio Trasatti Award",
+        "'CinemAvvenire' Award",
+        "Kodak Award",
+        "AIACE Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0117039",
+                      "title": "Michael Collins",
+                      "originalTitle": "Michael Collins"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0115738",
+                      "title": "Box of Moonlight",
+                      "originalTitle": "Box of Moonlight"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0116612",
+                      "title": "Ilona llega con la lluvia",
+                      "originalTitle": "Ilona llega con la lluvia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0117336",
+                      "title": "Pianese Nunzio, 14 anni a maggio",
+                      "originalTitle": "Pianese Nunzio, 14 anni a maggio"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0117301",
+                      "title": "Party",
+                      "originalTitle": "Party"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0117359",
+                      "title": "Ponette",
+                      "originalTitle": "Ponette"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0116378",
+                      "title": "The Funeral",
+                      "originalTitle": "The Funeral"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0116334",
+                      "title": "For Ever Mozart",
+                      "originalTitle": "For Ever Mozart"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0115755",
+                      "title": "Brigands, chapitre VII",
+                      "originalTitle": "Brigands, chapitre VII"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0116555",
+                      "title": "Hommes, femmes, mode d'emploi",
+                      "originalTitle": "Hommes, femmes, mode d'emploi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0115832",
+                      "title": "Carla's Song",
+                      "originalTitle": "Carla's Song"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0118074",
+                      "title": "Vesna va veloce",
+                      "originalTitle": "Vesna va veloce"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0117394",
+                      "title": "Profundo carmesí",
+                      "originalTitle": "Profundo carmesí"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0118043",
+                      "title": "Der Unhold",
+                      "originalTitle": "Der Unhold"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0115632",
+                      "title": "Basquiat",
+                      "originalTitle": "Basquiat"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0117822",
+                      "title": "Tai ping tian guo",
+                      "originalTitle": "Tai ping tian guo"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0116612",
+                      "title": "Ilona llega con la lluvia",
+                      "originalTitle": "Ilona llega con la lluvia"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1997,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Special Mention",
+        "The President of the Italian Senate's Gold Medal",
+        "Luigi De Laurentiis Award",
+        "Career Golden Lion",
+        "Prize of the International Youth Jury",
+        "FIPRESCI Prize",
+        "FIPRESCI Prize - Honorable Mention",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "FEDIC Award - Honorable Mention",
+        "Little Golden Lion",
+        "Anicaflash Prize",
+        "Elvira Notari Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Sergio Trasatti Award",
+        "'CinemAvvenire' Award",
+        "Enzo Serafin Award",
+        "Kodak Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119250",
+                      "title": "Hana-bi",
+                      "originalTitle": "Hana-bi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0123685",
+                      "title": "A ciegas",
+                      "originalTitle": "A ciegas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0118851",
+                      "title": "チャイニーズ・ボックス",
+                      "originalTitle": "Chinese Box"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0123707",
+                      "title": "Combat de fauves",
+                      "originalTitle": "Combat de fauves"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0123868",
+                      "title": "Giro di lune tra terra e mare",
+                      "originalTitle": "Giro di lune tra terra e mare"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0123889",
+                      "title": "Historie milosne",
+                      "originalTitle": "Historie milosne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119368",
+                      "title": "The Informant",
+                      "originalTitle": "The Informant"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119773",
+                      "title": "Nettoyage à sec",
+                      "originalTitle": "Nettoyage à sec"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119780",
+                      "title": "Niagara, Niagara",
+                      "originalTitle": "Niagara, Niagara"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119832",
+                      "title": "One Night Stand",
+                      "originalTitle": "One Night Stand"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119844",
+                      "title": "Ossos",
+                      "originalTitle": "Ossos"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0117264",
+                      "title": "A Ostra e o Vento",
+                      "originalTitle": "A Ostra e o Vento"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0122648",
+                      "title": "Ovosodo",
+                      "originalTitle": "Ovosodo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0124115",
+                      "title": "Le Septième Ciel",
+                      "originalTitle": "Le Septième Ciel"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0120441",
+                      "title": "I vesuviani",
+                      "originalTitle": "I vesuviani"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0124207",
+                      "title": "Vor",
+                      "originalTitle": "Vor"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0120521",
+                      "title": "The Winter Guest",
+                      "originalTitle": "The Winter Guest"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0120543",
+                      "title": "You hua hao hao shuo",
+                      "originalTitle": "You hua hao hao shuo"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1998,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Marcello Mastroianni Award",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "UNICEF Award - Special Mention",
+        "UNESCO Award",
+        "UNESCO Award - Special Mention",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Little Golden Lion",
+        "Anicaflash Prize",
+        "Elvira Notari Prize",
+        "Elvira Notari Prize - Special Mention",
+        "'Cult Network Italia' Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "Sergio Trasatti Award - Special Mention",
+        "'CinemAvvenire' Award",
+        "Kodak Award",
+        "Prix Pierrot",
+        "Max Factor Award",
+        "Best First Film"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0139951",
+                      "title": "Così ridevano",
+                      "originalTitle": "Così ridevano"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0118843",
+                      "title": "Crna macka, beli macor",
+                      "originalTitle": "Crna macka, beli macor"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0118798",
+                      "title": "Bulworth",
+                      "originalTitle": "Bulworth"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0168594",
+                      "title": "La nube",
+                      "originalTitle": "La nube"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0137439",
+                      "title": "Conte d'automne",
+                      "originalTitle": "Conte d'automne"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0140073",
+                      "title": "I giardini dell'Eden",
+                      "originalTitle": "I giardini dell'Eden"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0120643",
+                      "title": "Dancing at Lughnasa",
+                      "originalTitle": "Dancing at Lughnasa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119336",
+                      "title": "Casting Director",
+                      "originalTitle": "Hurlyburly"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0150915",
+                      "title": "Hilary and Jackie",
+                      "originalTitle": "Hilary and Jackie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0122657",
+                      "title": "I piccoli maestri",
+                      "originalTitle": "I piccoli maestri"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0130827",
+                      "title": "Run Lola Run",
+                      "originalTitle": "Lola rennt"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0133363",
+                      "title": "Los amantes del Círculo Polar",
+                      "originalTitle": "Los amantes del Círculo Polar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0133122",
+                      "title": "New Rose Hotel",
+                      "originalTitle": "New Rose Hotel"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0143093",
+                      "title": "L'albero delle pere",
+                      "originalTitle": "L'albero delle pere"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119901",
+                      "title": "Place Vendôme",
+                      "originalTitle": "Place Vendôme"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0128442",
+                      "title": "Rounders",
+                      "originalTitle": "Rounders"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0152438",
+                      "title": "Sokout",
+                      "originalTitle": "Sokout"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0151479",
+                      "title": "Terminus paradis",
+                      "originalTitle": "Terminus paradis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0120364",
+                      "title": "Tráfico",
+                      "originalTitle": "Tráfico"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0153588",
+                      "title": "Voleur de vie",
+                      "originalTitle": "Voleur de vie"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 1999,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Luigi De Laurentiis Award - Special Mention",
+        "Cinema of the Present - Lion of the Year",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Special Award",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Pietro Bianchi Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "FEDIC Special Award",
+        "FEDIC Award - Special Mention",
+        "Little Golden Lion",
+        "Anicaflash Prize",
+        "Elvira Notari Prize",
+        "'Cult Network Italia' Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "Sergio Trasatti Award - Special Mention",
+        "'CinemAvvenire' Award",
+        "Children and Cinema Award",
+        "Children and Cinema Award - Special Mention",
+        "Rota Soundtrack Award",
+        "Special Director's Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0209189",
+                      "title": "Yi ge dou bu neng shao",
+                      "originalTitle": "Yi ge dou bu neng shao"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0208658",
+                      "title": "A domani",
+                      "originalTitle": "A domani"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0200440",
+                      "title": "Appassionate",
+                      "originalTitle": "Appassionate"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0209463",
+                      "title": "Kaze ga fuku mama",
+                      "originalTitle": "Bad ma ra khahad bord"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0124315",
+                      "title": "Cider House Rule",
+                      "originalTitle": "The Cider House Rules"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0142201",
+                      "title": "Crazy in Alabama",
+                      "originalTitle": "Crazy in Alabama"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0208995",
+                      "title": "Gojitmal",
+                      "originalTitle": "Gojitmal"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0213695",
+                      "title": "Guo nian hui jia",
+                      "originalTitle": "Guo nian hui jia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0144715",
+                      "title": "Holy Smoke",
+                      "originalTitle": "Holy Smoke"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0186253",
+                      "title": "Jesus' Son",
+                      "originalTitle": "Jesus' Son"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0119603",
+                      "title": "Mal",
+                      "originalTitle": "Mal"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0209187",
+                      "title": "Nordrand",
+                      "originalTitle": "Nordrand"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0209223",
+                      "title": "Pas de scandale",
+                      "originalTitle": "Pas de scandale"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0209280",
+                      "title": "Rien à faire",
+                      "originalTitle": "Rien à faire"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0151568",
+                      "title": "Topsy-Turvy",
+                      "originalTitle": "Topsy-Turvy"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0209445",
+                      "title": "Tydzien z zycia mezczyzny",
+                      "originalTitle": "Tydzien z zycia mezczyzny"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0204709",
+                      "title": "Une liaison pornographique",
+                      "originalTitle": "Une liaison pornographique"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0211719",
+                      "title": "The Venice Project",
+                      "originalTitle": "The Venice Project"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0187579",
+                      "title": "Yokaze no nioi",
+                      "originalTitle": "Le vent de la nuit"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2000,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "The President of the Italian Senate's Gold Medal",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Cinema of the Present - Lion of the Year",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "OCIC Award - Honorable Mention",
+        "Netpac Award",
+        "Netpac Award - Special Mention",
+        "Don Quixote Award",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Elvira Notari Prize",
+        "'Cult Network Italia' Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "'CinemAvvenire' Award",
+        "Children and Cinema Award",
+        "Rota Soundtrack Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0255094",
+                      "title": "Dayereh",
+                      "originalTitle": "Dayereh"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0205271",
+                      "title": "Dr. T & the Women",
+                      "originalTitle": "Dr. T & the Women"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0255177",
+                      "title": "Freedom",
+                      "originalTitle": "Freedom"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0230753",
+                      "title": "Selon Matthieu",
+                      "originalTitle": "Selon Matthieu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0255327",
+                      "title": "Liu lian piao piao",
+                      "originalTitle": "Liu lian piao piao"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0206200",
+                      "title": "Il partigiano Johnny",
+                      "originalTitle": "Il partigiano Johnny"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0258885",
+                      "title": "Zhantai",
+                      "originalTitle": "Zhantai"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0255665",
+                      "title": "Uttara",
+                      "originalTitle": "Uttara"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0255321",
+                      "title": "Liam",
+                      "originalTitle": "Liam"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0238891",
+                      "title": "I cento passi",
+                      "originalTitle": "I cento passi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0255589",
+                      "title": "Sakana to neru onna",
+                      "originalTitle": "Seom"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0255195",
+                      "title": "The Goddess of 1967",
+                      "originalTitle": "The Goddess of 1967"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0206093",
+                      "title": "La lingua del santo",
+                      "originalTitle": "La lingua del santo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0200257",
+                      "title": "Palavra e Utopia",
+                      "originalTitle": "Palavra e Utopia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0206917",
+                      "title": "The Man Who Cried",
+                      "originalTitle": "The Man Who Cried"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0239381",
+                      "title": "O Fantasma",
+                      "originalTitle": "O Fantasma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0254325",
+                      "title": "Comédie de l'innocence",
+                      "originalTitle": "Comédie de l'innocence"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0221115",
+                      "title": "Denti",
+                      "originalTitle": "Denti"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0247196",
+                      "title": "Before Night Falls",
+                      "originalTitle": "Before Night Falls"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0250809",
+                      "title": "La virgen de los sicarios",
+                      "originalTitle": "La virgen de los sicarios"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2001,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Cinema of the Present - Lion of the Year",
+        "Cinema of the Present - Special Jury Award",
+        "Career Golden Lion",
+        "Audience Award",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "OCIC Award",
+        "Netpac Award",
+        "Don Quixote Award",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Italian Cinema Clubs Award",
+        "Pietro Bianchi Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Wella Prize",
+        "Elvira Notari Prize",
+        "Elvira Notari Prize - Special Mention",
+        "'Cult Network Italia' Prize",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Future Film Festival Digital Award",
+        "Laterna Magica Prize",
+        "Laterna Magica Prize - Special Mention",
+        "Sergio Trasatti Award",
+        "'CinemAvvenire' Award",
+        "Children and Cinema Award",
+        "Rota Soundtrack Award",
+        "Mimmo Rotella Foundation Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0265343",
+                      "title": "Monsoon Wedding",
+                      "originalTitle": "Monsoon Wedding"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0291003",
+                      "title": "Abril Despedaçado",
+                      "originalTitle": "Abril Despedaçado"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0290423",
+                      "title": "Dupa-amiaza unui tortionar",
+                      "originalTitle": "Dupa-amiaza unui tortionar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0242193",
+                      "title": "Bully",
+                      "originalTitle": "Bully"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0271017",
+                      "title": "Eden",
+                      "originalTitle": "Eden"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0290654",
+                      "title": "Heung Gong you ge He Li Huo",
+                      "originalTitle": "Heung Gong you ge He Li Huo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0256084",
+                      "title": "How Harry Became a Tree",
+                      "originalTitle": "How Harry Became a Tree"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0290661",
+                      "title": "Hundstage",
+                      "originalTitle": "Hundstage"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0258242",
+                      "title": "Loin",
+                      "originalTitle": "Loin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0282701",
+                      "title": "Luce dei miei occhi",
+                      "originalTitle": "Luce dei miei occhi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0290733",
+                      "title": "Luna rossa",
+                      "originalTitle": "Luna rossa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0279977",
+                      "title": "The Navigators",
+                      "originalTitle": "The Navigators"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0230600",
+                      "title": "The Others",
+                      "originalTitle": "The Others"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0210930",
+                      "title": "Quem És Tu?",
+                      "originalTitle": "Quem És Tu?"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0290823",
+                      "title": "Raye makhfi",
+                      "originalTitle": "Raye makhfi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0290841",
+                      "title": "Sauvage innocence",
+                      "originalTitle": "Sauvage innocence"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0284815",
+                      "title": "Address Unknown",
+                      "originalTitle": "Suchwiin bulmyeong"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0253840",
+                      "title": "The Triumph of Love",
+                      "originalTitle": "The Triumph of Love"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0243017",
+                      "title": "Waking Life",
+                      "originalTitle": "Waking Life"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0245574",
+                      "title": "Tengoku no kuchi, owari no rakuen",
+                      "originalTitle": "Y tu mamá también"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2002,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "New Cinema Award",
+        "San Marco Prize",
+        "San Marco Special Jury Award",
+        "San Marco Prize - Special Mention",
+        "Upstream Prize",
+        "Career Golden Lion",
+        "Audience Award",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "Don Quixote Award",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Pietro Bianchi Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Wella Prize",
+        "Elvira Notari Prize",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "Rota Soundtrack Award",
+        "Mimmo Rotella Foundation Award",
+        "Kinematrix Film Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0318411",
+                      "title": "The Magdalene Sisters",
+                      "originalTitle": "The Magdalene Sisters"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0283915",
+                      "title": "Bear's Kiss",
+                      "originalTitle": "Bear's Kiss"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0329106",
+                      "title": "Führer Ex",
+                      "originalTitle": "Führer Ex"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0333902",
+                      "title": "Mei li shi guang",
+                      "originalTitle": "Mei li shi guang"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0318780",
+                      "title": "Un monde presque paisible",
+                      "originalTitle": "Un monde presque paisible"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0300237",
+                      "title": "Nackt",
+                      "originalTitle": "Nackt"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0301199",
+                      "title": "Dirty Pretty Things",
+                      "originalTitle": "Dirty Pretty Things"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0329095",
+                      "title": "La forza del passato",
+                      "originalTitle": "La forza del passato"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0296099",
+                      "title": "Nha Fala",
+                      "originalTitle": "Nha Fala"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0297884",
+                      "title": "Far from Heaven",
+                      "originalTitle": "Far from Heaven"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0212132",
+                      "title": "The Tracker",
+                      "originalTitle": "The Tracker"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0246719",
+                      "title": "Julie Walking Home",
+                      "originalTitle": "Julie Walking Home"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0330229",
+                      "title": "Dôruzu",
+                      "originalTitle": "Dôruzu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0332605",
+                      "title": "Dom durakov",
+                      "originalTitle": "Dom durakov"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0301414",
+                      "title": "Ressha ni notta otoko",
+                      "originalTitle": "L'homme du train"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0320193",
+                      "title": "Oasiseu",
+                      "originalTitle": "Oasiseu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0290435",
+                      "title": "Au plus près du paradis",
+                      "originalTitle": "Au plus près du paradis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0257044",
+                      "title": "Road to Perdition",
+                      "originalTitle": "Road to Perdition"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0296145",
+                      "title": "Un viaggio chiamato amore",
+                      "originalTitle": "Un viaggio chiamato amore"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0120679",
+                      "title": "Frida",
+                      "originalTitle": "Frida"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0329731",
+                      "title": "Velocità massima",
+                      "originalTitle": "Velocità massima"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2003,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Luigi De Laurentiis Award - Special Mention",
+        "San Marco Prize",
+        "San Marco Special Jury Award",
+        "San Marco Prize - Special Mention",
+        "Upstream Prize",
+        "Career Golden Lion",
+        "Audience Award",
+        "Best Short Film",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Wella Prize",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Lina Mangiacapre Award - Special Mention",
+        "'Cult Network Italia' Prize",
+        "'Cult Network Italia' Prize - Special Mention",
+        "Future Film Festival Digital Award",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "'CinemAvvenire' Award",
+        "Award of the City of Rome",
+        "Award of the City of Rome - Special Mention",
+        "Rota Soundtrack Award",
+        "Special Pasinetti Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0376968",
+                      "title": "Vozvrashchenie",
+                      "originalTitle": "Vozvrashchenie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0315110",
+                      "title": "Twentynine Palms",
+                      "originalTitle": "Twentynine Palms"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0377569",
+                      "title": "Buongiorno, notte",
+                      "originalTitle": "Buongiorno, notte"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0378725",
+                      "title": "Segreti di stato",
+                      "originalTitle": "Segreti di stato"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0377610",
+                      "title": "Le cerf-volant",
+                      "originalTitle": "Le cerf-volant"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0339558",
+                      "title": "Raja",
+                      "originalTitle": "Raja"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0349079",
+                      "title": "Alila",
+                      "originalTitle": "Alila"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0315733",
+                      "title": "21 gram",
+                      "originalTitle": "21 Grams"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0314197",
+                      "title": "Imagining Argentina",
+                      "originalTitle": "Imagining Argentina"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0372782",
+                      "title": "Uwaki-na kazoku",
+                      "originalTitle": "Baramnan gajok"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0335426",
+                      "title": "Sjaj u ocima",
+                      "originalTitle": "Sjaj u ocima"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0363226",
+                      "title": "Zatôichi",
+                      "originalTitle": "Zatôichi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0357037",
+                      "title": "Pornografia",
+                      "originalTitle": "Pornografia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0377923",
+                      "title": "Luen ji fung ging",
+                      "originalTitle": "Luen ji fung ging"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0329584",
+                      "title": "Les sentiments",
+                      "originalTitle": "Les sentiments"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0364093",
+                      "title": "Um Filme Falado",
+                      "originalTitle": "Um Filme Falado"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0298131",
+                      "title": "Rosenstrasse",
+                      "originalTitle": "Rosenstrasse"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0377556",
+                      "title": "楽日",
+                      "originalTitle": "Bu san"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0378362",
+                      "title": "Il miracolo",
+                      "originalTitle": "Il miracolo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0345061",
+                      "title": "Code 46",
+                      "originalTitle": "Code 46"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2004,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Luigi De Laurentiis Award - Special Mention",
+        "Venice Horizons Award",
+        "Venice Horizons Award - Special Mention",
+        "Digital Cinema Award",
+        "Digital Cinema Award - Special Mention",
+        "Career Golden Lion",
+        "Best Short Film",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Audience Award (Critics' Week)",
+        "Isvema Award",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Little Golden Lion",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "\"Lino Miccichè\" First Feature Award",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Future Film Festival Digital Award",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "'CinemAvvenire' Award",
+        "Award of the City of Rome",
+        "International Peace Award",
+        "Human Rights Film Network Award",
+        "Human Rights Film Network Award - Special Mention",
+        "EIUC Award",
+        "EIUC Award - Special Mention",
+        "Special Pasinetti Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention",
+        "Fedeora Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0383694",
+                      "title": "Vera Drake",
+                      "originalTitle": "Vera Drake"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0354356",
+                      "title": "5x2",
+                      "originalTitle": "5x2"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0423866",
+                      "title": "Utsusemi",
+                      "originalTitle": "Binjip"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0337876",
+                      "title": "Birth",
+                      "originalTitle": "Birth"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0412596",
+                      "title": "珈琲時光",
+                      "originalTitle": "Kôhî jikô"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0345032",
+                      "title": "Le chiavi di casa",
+                      "originalTitle": "Le chiavi di casa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0431720",
+                      "title": "Delivery",
+                      "originalTitle": "Delivery"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0403100",
+                      "title": "Haryu insaeng",
+                      "originalTitle": "Haryu insaeng"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0347149",
+                      "title": "Hauru no ugoku shiro",
+                      "originalTitle": "Hauru no ugoku shiro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0422491",
+                      "title": "L'intrus",
+                      "originalTitle": "L'intrus"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0382357",
+                      "title": "Land of Plenty",
+                      "originalTitle": "Land of Plenty"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0422621",
+                      "title": "Lavorare con lentezza",
+                      "originalTitle": "Lavorare con lentezza"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0369702",
+                      "title": "Mar adentro",
+                      "originalTitle": "Mar adentro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0388526",
+                      "title": "Ovunque sei",
+                      "originalTitle": "Ovunque sei"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0362004",
+                      "title": "Palindromes",
+                      "originalTitle": "Palindromes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0424365",
+                      "title": "Ha'aretz hamuvtakhat",
+                      "originalTitle": "Ha'aretz hamuvtakhat"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0344273",
+                      "title": "Rois et reine",
+                      "originalTitle": "Rois et reine"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0423176",
+                      "title": "Shijie",
+                      "originalTitle": "Shijie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0423277",
+                      "title": "Sag-haye velgard",
+                      "originalTitle": "Sag-haye velgard"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0423397",
+                      "title": "Tout un hiver sans feu",
+                      "originalTitle": "Tout un hiver sans feu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0423433",
+                      "title": "Udalyonnyy dostup",
+                      "originalTitle": "Udalyonnyy dostup"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0241025",
+                      "title": "Vanity Fair",
+                      "originalTitle": "Vanity Fair"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2005,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Venice Horizons Documentary Award",
+        "Career Golden Lion",
+        "Audience Award",
+        "Best Short Film",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "Netpac Award",
+        "C.I.C.A.E. Award",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Critics' Week Award",
+        "Audience Award (Critics' Week)",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Label Europa Cinemas Award",
+        "Jameson Short Film Award",
+        "Young Cinema Award",
+        "\"Lino Miccichè\" First Feature Award",
+        "Wella Prize",
+        "Open Prize",
+        "Doc/It Award",
+        "Lina Mangiacapre Award",
+        "Future Film Festival Digital Award",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "Biografilm Award",
+        "'CinemAvvenire' Award",
+        "Award of the City of Rome",
+        "Venice Authors Prize",
+        "Human Rights Film Network Award",
+        "Human Rights Film Network Award - Special Mention",
+        "EIUC Award",
+        "Mimmo Rotella Foundation Award",
+        "Special Lion for the Overall Work",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention",
+        "Fedeora Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0388795",
+                      "title": "Brokeback Mountain",
+                      "originalTitle": "Brokeback Mountain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0475263",
+                      "title": "Chang hen ge",
+                      "originalTitle": "Chang hen ge"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0443844",
+                      "title": "Les Amants réguliers",
+                      "originalTitle": "Les Amants réguliers"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0443446",
+                      "title": "La bestia nel cuore",
+                      "originalTitle": "La bestia nel cuore"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0355295",
+                      "title": "The Brothers Grimm",
+                      "originalTitle": "The Brothers Grimm"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0451094",
+                      "title": "Shinsetsu-na Kumuja-san",
+                      "originalTitle": "Chinjeolhan Geumjassi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0387131",
+                      "title": "ナイロビの蜂",
+                      "originalTitle": "The Constant Gardener"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": "company: Filbox; recipient: Miguel Cadilhe",
+                  "titles": [
+                    {
+                      "imdbId": "tt0472521",
+                      "title": "Espelho Mágico",
+                      "originalTitle": "Espelho Mágico"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0472778",
+                      "title": "O Fatalista",
+                      "originalTitle": "O Fatalista"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0435479",
+                      "title": "Gabrielle",
+                      "originalTitle": "Gabrielle"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0488832",
+                      "title": "Garpastum",
+                      "originalTitle": "Garpastum"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0474694",
+                      "title": "I giorni dell'abbandono",
+                      "originalTitle": "I giorni dell'abbandono"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0433383",
+                      "title": "Good Night, and Good Luck.",
+                      "originalTitle": "Good Night, and Good Luck."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0425236",
+                      "title": "Mary",
+                      "originalTitle": "Mary"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0472884",
+                      "title": "Persona non grata",
+                      "originalTitle": "Persona non grata"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0377107",
+                      "title": "Proof of My Life",
+                      "originalTitle": "Proof"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0368222",
+                      "title": "Romance & Cigarettes",
+                      "originalTitle": "Romance & Cigarettes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0474917",
+                      "title": "La seconda notte di nozze",
+                      "originalTitle": "La seconda notte di nozze"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0478044",
+                      "title": "Takeshis'",
+                      "originalTitle": "Takeshis'"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0381690",
+                      "title": "Vers le sud",
+                      "originalTitle": "Vers le sud"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2006,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Luigi De Laurentiis Award - Special Mention",
+        "Venice Horizons Award",
+        "Venice Horizons Documentary Award",
+        "Career Golden Lion",
+        "Best Short Film",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Pietro Bianchi Award",
+        "Critics' Week Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "Gucci Prize",
+        "Wella Prize",
+        "Open Prize",
+        "Doc/It Award",
+        "Lina Mangiacapre Award",
+        "UAAR Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Biografilm Award",
+        "'CinemAvvenire' Award",
+        "Award of the City of Rome",
+        "Venice Authors Prize",
+        "Human Rights Film Network Award",
+        "Human Rights Film Network Award - Special Mention",
+        "EIUC Award",
+        "Mimmo Rotella Foundation Award",
+        "Special Lion for the Overall Work",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention",
+        "Fedeora Award",
+        "Corto Cortissimo Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0859765",
+                      "title": "Chou kou ereji",
+                      "originalTitle": "San xia hao ren"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0832347",
+                      "title": "Fallen",
+                      "originalTitle": "Fallen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0448131",
+                      "title": "La stella che non c'è",
+                      "originalTitle": "La stella che non c'è"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0414993",
+                      "title": "The Fountain",
+                      "originalTitle": "The Fountain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0427969",
+                      "title": "Hollywoodland",
+                      "originalTitle": "Hollywoodland"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0465188",
+                      "title": "Nuovomondo",
+                      "originalTitle": "Nuovomondo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0206634",
+                      "title": "Tomorrow World",
+                      "originalTitle": "Children of Men"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0387877",
+                      "title": "The Black Dahlia",
+                      "originalTitle": "The Black Dahlia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0308055",
+                      "title": "Bobby",
+                      "originalTitle": "Bobby"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0436697",
+                      "title": "The Queen",
+                      "originalTitle": "The Queen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0825241",
+                      "title": "Daratt",
+                      "originalTitle": "Daratt"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0810077",
+                      "title": "L'intouchable",
+                      "originalTitle": "L'intouchable"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0851578",
+                      "title": "Paprika",
+                      "originalTitle": "Paprika"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0855895",
+                      "title": "Nue propriété",
+                      "originalTitle": "Nue propriété"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0862946",
+                      "title": "Mushishi",
+                      "originalTitle": "Mushishi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0498120",
+                      "title": "Coeurs",
+                      "originalTitle": "Coeurs"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0815227",
+                      "title": "Quei loro incontri",
+                      "originalTitle": "Quei loro incontri"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0796212",
+                      "title": "Fong juk",
+                      "originalTitle": "Fong juk"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0855824",
+                      "title": "Hei yan quan",
+                      "originalTitle": "Hei yan quan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0389557",
+                      "title": "Zwartboek",
+                      "originalTitle": "Zwartboek"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0847877",
+                      "title": "Eyforiya",
+                      "originalTitle": "Eyforiya"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0477731",
+                      "title": "Seiki no hikari",
+                      "originalTitle": "Sang sattawat"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2007,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Venice Horizons Documentary Award",
+        "Venice Horizons Award - Special Mention",
+        "Career Golden Lion",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Prize of the Forum for Cinema and Literature",
+        "Critics' Week Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Queer Lion Award",
+        "Queer Lion - Special Mention",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "Open Prize",
+        "Doc/It Award",
+        "Doc/It Award - Special Mention",
+        "Lina Mangiacapre Award",
+        "Brian Award",
+        "Filmcritica \"Bastone Bianco\" Award",
+        "Future Film Festival Digital Award",
+        "Laterna Magica Prize",
+        "Biografilm Award",
+        "'CinemAvvenire' Award",
+        "Award of the City of Rome",
+        "Venice Authors Prize",
+        "EIUC Award",
+        "Mimmo Rotella Foundation Award",
+        "Special Lion for the Overall Work",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Persol Award",
+        "Fedeora Award",
+        "Corto Cortissimo Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0808357",
+                      "title": "Se, jie",
+                      "originalTitle": "Se, jie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1085799",
+                      "title": "Heya fawda",
+                      "originalTitle": "Heya fawda"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0783233",
+                      "title": "つぐない",
+                      "originalTitle": "Atonement"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0838221",
+                      "title": "The Darjeeling Limited",
+                      "originalTitle": "The Darjeeling Limited"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0857265",
+                      "title": "Sleuth",
+                      "originalTitle": "Sleuth"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0937237",
+                      "title": "Redacted",
+                      "originalTitle": "Redacted"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0443680",
+                      "title": "The Assassination of Jesse James by the Coward Robert Ford",
+                      "originalTitle": "The Assassination of Jesse James by the Coward Robert Ford"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1094267",
+                      "title": "Nessuna qualità agli eroi",
+                      "originalTitle": "Nessuna qualità agli eroi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0465538",
+                      "title": "Michael Clayton",
+                      "originalTitle": "Michael Clayton"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0809425",
+                      "title": "Dans la ville de Sylvia",
+                      "originalTitle": "Dans la ville de Sylvia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0478134",
+                      "title": "In the Valley of Elah",
+                      "originalTitle": "In the Valley of Elah"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0368794",
+                      "title": "I'm Not There",
+                      "originalTitle": "I'm Not There"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0769507",
+                      "title": "Tai yang zhao chang sheng qi",
+                      "originalTitle": "Tai yang zhao chang sheng qi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1076251",
+                      "title": "Bang bang wo ai shen",
+                      "originalTitle": "Bang bang wo ai shen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0487419",
+                      "title": "La Graine et le Mulet",
+                      "originalTitle": "La Graine et le Mulet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0807054",
+                      "title": "It's a Free World...",
+                      "originalTitle": "It's a Free World..."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1086355",
+                      "title": "L'ora di punta",
+                      "originalTitle": "L'ora di punta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0906665",
+                      "title": "Sukiyaki uesutan Jango",
+                      "originalTitle": "Sukiyaki uesutan Jango"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0488478",
+                      "title": "12",
+                      "originalTitle": "12"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1071785",
+                      "title": "Il dolce e l'amaro",
+                      "originalTitle": "Il dolce e l'amaro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0969269",
+                      "title": "San taam",
+                      "originalTitle": "San taam"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0823240",
+                      "title": "Les Amours d'Astrée et de Céladon",
+                      "originalTitle": "Les Amours d'Astrée et de Céladon"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0446750",
+                      "title": "Remburanto no yakei",
+                      "originalTitle": "Nightwatching"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2008,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Venice Horizons Documentary Award",
+        "Venice Horizons Award - Special Mention",
+        "Special Lion",
+        "Career Golden Lion",
+        "Best Short Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Pietro Bianchi Award",
+        "Critics' Week Award",
+        "Isvema Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "Gucci Prize",
+        "L'Oreal Paris Award",
+        "Doc/It Award",
+        "Doc/It Award - Special Mention",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Sergio Trasatti Award",
+        "Human Rights Film Network Award",
+        "Mimmo Rotella Foundation Award",
+        "Special Lion for the Overall Work",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Silver Lion - Short Film",
+        "Best Short Film - Special Mention",
+        "Fedeora Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1125849",
+                      "title": "Wrestler",
+                      "originalTitle": "The Wrestler"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1068641",
+                      "title": "The Burning Plain",
+                      "originalTitle": "The Burning Plain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1249306",
+                      "title": "Il papà di Giovanna",
+                      "originalTitle": "Il papà di Giovanna"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1054674",
+                      "title": "La terra degli uomini rossi - Birdwatchers",
+                      "originalTitle": "La terra degli uomini rossi - Birdwatchers"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1171704",
+                      "title": "L'autre",
+                      "originalTitle": "L'autre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0887912",
+                      "title": "Hurt Locker",
+                      "originalTitle": "The Hurt Locker"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1275799",
+                      "title": "Il seme della discordia",
+                      "originalTitle": "Il seme della discordia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1084950",
+                      "title": "Rachel Getting Married",
+                      "originalTitle": "Rachel Getting Married"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1284592",
+                      "title": "Teza",
+                      "originalTitle": "Teza"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1284576",
+                      "title": "Bumazhnyy soldat",
+                      "originalTitle": "Bumazhnyy soldat"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1284591",
+                      "title": "Süt",
+                      "originalTitle": "Süt"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1217243",
+                      "title": "Akiresu to kame",
+                      "originalTitle": "Akiresu to kame"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0876563",
+                      "title": "Ponyo on the Cliff by the Sea",
+                      "originalTitle": "Gake no ue no Ponyo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1283971",
+                      "title": "Vegas: Based on a True Story",
+                      "originalTitle": "Vegas: Based on a True Story"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1056437",
+                      "title": "Sukai kurora",
+                      "originalTitle": "Sukai kurora"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1056067",
+                      "title": "Un giorno perfetto",
+                      "originalTitle": "Un giorno perfetto"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1224153",
+                      "title": "Jerichow",
+                      "originalTitle": "Jerichow"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0818110",
+                      "title": "Injû",
+                      "originalTitle": "Inju, la bête dans l'ombre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1206485",
+                      "title": "Nuit de chien",
+                      "originalTitle": "Nuit de chien"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1284577",
+                      "title": "Gabbla",
+                      "originalTitle": "Gabbla"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1054119",
+                      "title": "Purasutikku shiti",
+                      "originalTitle": "Dang kou"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2009,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Controcampo Italiano Prize",
+        "Controcampo Italiano Prize - Special Mention",
+        "Venice Horizons Award",
+        "Venice Horizons Documentary Award",
+        "Venice Horizons Award - Special Mention",
+        "3-D Award",
+        "Career Golden Lion",
+        "Best Short Film",
+        "Best European Short Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "UNICEF Award",
+        "UNESCO Award",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Critics' Week Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "Gianni Astrei Award",
+        "Gucci Prize",
+        "L'Oreal Paris Award",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Sergio Trasatti Award",
+        "Christopher D. Smithers Foundation Special Award",
+        "Biografilm Award",
+        "Nazareno Taddei Award",
+        "AIF - For Film Fest Award",
+        "Best First Film",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "International Critics Award",
+        "Fedeora Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1483831",
+                      "title": "Lebanon",
+                      "originalTitle": "Lebanon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1239285",
+                      "title": "36 vues du Pic Saint Loup",
+                      "originalTitle": "36 vues du Pic Saint Loup"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1315981",
+                      "title": "Single Man",
+                      "originalTitle": "A Single Man"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1498708",
+                      "title": "Ahasin Wetei",
+                      "originalTitle": "Ahasin Wetei"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1498709",
+                      "title": "Al Mosafer",
+                      "originalTitle": "Al Mosafer"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1081935",
+                      "title": "Sicilia! Sicilia!",
+                      "originalTitle": "Baarìa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1095217",
+                      "title": "Bad Lieutenant",
+                      "originalTitle": "The Bad Lieutenant: Port of Call - New Orleans"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1232207",
+                      "title": "Capitalism: A Love Story",
+                      "originalTitle": "Capitalism: A Love Story"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1194231",
+                      "title": "Il grande sogno",
+                      "originalTitle": "Il grande sogno"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1379222",
+                      "title": "La doppia ora",
+                      "originalTitle": "La doppia ora"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1498834",
+                      "title": "Lei wangzi",
+                      "originalTitle": "Lei wangzi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0808526",
+                      "title": "Life During Wartime",
+                      "originalTitle": "Life During Wartime"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1371700",
+                      "title": "Lo spazio bianco",
+                      "originalTitle": "Lo spazio bianco"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1496792",
+                      "title": "Lola",
+                      "originalTitle": "Lola"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1405809",
+                      "title": "Lourdes",
+                      "originalTitle": "Lourdes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0485947",
+                      "title": "Mr. Nobody",
+                      "originalTitle": "Mr. Nobody"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1233219",
+                      "title": "My Son, My Son, What Have Ye Done",
+                      "originalTitle": "My Son, My Son, What Have Ye Done"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1303230",
+                      "title": "Persécution",
+                      "originalTitle": "Persécution"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1244668",
+                      "title": "Soul Kitchen",
+                      "originalTitle": "Soul Kitchen"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1134854",
+                      "title": "Survival of the Dead",
+                      "originalTitle": "Survival of the Dead"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1176416",
+                      "title": "Tetsuo: The Bullet Man",
+                      "originalTitle": "Tetsuo: The Bullet Man"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0898367",
+                      "title": "The Road",
+                      "originalTitle": "The Road"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1135952",
+                      "title": "White Material",
+                      "originalTitle": "White Material"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1202514",
+                      "title": "Yi ngoi",
+                      "originalTitle": "Yi ngoi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1498887",
+                      "title": "Zanan-e bedun-e mardan",
+                      "originalTitle": "Zanan-e bedun-e mardan"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2010,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Controcampo Italiano Prize",
+        "Controcampo Italiano Prize - Special Mention",
+        "Venice Horizons Award",
+        "Venice Horizons Award - Special Mention",
+        "3-D Award",
+        "Career Golden Lion",
+        "Audience Award",
+        "Best Short Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "UNICEF Award",
+        "UNESCO Award",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "Gianni Astrei Award",
+        "Lina Mangiacapre Award",
+        "Lina Mangiacapre Award - Special Mention",
+        "Brian Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Christopher D. Smithers Foundation Special Award",
+        "Biografilm Award",
+        "Nazareno Taddei Award",
+        "'CinemAvvenire' Award",
+        "Award of the City of Rome",
+        "Kodak Award",
+        "AIF - For Film Fest Award",
+        "Special Lion for the Overall Work",
+        "Equal Opportunity Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Venice Horizons Award - Special Jury Prize",
+        "Award of the City of Venice",
+        "Fedeora Award",
+        "Fedeora Award - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1421051",
+                      "title": "Somewhere",
+                      "originalTitle": "Somewhere"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0947798",
+                      "title": "Black Swan",
+                      "originalTitle": "Black Swan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1436045",
+                      "title": "Jûsannin no shikaku",
+                      "originalTitle": "Jûsannin no shikaku"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1270842",
+                      "title": "Noruwei no mori",
+                      "originalTitle": "Noruwei no mori"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1518812",
+                      "title": "Meek's Cutoff",
+                      "originalTitle": "Meek's Cutoff"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1680096",
+                      "title": "La pecora nera",
+                      "originalTitle": "La pecora nera"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1365490",
+                      "title": "Noi credevamo",
+                      "originalTitle": "Noi credevamo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1523498",
+                      "title": "La passione",
+                      "originalTitle": "La passione"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1693830",
+                      "title": "Ovsyanki",
+                      "originalTitle": "Ovsyanki"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1517177",
+                      "title": "3",
+                      "originalTitle": "3"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1723112",
+                      "title": "Jiabiangou",
+                      "originalTitle": "Jiabiangou"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1123373",
+                      "title": "Di Renjie: Tongtian diguo",
+                      "originalTitle": "Di Renjie: Tongtian diguo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1691323",
+                      "title": "Attenberg",
+                      "originalTitle": "Attenberg"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1561768",
+                      "title": "Essential Killing",
+                      "originalTitle": "Essential Killing"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1366409",
+                      "title": "Miral",
+                      "originalTitle": "Miral"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1521848",
+                      "title": "Potiche",
+                      "originalTitle": "Potiche"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1423894",
+                      "title": "Barney's Version",
+                      "originalTitle": "Barney's Version"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1714886",
+                      "title": "Post Mortem",
+                      "originalTitle": "Post Mortem"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1401643",
+                      "title": "Vénus noire",
+                      "originalTitle": "Vénus noire"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1572491",
+                      "title": "Crazy Clown Duel",
+                      "originalTitle": "Balada triste de trompeta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1504319",
+                      "title": "Road to Nowhere",
+                      "originalTitle": "Road to Nowhere"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1712563",
+                      "title": "Promises Written in Water",
+                      "originalTitle": "Promises Written in Water"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1441373",
+                      "title": "La solitudine dei numeri primi",
+                      "originalTitle": "La solitudine dei numeri primi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1528750",
+                      "title": "Happy Few",
+                      "originalTitle": "Happy Few"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2011,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Controcampo Italiano Prize",
+        "Controcampo Italiano Prize - Special Mention",
+        "Venice Horizons Award",
+        "Venice Horizons Award - Special Mention",
+        "3-D Award",
+        "Career Golden Lion",
+        "Audience Award",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "UNICEF Award",
+        "CICT-IFTC Award",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Pietro Bianchi Award",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "Gianni Astrei Award",
+        "Gucci Prize",
+        "L'Oreal Paris Award",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Lina Mangiacapre Award - Special Mention",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Laterna Magica Prize",
+        "Biografilm Award",
+        "Nazareno Taddei Award",
+        "'CinemAvvenire' Award",
+        "Mimmo Rotella Foundation Award",
+        "AIF - For Film Fest Award",
+        "Golden Mouse",
+        "Premium Cinema Talent Award",
+        "Equal Opportunity Award",
+        "Vittorio Veneto Film Festival Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Venice Horizons Award - Special Jury Prize",
+        "Vittorio Veneto Film Festival Award - Special Mention",
+        "Fedeora Award",
+        "Premio Laguna Sud (Venice Days)",
+        "Orizzonti Award for Best Short Film"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1437357",
+                      "title": "Faust",
+                      "originalTitle": "Faust"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1340800",
+                      "title": "Uragiri no Sâkasu",
+                      "originalTitle": "Tinker Tailor Soldier Spy"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1181614",
+                      "title": "Wuthering Heights",
+                      "originalTitle": "Wuthering Heights"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1389127",
+                      "title": "Texas Killing Fields",
+                      "originalTitle": "Texas Killing Fields"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1124035",
+                      "title": "The Ides of March",
+                      "originalTitle": "The Ides of March"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1680139",
+                      "title": "Quando la notte",
+                      "originalTitle": "Quando la notte"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1641410",
+                      "title": "Umi to tairiku",
+                      "originalTitle": "Terraferma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1571222",
+                      "title": "A Dangerous Method",
+                      "originalTitle": "A Dangerous Method"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1707391",
+                      "title": "4:44 Last Day on Earth",
+                      "originalTitle": "4:44 Last Day on Earth"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1726669",
+                      "title": "キラー・スナイパー",
+                      "originalTitle": "Killer Joe"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1740053",
+                      "title": "Un été brûlant",
+                      "originalTitle": "Un été brûlant"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1441368",
+                      "title": "Hahithalfut",
+                      "originalTitle": "Hahithalfut"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1859446",
+                      "title": "Alpeis",
+                      "originalTitle": "Alpeis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1723811",
+                      "title": "Shame",
+                      "originalTitle": "Shame"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1692486",
+                      "title": "Carnage",
+                      "originalTitle": "Carnage"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1663321",
+                      "title": "Poulet aux prunes",
+                      "originalTitle": "Poulet aux prunes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1690455",
+                      "title": "Dark Horse",
+                      "originalTitle": "Dark Horse"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1900893",
+                      "title": "Himizu",
+                      "originalTitle": "Himizu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2008006",
+                      "title": "The Happiness of Sister To",
+                      "originalTitle": "Tou ze"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2007993",
+                      "title": "Sedekku bare: Dai ichi bu: Taiyôki",
+                      "originalTitle": "Sai de ke · ba lai: Tai yang qi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2006781",
+                      "title": "L'ultimo terrestre",
+                      "originalTitle": "L'ultimo terrestre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1371585",
+                      "title": "Datsumeikin",
+                      "originalTitle": "Duet ming gam"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2050604",
+                      "title": "Ren shan ren hai",
+                      "originalTitle": "Ren shan ren hai"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4164468",
+                      "title": "Sedekku bare: Dai ni bu - Niji no hashi",
+                      "originalTitle": "Sai de ke · ba lai: Cai hong qiao"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2012,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Best European Short Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "UNICEF Award",
+        "CICT-IFTC Award",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Audience Award (Critics' Week)",
+        "FEDIC Award",
+        "FEDIC Award - Honorable Mention",
+        "Little Golden Lion",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "L'Oreal Paris Award",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Christopher D. Smithers Foundation Special Award",
+        "Biografilm Award",
+        "Nazareno Taddei Award",
+        "'CinemAvvenire' Award",
+        "Best Cinematography",
+        "AIF - For Film Fest Award",
+        "Golden Mouse",
+        "Premium Cinema Talent Award",
+        "Vittorio Veneto Film Festival Award",
+        "Fondazione Mimmo Rotella Award",
+        "Gillo Pontecorvo-Arcobaleno Latino Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "La Navicella Venezia Cinema Award",
+        "Nazareno Taddei Award - Special Mention",
+        "Persol Award",
+        "Silver Mouse",
+        "Venice Horizons Youtube Award",
+        "Premio Cinematografico \"Civitas Vitae prossima\" Award",
+        "Special Pasinetti Award",
+        "Bresson Award",
+        "Fedeora Award",
+        "Bisato d'Oro",
+        "Best Innovative Budget Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2299842",
+                      "title": "Pieta",
+                      "originalTitle": "Pieta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1846472",
+                      "title": "Après mai",
+                      "originalTitle": "Après mai"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1937449",
+                      "title": "At Any Price",
+                      "originalTitle": "At Any Price"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2184227",
+                      "title": "Bella addormentata",
+                      "originalTitle": "Bella addormentata"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1891788",
+                      "title": "È stato il figlio",
+                      "originalTitle": "È stato il figlio"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2219514",
+                      "title": "Lemale et ha-halal",
+                      "originalTitle": "Lemale et ha-halal"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2101441",
+                      "title": "Supuringu Bureikâzu",
+                      "originalTitle": "Spring Breakers"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1829012",
+                      "title": "Passion",
+                      "originalTitle": "Passion"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1849111",
+                      "title": "Superstar",
+                      "originalTitle": "Superstar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1595656",
+                      "title": "To the Wonder",
+                      "originalTitle": "To the Wonder"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1724962",
+                      "title": "Autoreiji: Biyondo",
+                      "originalTitle": "Autoreiji: Biyondo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2395459",
+                      "title": "Thy Womb",
+                      "originalTitle": "Thy Womb"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1928329",
+                      "title": "Linhas de Wellington",
+                      "originalTitle": "Linhas de Wellington"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2298820",
+                      "title": "La cinquième saison",
+                      "originalTitle": "La cinquième saison"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2299792",
+                      "title": "Un giorno speciale",
+                      "originalTitle": "Un giorno speciale"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2299954",
+                      "title": "Izmena",
+                      "originalTitle": "Izmena"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1560747",
+                      "title": "The Master",
+                      "originalTitle": "The Master"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2371824",
+                      "title": "Paradies: Glaube",
+                      "originalTitle": "Paradies: Glaube"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2013,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Audience Award (Critics' Week)",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "L'Oreal Paris Award",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Lina Mangiacapre Award - Special Mention",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Christopher D. Smithers Foundation Special Award",
+        "Nazareno Taddei Award",
+        "Mimmo Rotella Foundation Award",
+        "Golden Mouse",
+        "Vittorio Veneto Film Festival Award",
+        "Gillo Pontecorvo-Arcobaleno Latino Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Persol Award",
+        "Silver Mouse",
+        "Premio Cinematografico \"Civitas Vitae prossima\" Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Leoncino d'Oro Agiscuola Award - Cinema for UNICEF",
+        "CICT-UNESCO Enrico Fulchignoni Award",
+        "Magic Lantern Award",
+        "Golden Mouse - Special Mention",
+        "Gillo Pontecorvo-Arte e Industria Award",
+        "Vittorio Veneto Film Festival Award - Special Mention",
+        "Soundtrack Stars Award",
+        "Soundtrack Stars Award - Special Mention",
+        "Schermi di Qualità Award",
+        "Label Europa Cinemas - Special Mention",
+        "Fedeora Award",
+        "Fedeora Award - Special Mention",
+        "Bianchi Award",
+        "Ambiente WWF Award",
+        "Best Innovative Budget Award",
+        "S.I.A.E. Award for Emrging Talent"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3172520",
+                      "title": "Sacro GRA",
+                      "originalTitle": "Sacro GRA"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3177612",
+                      "title": "Es-Stouh",
+                      "originalTitle": "Es-Stouh"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3074784",
+                      "title": "L'intrepido",
+                      "originalTitle": "L'intrepido"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3078242",
+                      "title": "Miss Violence",
+                      "originalTitle": "Miss Violence"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2167266",
+                      "title": "Kiseki no 2,000 mile",
+                      "originalTitle": "Tracks"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1966637",
+                      "title": "Via Castellana Bandiera",
+                      "originalTitle": "Via Castellana Bandiera"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2427892",
+                      "title": "Tom à la ferme",
+                      "originalTitle": "Tom à la ferme"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1951095",
+                      "title": "Child of God",
+                      "originalTitle": "Child of God"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2431286",
+                      "title": "Anata wo dakishimeru hi made",
+                      "originalTitle": "Philomena"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2511670",
+                      "title": "La Jalousie",
+                      "originalTitle": "La Jalousie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2333804",
+                      "title": "The Zero Theorem",
+                      "originalTitle": "The Zero Theorem"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3092086",
+                      "title": "Ana Arabia",
+                      "originalTitle": "Ana Arabia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1441395",
+                      "title": "Under the Skin",
+                      "originalTitle": "Under the Skin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2382396",
+                      "title": "Joe",
+                      "originalTitle": "Joe"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1734429",
+                      "title": "Die Frau des Polizisten",
+                      "originalTitle": "Die Frau des Polizisten"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2345112",
+                      "title": "Pâkurando: Kenedi ansatsu, shinjitsu no yokka-kan",
+                      "originalTitle": "Parkland"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2013293",
+                      "title": "The Wind Rises",
+                      "originalTitle": "Kaze tachinu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2390962",
+                      "title": "The Unknown Known",
+                      "originalTitle": "The Unknown Known"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2043933",
+                      "title": "Night Moves",
+                      "originalTitle": "Night Moves"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3119416",
+                      "title": "Jiao you",
+                      "originalTitle": "Jiao you"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2014,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "C.I.C.A.E. Award",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Audience Award (Critics' Week)",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "L'Oreal Paris Award",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Nazareno Taddei Award",
+        "Human Rights Film Network Award",
+        "Golden Mouse",
+        "Vittorio Veneto Film Festival Award",
+        "Fondazione Mimmo Rotella Award",
+        "Gillo Pontecorvo-Arcobaleno Latino Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Persol Award",
+        "Silver Mouse",
+        "Premio Cinematografico \"Civitas Vitae prossima\" Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Leoncino d'Oro Agiscuola Award - Cinema for UNICEF",
+        "Arca CinemaGiovani Award",
+        "Vittorio Veneto Film Festival Award - Special Mention",
+        "Soundtrack Stars Award",
+        "Schermi di Qualità Award",
+        "Fedeora Award",
+        "International Award - Documentary",
+        "Bisato d'Oro",
+        "Piccioni Award",
+        "AssoMusica Award",
+        "Sorriso Diverso Venezia Award",
+        "BNL People's Choice Award",
+        "Best Innovative Budget Award",
+        "Cinecibo Award",
+        "Bisato d'Oro - Special Mention",
+        "AKAI International Film Fest Award",
+        "AKAI International Film Fest Award - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1883180",
+                      "title": "En duva satt på en gren och funderade på tillvaron",
+                      "originalTitle": "En duva satt på en gren och funderade på tillvaron"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2562232",
+                      "title": "Birdman aruiwa (Muchi ga Motarasu Yoki senu Kiseki)",
+                      "originalTitle": "Birdman or (The Unexpected Virtue of Ignorance)"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2245171",
+                      "title": "The Cut",
+                      "originalTitle": "The Cut"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2891174",
+                      "title": "99 Homes",
+                      "originalTitle": "99 Homes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3526482",
+                      "title": "Ghesse-ha",
+                      "originalTitle": "Ghesse-ha"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3194410",
+                      "title": "La rançon de la gloire",
+                      "originalTitle": "La rançon de la gloire"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3344922",
+                      "title": "Hungry Hearts",
+                      "originalTitle": "Hungry Hearts"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3227712",
+                      "title": "Le dernier coup de marteau",
+                      "originalTitle": "Le dernier coup de marteau"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3125652",
+                      "title": "Pasolini",
+                      "originalTitle": "Pasolini"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2822742",
+                      "title": "3 coeurs",
+                      "originalTitle": "3 coeurs"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3591984",
+                      "title": "Belye nochi pochtalyona Alekseya Tryapitsyna",
+                      "originalTitle": "Belye nochi pochtalyona Alekseya Tryapitsyna"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3152602",
+                      "title": "Il giovane favoloso",
+                      "originalTitle": "Il giovane favoloso"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3894344",
+                      "title": "Sivas",
+                      "originalTitle": "Sivas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3894190",
+                      "title": "Anime nere",
+                      "originalTitle": "Anime nere"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3297330",
+                      "title": "Good Kill",
+                      "originalTitle": "Good Kill"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2936180",
+                      "title": "Loin des hommes",
+                      "originalTitle": "Loin des hommes"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3521134",
+                      "title": "The Look of Silence",
+                      "originalTitle": "The Look of Silence"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3893038",
+                      "title": "Nobi",
+                      "originalTitle": "Nobi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3890278",
+                      "title": "Chuang ru zhe",
+                      "originalTitle": "Chuang ru zhe"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2893490",
+                      "title": "Manglehorn",
+                      "originalTitle": "Manglehorn"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2015,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Prix UIP Venice (European Short Film)",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Queer Lion - Special Mention",
+        "Label Europa Cinemas Award",
+        "L'Oreal Paris Award",
+        "Open Prize",
+        "Lina Mangiacapre Award",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Laterna Magica Prize",
+        "Nazareno Taddei Award",
+        "Human Rights Film Network Award",
+        "Mimmo Rotella Foundation Award",
+        "Golden Mouse",
+        "Vittorio Veneto Film Festival Award",
+        "Fondazione Mimmo Rotella Award",
+        "Gillo Pontecorvo-Arcobaleno Latino Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Silver Mouse",
+        "Premio Cinematografico \"Civitas Vitae prossima\" Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Arca CinemaGiovani Award",
+        "CICT-UNESCO Enrico Fulchignoni Award",
+        "Vittorio Veneto Film Festival Award - Special Mention",
+        "Soundtrack Stars Award",
+        "Schermi di Qualità Award",
+        "Fedeora Award",
+        "Bisato d'Oro",
+        "AssoMusica Award",
+        "Sorriso Diverso Venezia Award",
+        "Best Innovative Budget Award",
+        "Persol Tribute Visionary Talent Award",
+        "Fondazione Mimmo Rotella Special Award",
+        "Soundtrack Stars Lifetime Achievement Award",
+        "Amnesty International Italia Award",
+        "NuovoImaie Talent Award",
+        "Saturnia Prize",
+        "S.I.A.E. Award for Emrging Talent"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": null,
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4721400",
+                      "title": "Desde Allá",
+                      "originalTitle": "Desde Allá"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4895740",
+                      "title": "Abluka",
+                      "originalTitle": "Abluka"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4935446",
+                      "title": "Heart of a Dog",
+                      "originalTitle": "Heart of a Dog"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2922590",
+                      "title": "Sangue del mio sangue",
+                      "originalTitle": "Sangue del mio sangue"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4000936",
+                      "title": "Looking for Grace",
+                      "originalTitle": "Looking for Grace"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3289728",
+                      "title": "Lost Emotion",
+                      "originalTitle": "Equals"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3704050",
+                      "title": "Remember",
+                      "originalTitle": "Remember"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1365050",
+                      "title": "Beasts of No Nation",
+                      "originalTitle": "Beasts of No Nation"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4898888",
+                      "title": "Per amor vostro",
+                      "originalTitle": "Per amor vostro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4428788",
+                      "title": "Marguerite",
+                      "originalTitle": "Marguerite"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4935282",
+                      "title": "Rabin, ha'yom ha'akharon",
+                      "originalTitle": "Rabin, ha'yom ha'akharon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2056771",
+                      "title": "A Bigger Splash",
+                      "originalTitle": "A Bigger Splash"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4467154",
+                      "title": "The Endless River",
+                      "originalTitle": "The Endless River"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0810819",
+                      "title": "The Danish Girl",
+                      "originalTitle": "The Danish Girl"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2401878",
+                      "title": "White Puppet Problems",
+                      "originalTitle": "Anomalisa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4901304",
+                      "title": "Bei xi mo shou",
+                      "originalTitle": "Bei xi mo shou"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3715122",
+                      "title": "L'attesa",
+                      "originalTitle": "L'attesa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3865478",
+                      "title": "11 minut",
+                      "originalTitle": "11 minut"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3451720",
+                      "title": "Francofonia",
+                      "originalTitle": "Francofonia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4411504",
+                      "title": "El Clan",
+                      "originalTitle": "El Clan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4216908",
+                      "title": "L'hermine",
+                      "originalTitle": "L'hermine"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2016,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Best Short Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "Pasinetti Award",
+        "Audience Award (Critics' Week)",
+        "FEDIC Award",
+        "Little Golden Lion",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Venice Award - Special Mention",
+        "Gianni Astrei Award",
+        "Lina Mangiacapre Award",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Future Film Festival Digital Award - Special Mention",
+        "Laterna Magica Prize",
+        "Human Rights Film Network Award",
+        "Human Rights Film Network Award - Special Mention",
+        "Mimmo Rotella Foundation Award",
+        "Biennale Award",
+        "Vittorio Veneto Film Festival Award",
+        "Fondazione Mimmo Rotella Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Best Short Film - Special Mention",
+        "Venezia Classici Award",
+        "Arca CinemaGiovani Award",
+        "Soundtrack Stars Award",
+        "Fedeora Award",
+        "Civitas Vitae Prossima Award",
+        "Fondazione Mimmo Rotella Special Award",
+        "NuovoImaie Award",
+        "MigrArti Prize"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5843990",
+                      "title": "Ang babaeng humayo",
+                      "originalTitle": "Ang babaeng humayo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4334266",
+                      "title": "The Bad Batch",
+                      "originalTitle": "The Bad Batch"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5078134",
+                      "title": "Une vie",
+                      "originalTitle": "Une vie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3783958",
+                      "title": "La La Land",
+                      "originalTitle": "La La Land"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2547584",
+                      "title": "The Light Between Oceans",
+                      "originalTitle": "The Light Between Oceans"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4562518",
+                      "title": "El ciudadano ilustre",
+                      "originalTitle": "El ciudadano ilustre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5917932",
+                      "title": "Spira Mirabilis",
+                      "originalTitle": "Spira Mirabilis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4550098",
+                      "title": "Nocturnal Animals",
+                      "originalTitle": "Nocturnal Animals"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5247192",
+                      "title": "Piuma",
+                      "originalTitle": "Piuma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4551318",
+                      "title": "Ray",
+                      "originalTitle": "Ray"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1895315",
+                      "title": "Brimstone",
+                      "originalTitle": "Brimstone"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2800340",
+                      "title": "On the Milky Road",
+                      "originalTitle": "On the Milky Road"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1619029",
+                      "title": "Jackie",
+                      "originalTitle": "Jackie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1945228",
+                      "title": "Voyage of Time: Life's Journey",
+                      "originalTitle": "Voyage of Time: Life's Journey"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4778424",
+                      "title": "El Cristo ciego",
+                      "originalTitle": "El Cristo ciego"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5029608",
+                      "title": "Frantz",
+                      "originalTitle": "Frantz"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5784568",
+                      "title": "Questi giorni",
+                      "originalTitle": "Questi giorni"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2543164",
+                      "title": "Message",
+                      "originalTitle": "Arrival"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4715652",
+                      "title": "Les beaux jours d'Aranjuez",
+                      "originalTitle": "Les beaux jours d'Aranjuez"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5265960",
+                      "title": "La región salvaje",
+                      "originalTitle": "La región salvaje"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2017,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Best Italian Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "Pasinetti Award",
+        "Audience Award (Critics' Week)",
+        "Queer Lion Award",
+        "Lina Mangiacapre Award",
+        "Brian Award",
+        "Future Film Festival Digital Award",
+        "Human Rights Film Network Award",
+        "Human Rights Film Network Award - Special Mention",
+        "Fondazione Mimmo Rotella Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award - Cinema for UNICEF",
+        "Arca CinemaGiovani Award",
+        "CICT-UNESCO Enrico Fulchignoni Award",
+        "Soundtrack Stars Award",
+        "Fedeora Award",
+        "BNL People's Choice Award",
+        "S.I.A.E. Award for Emrging Talent",
+        "Fair Play Cinema Award",
+        "Fair Play Cinema Award - Special Mention",
+        "CICT-UNESCO C. Smithers Foundation Award",
+        "UNIMED Award",
+        "Franca Sozzani Award",
+        "Mouse d'Oro Award",
+        "La Pellicola d'Oro Award",
+        "Circolo del Cinema di Verona Award",
+        "Best VR Story",
+        "GdA Director's Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5580390",
+                      "title": "The Shape of Water",
+                      "originalTitle": "The Shape of Water"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6573444",
+                      "title": "Human Flow",
+                      "originalTitle": "Human Flow"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5109784",
+                      "title": "Mother!",
+                      "originalTitle": "Mother!"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0491175",
+                      "title": "Suburbicon",
+                      "originalTitle": "Suburbicon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7048622",
+                      "title": "L'insulte",
+                      "originalTitle": "L'insulte"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7219324",
+                      "title": "La villa",
+                      "originalTitle": "La villa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5340300",
+                      "title": "Lean on Pete",
+                      "originalTitle": "Lean on Pete"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6121444",
+                      "title": "Mektoub, My Love: Canto Uno",
+                      "originalTitle": "Mektoub, My Love: Canto Uno"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6410564",
+                      "title": "Sandome no satsujin",
+                      "originalTitle": "Sandome no satsujin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6002232",
+                      "title": "Julien",
+                      "originalTitle": "Jusqu'à la garde"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7204006",
+                      "title": "Ammore e malavita",
+                      "originalTitle": "Ammore e malavita"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6896536",
+                      "title": "Foxtrot",
+                      "originalTitle": "Foxtrot"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5027774",
+                      "title": "Three Billboards Outside Ebbing, Missouri",
+                      "originalTitle": "Three Billboards Outside Ebbing, Missouri"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4432006",
+                      "title": "Hannah",
+                      "originalTitle": "Hannah"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1389072",
+                      "title": "Downsizing",
+                      "originalTitle": "Downsizing"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7205208",
+                      "title": "Jia nian hua",
+                      "originalTitle": "Jia nian hua"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6256056",
+                      "title": "Una famiglia",
+                      "originalTitle": "Una famiglia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6053438",
+                      "title": "Tamashii no yukue",
+                      "originalTitle": "First Reformed"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6958212",
+                      "title": "Sweet Country",
+                      "originalTitle": "Sweet Country"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3741632",
+                      "title": "The Leisure Seeker",
+                      "originalTitle": "The Leisure Seeker"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6209282",
+                      "title": "Ex Libris",
+                      "originalTitle": "Ex Libris"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2018,
+      "awardNames": [
+        "Golden Lion",
+        "Grand Special Jury Prize",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Best Short Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "UNICEF Award",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Critics' Week Award",
+        "Audience Award (Critics' Week)",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Human Rights Film Network Award",
+        "Human Rights Film Network Award - Special Mention",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Arca CinemaGiovani Award",
+        "CICT-UNESCO Enrico Fulchignoni Award",
+        "Magic Lantern Award",
+        "Soundtrack Stars Award",
+        "Soundtrack Stars Award - Special Mention",
+        "Fedeora Award",
+        "BNL People's Choice Award",
+        "NuovoImaie Talent Award",
+        "MigrArti Prize",
+        "Fair Play Cinema Award",
+        "Fair Play Cinema Award - Special Mention",
+        "UNIMED Award",
+        "La Pellicola d'Oro Award",
+        "Circolo del Cinema di Verona Award",
+        "Best VR Story",
+        "Hearst Film Award",
+        "Smithers Foundation Award - Special Mention",
+        "Premio Vivere da Sportivi Award",
+        "Campari Passion for the Cinema Award",
+        "Smithers Foundation Award",
+        "Edipo Re Award (Università degli Studi di Padova e ResInt Rete dell'Economia Sociale Internazionale)",
+        "Mario Serandrei - Hotel Saturnia & International Award for the Best Technical Contribution",
+        "Sfera 1932 Award",
+        "GdA Director's Award",
+        "Grand Jury Prize for Best VR Immersive Work"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6155172",
+                      "title": "Roma",
+                      "originalTitle": "Roma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7950334",
+                      "title": "The Mountain",
+                      "originalTitle": "The Mountain"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7250056",
+                      "title": "Doubles vies",
+                      "originalTitle": "Doubles vies"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4971344",
+                      "title": "Golden River",
+                      "originalTitle": "The Sisters Brothers"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6412452",
+                      "title": "The Ballad of Buster Scruggs",
+                      "originalTitle": "The Ballad of Buster Scruggs"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5960374",
+                      "title": "Vox Lux",
+                      "originalTitle": "Vox Lux"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7280898",
+                      "title": "22 July",
+                      "originalTitle": "22 July"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1034415",
+                      "title": "Sasuperia",
+                      "originalTitle": "Suspiria"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5311542",
+                      "title": "Werk ohne Autor",
+                      "originalTitle": "Werk ohne Autor"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4068576",
+                      "title": "ナイチンゲール",
+                      "originalTitle": "The Nightingale"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5083738",
+                      "title": "Joouheika no okiniiri",
+                      "originalTitle": "The Favourite"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4614612",
+                      "title": "Peterloo",
+                      "originalTitle": "Peterloo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7188002",
+                      "title": "Capri-Revolution",
+                      "originalTitle": "Capri-Revolution"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8747596",
+                      "title": "What You Gonna Do When the World's on Fire?",
+                      "originalTitle": "What You Gonna Do When the World's on Fire?"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5855772",
+                      "title": "Napszállta",
+                      "originalTitle": "Napszállta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6527586",
+                      "title": "Frères ennemis",
+                      "originalTitle": "Frères ennemis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6938828",
+                      "title": "At Eternity's Gate",
+                      "originalTitle": "At Eternity's Gate"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7952000",
+                      "title": "Acusada",
+                      "originalTitle": "Acusada"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7117352",
+                      "title": "Zan,",
+                      "originalTitle": "Zan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5265964",
+                      "title": "Nuestro tiempo",
+                      "originalTitle": "Nuestro tiempo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1213641",
+                      "title": "First Man",
+                      "originalTitle": "First Man"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "category": "Immersive VR",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7918178",
+                      "title": "Spheres",
+                      "originalTitle": "Spheres"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2019,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Best Short Film",
+        "FIPRESCI Prize",
+        "UNICEF Award",
+        "International Critics' Week Award",
+        "Pasinetti Award",
+        "Audience Award (Critics' Week)",
+        "Queer Lion Award",
+        "Human Rights Film Network Award - Special Mention",
+        "Fondazione Mimmo Rotella Award",
+        "Green Drop Award",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Soundtrack Stars Award",
+        "Fedeora Award",
+        "Sorriso Diverso Venezia Award",
+        "UNIMED Award",
+        "La Pellicola d'Oro Award",
+        "Orizzonti Award for Best Short Film",
+        "Best VR Story",
+        "Campari Passion for the Cinema Award",
+        "Edipo Re Award (Università degli Studi di Padova e ResInt Rete dell'Economia Sociale Internazionale)",
+        "Mario Serandrei - Hotel Saturnia & International Award for the Best Technical Contribution",
+        "Filming Italy Award",
+        "GdA Director's Award",
+        "Verona Film Club Award for Most Innovative Film",
+        "Lanterna Magica Award",
+        "Lizzani Award",
+        "Fanheart3 Award",
+        "Sfera 1932 Award - Special Mention",
+        "Best VR Immersive User Experience",
+        "Venice Award for Best Virtual Reality"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7286456",
+                      "title": "Joker",
+                      "originalTitle": "Joker"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8499638",
+                      "title": "Lan xin da ju yuan",
+                      "originalTitle": "Lan xin da ju yuan"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6817944",
+                      "title": "Om det oändliga",
+                      "originalTitle": "Om det oändliga"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2935510",
+                      "title": "Ad Astra",
+                      "originalTitle": "Ad Astra"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8399664",
+                      "title": "Babyteeth",
+                      "originalTitle": "Babyteeth"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8800266",
+                      "title": "Ema",
+                      "originalTitle": "Ema"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9584814",
+                      "title": "Sic Transit Gloria Mundi",
+                      "originalTitle": "Sic Transit Gloria Mundi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9143636",
+                      "title": "Guest of Honour",
+                      "originalTitle": "Guest of Honour"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8439860",
+                      "title": "A Herdade",
+                      "originalTitle": "A Herdade"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt10673846",
+                      "title": "La mafia non è più quella di una volta",
+                      "originalTitle": "La mafia non è più quella di una volta"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7653254",
+                      "title": "Marriage Story",
+                      "originalTitle": "Marriage Story"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4516162",
+                      "title": "Martin Eden",
+                      "originalTitle": "Martin Eden"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9778888",
+                      "title": "Il sindaco del Rione Sanità",
+                      "originalTitle": "Il sindaco del Rione Sanità"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt10687168",
+                      "title": "Jiyuantai qihao",
+                      "originalTitle": "Jiyuantai qihao"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt2398149",
+                      "title": "J'accuse",
+                      "originalTitle": "J'accuse"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1667354",
+                      "title": "Nabarvené ptáce",
+                      "originalTitle": "Nabarvené ptáce"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6971114",
+                      "title": "Al-murashahat al-muthalia",
+                      "originalTitle": "Al-murashahat al-muthalia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8323120",
+                      "title": "Shinjitsu",
+                      "originalTitle": "La vérité"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6149154",
+                      "title": "Waiting for the Barbarians",
+                      "originalTitle": "Waiting for the Barbarians"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6760876",
+                      "title": "Wasp Network",
+                      "originalTitle": "Wasp Network"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5865326",
+                      "title": "The Laundromat",
+                      "originalTitle": "The Laundromat"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2020,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Best First Work",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "SIGNIS Award - Honorable Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Young Cinema Award",
+        "Best Director",
+        "Best First Film",
+        "Jaeger-LeCoultre Glory to the Filmmaker Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Arca CinemaGiovani Award",
+        "Soundtrack Stars Award",
+        "Bisato d'Oro",
+        "Sorriso Diverso Venezia Award",
+        "NuovoImaie Talent Award",
+        "Fair Play Cinema Award",
+        "Fair Play Cinema Award - Special Mention",
+        "La Pellicola d'Oro Award",
+        "Best VR Story",
+        "Campari Passion for the Cinema Award",
+        "Edipo Re Award (Università degli Studi di Padova e ResInt Rete dell'Economia Sociale Internazionale)",
+        "Mario Serandrei - Hotel Saturnia & International Award for the Best Technical Contribution",
+        "GdA Director's Award",
+        "Verona Film Club Award for Most Innovative Film",
+        "Lanterna Magica Award",
+        "Fanheart3 Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award - Special Mention",
+        "RB Casting Award",
+        "Best VR Immersive User Experience",
+        "Venice Award for Best Virtual Reality",
+        "Grand Prize Venice International Critics' Week",
+        "Giornate degli Autori Award",
+        "SIAE Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9770150",
+                      "title": "Nomadland",
+                      "originalTitle": "Nomadland"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9800670",
+                      "title": "Amants",
+                      "originalTitle": "Amants"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11423784",
+                      "title": "夢追い人",
+                      "originalTitle": "The Disciple"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11767722",
+                      "title": "Khorshid",
+                      "originalTitle": "Khorshid"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11268864",
+                      "title": "Sepelenmis ölümler arasinda",
+                      "originalTitle": "Sepelenmis ölümler arasinda"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12716170",
+                      "title": "Layla BeHaifa",
+                      "originalTitle": "Layla BeHaifa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11009666",
+                      "title": "Miss Marx",
+                      "originalTitle": "Miss Marx"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9526784",
+                      "title": "Sniegu juz nigdy nie bedzie",
+                      "originalTitle": "Sniegu juz nigdy nie bedzie"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12474056",
+                      "title": "Nuevo orden",
+                      "originalTitle": "Nuevo orden"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7945450",
+                      "title": "Notturno",
+                      "originalTitle": "Notturno"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt10798072",
+                      "title": "Padrenostro",
+                      "originalTitle": "Padrenostro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7716120",
+                      "title": "そして明日は全世界に",
+                      "originalTitle": "Und morgen die ganze Welt"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12789110",
+                      "title": "Le sorelle Macaluso",
+                      "originalTitle": "Le sorelle Macaluso"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11161474",
+                      "title": "Pieces of a Woman",
+                      "originalTitle": "Pieces of a Woman"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11917942",
+                      "title": "Supai no tsuma",
+                      "originalTitle": "Supai no tsuma"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9738716",
+                      "title": "The World to Come",
+                      "originalTitle": "The World to Come"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8633462",
+                      "title": "Quo Vadis, Aida?",
+                      "originalTitle": "Quo Vadis, Aida?"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt10796286",
+                      "title": "Dorogie tovarishchi",
+                      "originalTitle": "Dorogie tovarishchi"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12716170",
+                      "title": "Layla BeHaifa",
+                      "originalTitle": "Layla BeHaifa"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2021,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "Pasinetti Award",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Interfilm Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Leoncino d'Oro Agiscuola Award - Cinema for UNICEF",
+        "Soundtrack Stars Award",
+        "Soundtrack Stars Award - Special Mention",
+        "Bisato d'Oro",
+        "Sorriso Diverso Venezia Award",
+        "BNL People's Choice Award",
+        "NuovoImaie Talent Award",
+        "S.I.A.E. Award for Emrging Talent",
+        "La Pellicola d'Oro Award",
+        "Circolo del Cinema di Verona Award",
+        "Campari Passion for the Cinema Award",
+        "Edipo Re Award (Università degli Studi di Padova e ResInt Rete dell'Economia Sociale Internazionale)",
+        "Mario Serandrei - Hotel Saturnia & International Award for the Best Technical Contribution",
+        "GdA Director's Award",
+        "Lanterna Magica Award",
+        "Fanheart3 Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award - Special Mention",
+        "Grand Prize Venice International Critics' Week",
+        "Audience Award - Armani Beauty (Orizzonti Extra)",
+        "SIC@SIC Short Italian Cinema alla Settimana Internazionale della Critica",
+        "Giornate degli Autori Award",
+        "Grand Jury Prize for Best VR Immersive Work",
+        "Cartier Glory to the Filmmaker Award",
+        "HFPA Special Prize",
+        "Giornate degli Autori - Award for Women Screenwriters Under 40",
+        "Premio per l'inclusione Edipo Re (Giornate degli Autori)",
+        "Premio Ulisse Terra di Cinema"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13880104",
+                      "title": "L'événement",
+                      "originalTitle": "L'événement"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12618926",
+                      "title": "Madres paralelas",
+                      "originalTitle": "Madres paralelas"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8760670",
+                      "title": "Mona Lisa and the Blood Moon",
+                      "originalTitle": "Mona Lisa and the Blood Moon"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12536294",
+                      "title": "Spencer",
+                      "originalTitle": "Spencer"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt10293406",
+                      "title": "The Power of the Dog",
+                      "originalTitle": "The Power of the Dog"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13932304",
+                      "title": "America Latina",
+                      "originalTitle": "America Latina"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11012320",
+                      "title": "Il buco",
+                      "originalTitle": "Il buco"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12680684",
+                      "title": "È stata la mano di Dio",
+                      "originalTitle": "È stata la mano di Dio"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt7270808",
+                      "title": "Freaks Out",
+                      "originalTitle": "Freaks Out"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9526392",
+                      "title": "Qui rido io",
+                      "originalTitle": "Qui rido io"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15115102",
+                      "title": "Un autre monde",
+                      "originalTitle": "Un autre monde"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15115280",
+                      "title": "Sundown",
+                      "originalTitle": "Sundown"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9100054",
+                      "title": "The Lost Daughter",
+                      "originalTitle": "The Lost Daughter"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3785036",
+                      "title": "On the Job 2: The Missing 8",
+                      "originalTitle": "On the Job 2: The Missing 8"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13473548",
+                      "title": "Zeby nie bylo sladów",
+                      "originalTitle": "Zeby nie bylo sladów"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13322726",
+                      "title": "Kapitan Volkonogov bezhal",
+                      "originalTitle": "Kapitan Volkonogov bezhal"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11196036",
+                      "title": "The Card Counter",
+                      "originalTitle": "The Card Counter"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14225832",
+                      "title": "Vidblysk",
+                      "originalTitle": "Vidblysk"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13846544",
+                      "title": "La caja",
+                      "originalTitle": "La caja"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt10505316",
+                      "title": "Illusions perdues",
+                      "originalTitle": "Illusions perdues"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11700260",
+                      "title": "Competencia oficial",
+                      "originalTitle": "Competencia oficial"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2022,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "Best Italian Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "FEDIC Award",
+        "Queer Lion Award",
+        "Brian Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Arca CinemaGiovani Award",
+        "CICT-UNESCO Enrico Fulchignoni Award",
+        "Soundtrack Stars Award",
+        "Fedeora Award",
+        "Sorriso Diverso Venezia Award",
+        "NuovoImaie Talent Award",
+        "UNIMED Award",
+        "La Pellicola d'Oro Award",
+        "Campari Passion for the Cinema Award",
+        "Smithers Foundation Award",
+        "Edipo Re Award (Università degli Studi di Padova e ResInt Rete dell'Economia Sociale Internazionale)",
+        "Mario Serandrei - Hotel Saturnia & International Award for the Best Technical Contribution",
+        "Filming Italy Award",
+        "GdA Director's Award",
+        "Verona Film Club Award for Most Innovative Film",
+        "Lanterna Magica Award",
+        "Lizzani Award",
+        "Fanheart3 Award",
+        "RB Casting Award",
+        "Grand Prize Venice International Critics' Week",
+        "Audience Award - Armani Beauty (Orizzonti Extra)",
+        "SIC@SIC Short Italian Cinema alla Settimana Internazionale della Critica",
+        "Cartier Glory to the Filmmaker Award",
+        "HFPA Special Prize",
+        "Venice Immersive",
+        "Green Drop Award - Special Mention",
+        "Premio CinemaSarà Award",
+        "Authors under 40 Award",
+        "Giornate Degli Autori's People Choice Award",
+        "amfAR Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt21374850",
+                      "title": "All the Beauty and the Bloodshed",
+                      "originalTitle": "All the Beauty and the Bloodshed"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6160448",
+                      "title": "White Noise",
+                      "originalTitle": "White Noise"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13874422",
+                      "title": "The Eternal Daughter",
+                      "originalTitle": "The Eternal Daughter"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt10168670",
+                      "title": "Bones and All",
+                      "originalTitle": "Bones and All"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13833688",
+                      "title": "The Whale",
+                      "originalTitle": "The Whale"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14176542",
+                      "title": "Bardo, falsa crónica de unas cuantas verdades",
+                      "originalTitle": "Bardo, falsa crónica de unas cuantas verdades"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt6337816",
+                      "title": "Monica",
+                      "originalTitle": "Monica"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13051724",
+                      "title": "L'immensità",
+                      "originalTitle": "L'immensità"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14458442",
+                      "title": "The Son",
+                      "originalTitle": "The Son"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14444726",
+                      "title": "Tár",
+                      "originalTitle": "Tár"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1655389",
+                      "title": "Blonde",
+                      "originalTitle": "Blonde"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11813216",
+                      "title": "The Banshees of Inisherin",
+                      "originalTitle": "The Banshees of Inisherin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15376894",
+                      "title": "Saint Omer",
+                      "originalTitle": "Saint Omer"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15445056",
+                      "title": "Athena",
+                      "originalTitle": "Athena"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15301048",
+                      "title": "Argentina, 1985",
+                      "originalTitle": "Argentina, 1985"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15027532",
+                      "title": "Chiara",
+                      "originalTitle": "Chiara"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14575898",
+                      "title": "Il signore delle formiche",
+                      "originalTitle": "Il signore delle formiche"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt20205236",
+                      "title": "Khers nist",
+                      "originalTitle": "Khers nist"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13920988",
+                      "title": "Shab, Dakheli, Divar",
+                      "originalTitle": "Shab, Dakheli, Divar"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15403712",
+                      "title": "Les enfants des autres",
+                      "originalTitle": "Les enfants des autres"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt21372086",
+                      "title": "Les miens",
+                      "originalTitle": "Les miens"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt21374862",
+                      "title": "Un couple",
+                      "originalTitle": "Un couple"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt18235306",
+                      "title": "Love Life",
+                      "originalTitle": "Love Life"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2023,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Marcello Mastroianni Award",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Career Golden Lion",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "SIGNIS Award - Honorable Mention",
+        "Netpac Award",
+        "UNESCO Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Brian Award",
+        "Best Director",
+        "Best First Film",
+        "Green Drop Award",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Leoncino d'Oro Agiscuola Award - Cinema for UNICEF",
+        "Arca CinemaGiovani Award",
+        "Soundtrack Stars Award",
+        "Soundtrack Stars Award - Special Mention",
+        "Bisato d'Oro",
+        "Sorriso Diverso Venezia Award",
+        "NuovoImaie Talent Award",
+        "UNIMED Award",
+        "La Pellicola d'Oro Award",
+        "Orizzonti Award for Best Short Film",
+        "Campari Passion for the Cinema Award",
+        "Mario Serandrei - Hotel Saturnia & International Award for the Best Technical Contribution",
+        "GdA Director's Award",
+        "Verona Film Club Award for Most Innovative Film",
+        "Lanterna Magica Award",
+        "Lizzani Award",
+        "Fanheart3 Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award",
+        "Grand Prize Venice International Critics' Week",
+        "Audience Award - Armani Beauty (Orizzonti Extra)",
+        "SIC@SIC Short Italian Cinema alla Settimana Internazionale della Critica",
+        "Giornate degli Autori Award",
+        "Cartier Glory to the Filmmaker Award",
+        "Venice Immersive",
+        "Premio CinemaSarà Award",
+        "Authors under 40 Award",
+        "Venice Immersive Grand Prize",
+        "Le Vie Dell'Immagine Award",
+        "Premio CinemaSarà Award - Special Mention",
+        "Ca' Foscari Young Jury Award",
+        "UNIMED Prize for Cultural Diversity",
+        "Robert Bresson Award",
+        "The Film Club Audience Award",
+        "ImpACT Award",
+        "Cinema & Arts Award",
+        "Cinema & Arts Award - Special Mention"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14230458",
+                      "title": "Poor Things",
+                      "originalTitle": "Poor Things"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt23573936",
+                      "title": "Comandante",
+                      "originalTitle": "Comandante"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt20561198",
+                      "title": "Bastarden",
+                      "originalTitle": "Bastarden"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt17009348",
+                      "title": "Dogman",
+                      "originalTitle": "Dogman"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14407336",
+                      "title": "La bête",
+                      "originalTitle": "La bête"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt27219440",
+                      "title": "Enea",
+                      "originalTitle": "Enea"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt5535276",
+                      "title": "Maesutoro",
+                      "originalTitle": "Maestro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt22041854",
+                      "title": "Priscilla",
+                      "originalTitle": "Priscilla"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt21824548",
+                      "title": "Finalmente l'alba",
+                      "originalTitle": "Finalmente l'alba"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt4707780",
+                      "title": "Lubo",
+                      "originalTitle": "Lubo"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13321244",
+                      "title": "Origin",
+                      "originalTitle": "Origin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1136617",
+                      "title": "The Killer",
+                      "originalTitle": "The Killer"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt19864828",
+                      "title": "Memory",
+                      "originalTitle": "Memory"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14225838",
+                      "title": "Io capitano",
+                      "originalTitle": "Io capitano"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt27722543",
+                      "title": "Zielona granica",
+                      "originalTitle": "Zielona granica"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt18453866",
+                      "title": "Die Theorie von Allem",
+                      "originalTitle": "Die Theorie von Allem"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt21113540",
+                      "title": "El conde",
+                      "originalTitle": "El conde"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt26746630",
+                      "title": "Kobieta z...",
+                      "originalTitle": "Kobieta z..."
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt27704325",
+                      "title": "Hors-saison",
+                      "originalTitle": "Hors-saison"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13866832",
+                      "title": "Holly",
+                      "originalTitle": "Holly"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt28490044",
+                      "title": "Aku wa sonzai shinai",
+                      "originalTitle": "Aku wa sonzai shinai"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt22001304",
+                      "title": "Adagio",
+                      "originalTitle": "Adagio"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt3758542",
+                      "title": "Ferrari",
+                      "originalTitle": "Ferrari"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2024,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Special Mention",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "Best Short Film",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "Netpac Award",
+        "Pasinetti Award",
+        "Pasinetti Award - Special Mention",
+        "Critics' Week Award",
+        "FEDIC Award",
+        "FEDIC Award - Special Mention",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Brian Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "Silver Lion - Short Film",
+        "Award of the City of Venice",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Leoncino d'Oro Agiscuola Award - Cinema for UNICEF",
+        "Arca CinemaGiovani Award",
+        "CICT-UNESCO Enrico Fulchignoni Award",
+        "Soundtrack Stars Award",
+        "Sorriso Diverso Venezia Award",
+        "Marcello Mastrioanno Award",
+        "NuovoImaie Talent Award",
+        "La Pellicola d'Oro Award",
+        "Campari Passion for the Cinema Award",
+        "Smithers Foundation Award",
+        "Edipo Re Award (Università degli Studi di Padova e ResInt Rete dell'Economia Sociale Internazionale)",
+        "Mario Serandrei - Hotel Saturnia & International Award for the Best Technical Contribution",
+        "Verona Film Club Award for Most Innovative Film",
+        "Lanterna Magica Award",
+        "Lizzani Award",
+        "Fanheart3 Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award - Special Mention",
+        "RB Casting Award",
+        "Grand Prize Venice International Critics' Week",
+        "Audience Award - Armani Beauty (Orizzonti Extra)",
+        "SIC@SIC Short Italian Cinema alla Settimana Internazionale della Critica",
+        "Cartier Glory to the Filmmaker Award",
+        "Venice Immersive",
+        "Green Drop Award - Special Mention",
+        "Premio CinemaSarà Award",
+        "Authors under 40 Award",
+        "Golden Lion for Lifetime Achievement",
+        "Liberatum Pioneer Award",
+        "Giornate degli Autori Director's Award",
+        "Giornate degli Autori Audience Award",
+        "Venice Immersive Grand Prize",
+        "Premio CinemaSarà Award - Special Mention",
+        "Ca' Foscari Young Jury Award",
+        "UNIMED Prize for Cultural Diversity",
+        "ImpACT Award",
+        "Cinema & Arts Award",
+        "Critics' Week Audience Award",
+        "Luciano Sovena Award",
+        "Rotella Award",
+        "Edipo Re Award - Special Mention",
+        "Premio Speciale Film Impresa Award",
+        "Starlight international Cinema Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt29439114",
+                      "title": "The Room Next Door",
+                      "originalTitle": "The Room Next Door"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt28297850",
+                      "title": "Iddu",
+                      "originalTitle": "Iddu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt24176060",
+                      "title": "Queer",
+                      "originalTitle": "Queer"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11315808",
+                      "title": "Joker: Folie à Deux",
+                      "originalTitle": "Joker: Folie à Deux"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt22893404",
+                      "title": "Maria",
+                      "originalTitle": "Maria"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt14961016",
+                      "title": "Ainda Estou Aqui",
+                      "originalTitle": "Ainda Estou Aqui"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt31322960",
+                      "title": "Campo di battaglia",
+                      "originalTitle": "Campo di battaglia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt28618488",
+                      "title": "Vermiglio",
+                      "originalTitle": "Vermiglio"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt31105878",
+                      "title": "Diva Futura",
+                      "originalTitle": "Diva Futura"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt13610344",
+                      "title": "Harvest",
+                      "originalTitle": "Harvest"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt26625693",
+                      "title": "The Order",
+                      "originalTitle": "The Order"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt8999762",
+                      "title": "The Brutalist",
+                      "originalTitle": "The Brutalist"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt31350080",
+                      "title": "Aprilis",
+                      "originalTitle": "Aprilis"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt30057084",
+                      "title": "Babygirl",
+                      "originalTitle": "Babygirl"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt33029375",
+                      "title": "Qingchun: Gui",
+                      "originalTitle": "Qingchun: Gui"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt30810792",
+                      "title": "Kjærlighet",
+                      "originalTitle": "Kjærlighet"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt28522540",
+                      "title": "Leurs enfants après eux",
+                      "originalTitle": "Leurs enfants après eux"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt28231777",
+                      "title": "El jockey",
+                      "originalTitle": "El jockey"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt28419037",
+                      "title": "Mo shi lu",
+                      "originalTitle": "Mo shi lu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt28601337",
+                      "title": "Jouer avec le feu",
+                      "originalTitle": "Jouer avec le feu"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt30325268",
+                      "title": "Trois amies",
+                      "originalTitle": "Trois amies"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2025,
+      "awardNames": [
+        "Golden Lion",
+        "Silver Lion",
+        "Special Jury Prize",
+        "Golden Osella",
+        "Volpi Cup",
+        "Luigi De Laurentiis Award",
+        "Venice Horizons Award",
+        "FIPRESCI Prize",
+        "SIGNIS Award",
+        "Netpac Award",
+        "Netpac Award - Special Mention",
+        "UNICEF Award",
+        "Pasinetti Award",
+        "Pietro Bianchi Award",
+        "Critics' Week Award",
+        "FEDIC Award",
+        "Queer Lion Award",
+        "Label Europa Cinemas Award",
+        "Brian Award",
+        "Special Award",
+        "Green Drop Award",
+        "Interfilm Award",
+        "International Critics Award - Special Mention",
+        "Venezia Classici Award",
+        "Leoncino d'Oro Agiscuola Award",
+        "Leoncino d'Oro Agiscuola Award - Cinema for UNICEF",
+        "Arca CinemaGiovani Award",
+        "CICT-UNESCO Enrico Fulchignoni Award",
+        "Magic Lantern Award",
+        "Soundtrack Stars Award",
+        "Bisato d'Oro",
+        "Sorriso Diverso Venezia Award",
+        "Marcello Mastrioanno Award",
+        "NuovoImaie Talent Award",
+        "La Pellicola d'Oro Award",
+        "Campari Passion for the Cinema Award",
+        "Edipo Re Award (Università degli Studi di Padova e ResInt Rete dell'Economia Sociale Internazionale)",
+        "Fanheart3 Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award",
+        "Premio Fondazione Fai Persona Lavoro Ambiente Award - Special Mention",
+        "RB Casting Award",
+        "Audience Award - Armani Beauty (Orizzonti Extra)",
+        "SIC@SIC Short Italian Cinema alla Settimana Internazionale della Critica",
+        "Giornate degli Autori Award",
+        "Cartier Glory to the Filmmaker Award",
+        "Venice Immersive",
+        "Authors under 40 Award",
+        "Giornate Degli Autori's People Choice Award",
+        "Golden Lion for Lifetime Achievement",
+        "Venice Immersive Grand Prize",
+        "Ca' Foscari Young Jury Award",
+        "Cinema & Arts Award",
+        "Cinema & Arts Award - Special Mention",
+        "Luciano Sovena Award",
+        "Impact Golden Globes Prize for Documentary",
+        "Croce Rossa Italiana Award",
+        "CinemaSarà Award",
+        "Premio Carlo Lizzani"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": true,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt31189315",
+                      "title": "Father Mother Sister Brother",
+                      "originalTitle": "Father Mother Sister Brother"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt34886821",
+                      "title": "La grazia",
+                      "originalTitle": "La grazia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt32386654",
+                      "title": "Le Mage du Kremlin",
+                      "originalTitle": "Le Mage du Kremlin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt30446847",
+                      "title": "Jay Kelly",
+                      "originalTitle": "Jay Kelly"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt36943034",
+                      "title": "Sawt Hind Rajab",
+                      "originalTitle": "Sawt Hind Rajab"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt32376165",
+                      "title": "A House of Dynamite",
+                      "originalTitle": "A House of Dynamite"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt32907482",
+                      "title": "Ri gua zhong tian",
+                      "originalTitle": "Ri gua zhong tian"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1312221",
+                      "title": "Frankenstein",
+                      "originalTitle": "Frankenstein"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt37660578",
+                      "title": "Elisa",
+                      "originalTitle": "Elisa"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt37660587",
+                      "title": "À pied d'oeuvre",
+                      "originalTitle": "À pied d'oeuvre"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt27811632",
+                      "title": "Stille Freundin",
+                      "originalTitle": "Stille Freundin"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt34819091",
+                      "title": "The Testament of Ann Lee",
+                      "originalTitle": "The Testament of Ann Lee"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt12300742",
+                      "title": "Bugonia",
+                      "originalTitle": "Bugonia"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt31415482",
+                      "title": "Duse",
+                      "originalTitle": "Duse"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt30874362",
+                      "title": "Un film fatto per Bene",
+                      "originalTitle": "Un film fatto per Bene"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt31065630",
+                      "title": "Árva",
+                      "originalTitle": "Árva"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt36243564",
+                      "title": "L'étranger",
+                      "originalTitle": "L'étranger"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt1527793",
+                      "title": "Eo-jjeol su-ga eop-da",
+                      "originalTitle": "Eo-jjeol su-ga eop-da"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt36874833",
+                      "title": "Sotto le nuvole",
+                      "originalTitle": "Sotto le nuvole"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt11214558",
+                      "title": "The Smashing Machine",
+                      "originalTitle": "The Smashing Machine"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt33396536",
+                      "title": "Nühai",
+                      "originalTitle": "Nühai"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "year": 2026,
+      "awardNames": [
+        "Golden Lion",
+        "Venice Horizons Award",
+        "International Critics' Week Award",
+        "Campari Passion for the Cinema Award",
+        "Giornate degli Autori Award",
+        "Golden Lion for Lifetime Achievement",
+        "Venice Immersive Grand Prize",
+        "Armani Beauty Audience Award"
+      ],
+      "goldenLion": [
+        {
+          "categories": [
+            {
+              "category": "Best Film",
+              "total": null,
+              "nominations": [
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt37967547",
+                      "title": "Ink",
+                      "originalTitle": "Ink"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt41802342",
+                      "title": "Un bon petit soldat",
+                      "originalTitle": "Un bon petit soldat"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt9395802",
+                      "title": "The Echo Chamber",
+                      "originalTitle": "The Echo Chamber"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt38807757",
+                      "title": "Un peu avant minuit",
+                      "originalTitle": "Un peu avant minuit"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt37803364",
+                      "title": "Ganeunghan sarang",
+                      "originalTitle": "Ganeunghan sarang"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt34206385",
+                      "title": "Primetime",
+                      "originalTitle": "Primetime"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt41240964",
+                      "title": "Nelson san, anata ha hito wo koroshimashitaka?",
+                      "originalTitle": "Nelson-san, anata wa hito o koro shimashita ka?"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt43704846",
+                      "title": "Kami nour",
+                      "originalTitle": "Kami nour"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt0772163",
+                      "title": "Company",
+                      "originalTitle": "Company"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt23411728",
+                      "title": "L'estranea",
+                      "originalTitle": "L'estranea"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt39094466",
+                      "title": "Rukku Bakku",
+                      "originalTitle": "Rukku Bakku"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt37341481",
+                      "title": "Succederà questa notte",
+                      "originalTitle": "Succederà questa notte"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt35670577",
+                      "title": "Bucking Fastard",
+                      "originalTitle": "Bucking Fastard"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt42826707",
+                      "title": "15/18",
+                      "originalTitle": "15/18"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt34888026",
+                      "title": "Kvinde ukendt",
+                      "originalTitle": "Kvinde ukendt"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt34621251",
+                      "title": "Il fuoco che ti porti dentro",
+                      "originalTitle": "Il fuoco che ti porti dentro"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt43702526",
+                      "title": "Dau",
+                      "originalTitle": "Dau"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt39239726",
+                      "title": "Ritorno a Buenos Aires",
+                      "originalTitle": "Ritorno a Buenos Aires"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt15799564",
+                      "title": "Wild Horse Nine",
+                      "originalTitle": "Wild Horse Nine"
+                    }
+                  ]
+                },
+                {
+                  "isWinner": false,
+                  "notes": null,
+                  "titles": [
+                    {
+                      "imdbId": "tt36770512",
+                      "title": "Bunker",
+                      "originalTitle": "Bunker"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/scrapers/package.json
+++ b/apps/scrapers/package.json
@@ -13,6 +13,7 @@
     "availability-check": "tsx src/availability-check-cli.ts",
     "japanese-translations": "tsx src/japanese-translations-cli.ts",
     "cannes-film-festival": "tsx src/cannes-film-festival-cli.ts",
+    "venice-film-festival": "tsx src/venice-film-festival-cli.ts",
     "sns-post": "tsx src/sns-post-cli.ts"
   },
   "dependencies": {

--- a/apps/scrapers/src/__tests__/venice-film-festival.test.ts
+++ b/apps/scrapers/src/__tests__/venice-film-festival.test.ts
@@ -1,0 +1,637 @@
+/* eslint-disable unicorn/no-null -- IMDbから収集したJSONはnullを含む */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {and, eq} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {referenceUrls} from '@shine/database/schema/reference-urls';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  extractGoldenLionEditions,
+  importVeniceGoldenLion,
+  veniceCeremonyNumber,
+  type VeniceCollectedData,
+  type VeniceEdition,
+} from '../venice-film-festival';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+async function createTestEnvironment(): Promise<{
+  environment: Environment;
+  database: ReturnType<typeof getDatabase>;
+}> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-venice-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+  return {environment, database};
+}
+
+function nomination(
+  imdbId: string,
+  originalTitle: string,
+  isWinner = false,
+): VeniceEdition['goldenLion'][number]['categories'][number]['nominations'][number] {
+  return {
+    isWinner,
+    notes: null,
+    titles: [{imdbId, title: originalTitle, originalTitle}],
+  };
+}
+
+function edition(
+  year: number,
+  nominations_: Array<
+    VeniceEdition['goldenLion'][number]['categories'][number]['nominations'][number]
+  >,
+  category: string | null = null,
+): VeniceEdition {
+  return {
+    year,
+    awardNames: ['Golden Lion'],
+    goldenLion: [
+      {
+        categories: [{category, total: null, nominations: nominations_}],
+      },
+    ],
+  };
+}
+
+function collectedData(editions: VeniceEdition[]): VeniceCollectedData {
+  return {
+    collectedAt: '2026-08-14',
+    source: 'https://www.imdb.com/event/ev0000681/',
+    editions,
+  };
+}
+
+describe('veniceCeremonyNumber', () => {
+  it('第1回は1932年', () => {
+    expect(veniceCeremonyNumber(1932)).toBe(1);
+  });
+
+  it('1934〜1939年は年-1932', () => {
+    expect(veniceCeremonyNumber(1934)).toBe(2);
+    expect(veniceCeremonyNumber(1939)).toBe(7);
+  });
+
+  it('戦時中の1940〜1942年は公式回次に数えない', () => {
+    expect(veniceCeremonyNumber(1940)).toBeUndefined();
+    expect(veniceCeremonyNumber(1942)).toBeUndefined();
+  });
+
+  it('1946年は公式回次に数えない', () => {
+    expect(veniceCeremonyNumber(1946)).toBeUndefined();
+  });
+
+  it('1947〜1972年は年-1939', () => {
+    expect(veniceCeremonyNumber(1947)).toBe(8);
+    expect(veniceCeremonyNumber(1949)).toBe(10);
+    expect(veniceCeremonyNumber(1968)).toBe(29);
+    expect(veniceCeremonyNumber(1972)).toBe(33);
+  });
+
+  it('未開催・非公式の1973〜1978年はundefined', () => {
+    expect(veniceCeremonyNumber(1973)).toBeUndefined();
+    expect(veniceCeremonyNumber(1975)).toBeUndefined();
+    expect(veniceCeremonyNumber(1978)).toBeUndefined();
+  });
+
+  it('1979年は第36回', () => {
+    expect(veniceCeremonyNumber(1979)).toBe(36);
+  });
+
+  it('1980年以降は年-1943', () => {
+    expect(veniceCeremonyNumber(1980)).toBe(37);
+    expect(veniceCeremonyNumber(2025)).toBe(82);
+    expect(veniceCeremonyNumber(2026)).toBe(83);
+  });
+});
+
+describe('extractGoldenLionEditions', () => {
+  it('goldenLionが空の回は除外する', () => {
+    const data = collectedData([
+      {year: 1946, awardNames: ['ANICA Cup'], goldenLion: []},
+      edition(1951, [
+        nomination('tt0042876', 'Rashômon', true),
+        nomination('tt0043338', 'Ace in the Hole'),
+      ]),
+    ]);
+
+    const editions = extractGoldenLionEditions(data);
+
+    expect(editions.map(entry => entry.year)).toEqual([1951]);
+  });
+
+  it('Best Film以外のカテゴリ（Immersive VR等）を除外する', () => {
+    const data = collectedData([
+      {
+        year: 2018,
+        awardNames: ['Golden Lion'],
+        goldenLion: [
+          {
+            categories: [
+              {
+                category: 'Best Film',
+                total: null,
+                nominations: [
+                  nomination('tt6155172', 'Roma', true),
+                  nomination('tt5342766', 'The Favourite'),
+                ],
+              },
+              {
+                category: 'Immersive VR',
+                total: null,
+                nominations: [nomination('tt7918178', 'Spheres', true)],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const editions = extractGoldenLionEditions(data);
+
+    expect(editions[0].films.map(film => film.imdbId)).toEqual([
+      'tt6155172',
+      'tt5342766',
+    ]);
+  });
+
+  it('nullカテゴリとBest Filmカテゴリを統合する', () => {
+    const data = collectedData([
+      {
+        year: 1957,
+        awardNames: ['Golden Lion'],
+        goldenLion: [
+          {
+            categories: [
+              {
+                category: null,
+                total: null,
+                nominations: [
+                  nomination('tt0048956', 'Aparajito', true),
+                  nomination('tt0050126', 'Bitter Victory'),
+                ],
+              },
+              {
+                category: 'Best Film',
+                total: null,
+                nominations: [nomination('tt0050850', 'Porte des Lilas')],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const editions = extractGoldenLionEditions(data);
+
+    expect(editions[0].films).toHaveLength(3);
+  });
+
+  it('タイトルが空のノミネーション（Not awardedマーカー）を除外する', () => {
+    const data = collectedData([
+      edition(1953, [
+        {isWinner: true, notes: 'Not awarded.', titles: []},
+        nomination('tt0046250', 'Roman Holiday'),
+        nomination('tt0046478', 'Ugetsu monogatari'),
+      ]),
+    ]);
+
+    const editions = extractGoldenLionEditions(data);
+
+    expect(editions[0].films).toHaveLength(2);
+    expect(editions[0].films.every(film => !film.isWinner)).toBe(true);
+  });
+
+  it('同一imdbIdの重複を除去しisWinnerをORで残す', () => {
+    const data = collectedData([
+      edition(1960, [
+        {
+          isWinner: false,
+          notes: null,
+          titles: [
+            {
+              imdbId: 'tt0053628',
+              title: 'Baltiyskoe nebo',
+              originalTitle: 'Baltiyskoe nebo',
+            },
+            {
+              imdbId: 'tt0053628',
+              title: 'Baltiyskoe nebo',
+              originalTitle: 'Baltiyskoe nebo',
+            },
+          ],
+        },
+        nomination('tt0053946', 'Le passage du Rhin', true),
+        nomination('tt0053946', 'Le passage du Rhin'),
+      ]),
+    ]);
+
+    const editions = extractGoldenLionEditions(data);
+
+    expect(editions[0].films).toHaveLength(2);
+    const winner = editions[0].films.find(film => film.imdbId === 'tt0053946');
+    expect(winner?.isWinner).toBe(true);
+  });
+
+  it('2件未満しか残らない回（1979年のノイズ等）を除外する', () => {
+    const data = collectedData([
+      edition(1979, [nomination('tt0078978', 'Clair de femme')]),
+      edition(1980, [
+        nomination('tt0080749', 'Gloria', true),
+        nomination('tt0080388', 'Atlantic City', true),
+      ]),
+    ]);
+
+    const editions = extractGoldenLionEditions(data);
+
+    expect(editions.map(entry => entry.year)).toEqual([1980]);
+  });
+});
+
+const basicData = () =>
+  collectedData([
+    edition(1951, [
+      nomination('tt0042876', 'Rashômon', true),
+      nomination('tt0043338', 'Ace in the Hole'),
+    ]),
+    edition(2026, [
+      nomination('tt37967547', 'Ink'),
+      nomination('tt31434639', 'La Grazia'),
+    ]),
+  ]);
+
+describe('importVeniceGoldenLion', () => {
+  let environment: Environment;
+  let database: ReturnType<typeof getDatabase>;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('組織・カテゴリ・回次付きセレモニーを作成する', async () => {
+    await importVeniceGoldenLion({environment, data: basicData()});
+
+    const [organization] = await database
+      .select()
+      .from(awardOrganizations)
+      .where(eq(awardOrganizations.name, 'Venice Film Festival'));
+    expect(organization.country).toBe('Italy');
+    expect(organization.establishedYear).toBe(1932);
+
+    const [category] = await database
+      .select()
+      .from(awardCategories)
+      .where(eq(awardCategories.organizationUid, organization.uid));
+    expect(category.name).toBe('Golden Lion');
+
+    const ceremonies = await database
+      .select()
+      .from(awardCeremonies)
+      .where(eq(awardCeremonies.organizationUid, organization.uid));
+    const byYear = new Map(ceremonies.map(row => [row.year, row]));
+    expect(byYear.get(1951)?.ceremonyNumber).toBe(12);
+    expect(byYear.get(2026)?.ceremonyNumber).toBe(83);
+  });
+
+  it('TMDbキーなしでも映画・翻訳・ノミネーションを作成する', async () => {
+    await importVeniceGoldenLion({environment, data: basicData()});
+
+    const movieRows = await database.select().from(movies);
+    expect(movieRows).toHaveLength(4);
+
+    const [rashomon] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.imdbId, 'tt0042876'));
+    expect(rashomon.year).toBe(1951);
+
+    const titleRows = await database
+      .select()
+      .from(translations)
+      .where(
+        and(
+          eq(translations.resourceUid, rashomon.uid),
+          eq(translations.resourceType, 'movie_title'),
+        ),
+      );
+    expect(titleRows).toHaveLength(1);
+    expect(titleRows[0].languageCode).toBe('en');
+    expect(titleRows[0].content).toBe('Rashômon');
+
+    const nominationRows = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.movieUid, rashomon.uid));
+    expect(nominationRows).toHaveLength(1);
+    expect(nominationRows[0].isWinner).toBe(1);
+  });
+
+  it('再実行しても重複を作らない', async () => {
+    await importVeniceGoldenLion({environment, data: basicData()});
+    await importVeniceGoldenLion({environment, data: basicData()});
+
+    expect(await database.select().from(movies)).toHaveLength(4);
+    expect(await database.select().from(nominations)).toHaveLength(4);
+    expect(await database.select().from(translations)).toHaveLength(4);
+    expect(await database.select().from(awardCeremonies)).toHaveLength(2);
+  });
+
+  it('soft-deletedの映画はスキップし復活させない', async () => {
+    await database.insert(movies).values({
+      uid: 'deleted-rashomon',
+      imdbId: 'tt0042876',
+      year: 1950,
+      deletedAt: 1000,
+    });
+
+    const stats = await importVeniceGoldenLion({
+      environment,
+      data: basicData(),
+    });
+
+    expect(stats.skippedSoftDeleted).toBe(1);
+    const [row] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.imdbId, 'tt0042876'));
+    expect(row.deletedAt).toBe(1000);
+    const nominationRows = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.movieUid, 'deleted-rashomon'));
+    expect(nominationRows).toHaveLength(0);
+  });
+
+  it('既存の映画には新規作成せずノミネーションを付ける', async () => {
+    await database.insert(movies).values({
+      uid: 'existing-rashomon',
+      imdbId: 'tt0042876',
+      year: 1950,
+    });
+
+    const stats = await importVeniceGoldenLion({
+      environment,
+      data: basicData(),
+    });
+
+    expect(stats.moviesCreated).toBe(3);
+    expect(stats.moviesExisting).toBe(1);
+    const nominationRows = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.movieUid, 'existing-rashomon'));
+    expect(nominationRows).toHaveLength(1);
+    expect(nominationRows[0].isWinner).toBe(1);
+  });
+
+  it('既存ノミネーションのisWinnerを0から1へ更新する', async () => {
+    await importVeniceGoldenLion({
+      environment,
+      data: collectedData([
+        edition(2026, [
+          nomination('tt37967547', 'Ink'),
+          nomination('tt31434639', 'La Grazia'),
+        ]),
+      ]),
+    });
+
+    const stats = await importVeniceGoldenLion({
+      environment,
+      data: collectedData([
+        edition(2026, [
+          nomination('tt37967547', 'Ink', true),
+          nomination('tt31434639', 'La Grazia'),
+        ]),
+      ]),
+    });
+
+    expect(stats.winnersUpdated).toBe(1);
+    const [ink] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.imdbId, 'tt37967547'));
+    const nominationRows = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.movieUid, ink.uid));
+    expect(nominationRows[0].isWinner).toBe(1);
+  });
+
+  it('year指定でその回だけ処理する', async () => {
+    await importVeniceGoldenLion({
+      environment,
+      data: basicData(),
+      year: 2026,
+    });
+
+    expect(await database.select().from(awardCeremonies)).toHaveLength(1);
+    expect(await database.select().from(movies)).toHaveLength(2);
+  });
+
+  it('dryRunでは書き込まない', async () => {
+    await importVeniceGoldenLion({
+      environment,
+      data: basicData(),
+      dryRun: true,
+    });
+
+    expect(await database.select().from(awardOrganizations)).toHaveLength(0);
+    expect(await database.select().from(movies)).toHaveLength(0);
+  });
+
+  it('TMDbが使える場合は詳細・邦題・ポスターを保存する', async () => {
+    environment.TMDB_API_KEY = 'test-key';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/find/tt0042876')) {
+          return Response.json({
+            movie_results: [{id: 548, media_type: 'movie'}],
+            tv_results: [],
+          });
+        }
+
+        if (url.includes('/movie/548') && url.includes('language=ja')) {
+          return Response.json({
+            id: 548,
+            title: '羅生門',
+            original_title: '羅生門',
+            overview: 'あらすじ',
+          });
+        }
+
+        if (url.includes('/movie/548')) {
+          return Response.json({
+            id: 548,
+            title: 'Rashomon',
+            original_title: '羅生門',
+            original_language: 'ja',
+            release_date: '1950-08-25',
+            poster_path: '/rashomon.jpg',
+            imdb_id: 'tt0042876',
+            overview: 'A samurai is murdered.',
+          });
+        }
+
+        if (url.includes('/configuration')) {
+          return Response.json({
+            images: {
+              secure_base_url: 'https://image.tmdb.org/t/p/',
+              poster_sizes: ['w342', 'w500', 'original'],
+            },
+          });
+        }
+
+        return new Response('not found', {status: 404});
+      }),
+    );
+
+    await importVeniceGoldenLion({
+      environment,
+      data: collectedData([
+        edition(1951, [
+          nomination('tt0042876', 'Rashômon', true),
+          {
+            isWinner: false,
+            notes: null,
+            titles: [
+              {imdbId: 'tt0000001', title: 'Unknown', originalTitle: 'Unknown'},
+            ],
+          },
+        ]),
+      ]),
+      throttleMs: 0,
+    });
+
+    const [rashomon] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.imdbId, 'tt0042876'));
+    expect(rashomon.tmdbId).toBe(548);
+    expect(rashomon.year).toBe(1950);
+    expect(rashomon.originalLanguage).toBe('ja');
+
+    const titleRows = await database
+      .select()
+      .from(translations)
+      .where(
+        and(
+          eq(translations.resourceUid, rashomon.uid),
+          eq(translations.resourceType, 'movie_title'),
+        ),
+      );
+    const byLanguage = new Map(titleRows.map(row => [row.languageCode, row]));
+    expect(byLanguage.get('en')?.content).toBe('Rashomon');
+    expect(byLanguage.get('ja')?.content).toBe('羅生門');
+
+    const posterRows = await database
+      .select()
+      .from(posterUrls)
+      .where(eq(posterUrls.movieUid, rashomon.uid));
+    expect(posterRows[0].url).toBe(
+      'https://image.tmdb.org/t/p/w500/rashomon.jpg',
+    );
+
+    const referenceRows = await database
+      .select()
+      .from(referenceUrls)
+      .where(eq(referenceUrls.movieUid, rashomon.uid));
+    expect(referenceRows.map(row => row.sourceType).toSorted()).toEqual([
+      'imdb',
+      'other',
+    ]);
+
+    const [unknown] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.imdbId, 'tt0000001'));
+    expect(unknown.tmdbId).toBeNull();
+    expect(unknown.year).toBe(1951);
+  });
+
+  it('TMDbのIDが既存映画と衝突したら既存映画を再利用しimdbIdを補完する', async () => {
+    environment.TMDB_API_KEY = 'test-key';
+    await database.insert(movies).values({
+      uid: 'existing-by-tmdb',
+      tmdbId: 548,
+      year: 1950,
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/find/tt0042876')) {
+          return Response.json({
+            movie_results: [{id: 548, media_type: 'movie'}],
+            tv_results: [],
+          });
+        }
+
+        if (url.includes('/movie/548')) {
+          return Response.json({
+            id: 548,
+            title: 'Rashomon',
+            original_title: '羅生門',
+            release_date: '1950-08-25',
+          });
+        }
+
+        if (url.includes('/configuration')) {
+          return Response.json({
+            images: {secure_base_url: 'https://x/', poster_sizes: ['w500']},
+          });
+        }
+
+        return new Response('not found', {status: 404});
+      }),
+    );
+
+    await importVeniceGoldenLion({
+      environment,
+      data: collectedData([
+        edition(1951, [
+          nomination('tt0042876', 'Rashômon', true),
+          nomination('tt0043338', 'Ace in the Hole'),
+        ]),
+      ]),
+      throttleMs: 0,
+    });
+
+    const movieRows = await database.select().from(movies);
+    expect(movieRows).toHaveLength(2);
+    const [reused] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'existing-by-tmdb'));
+    expect(reused.imdbId).toBe('tt0042876');
+    const nominationRows = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.movieUid, 'existing-by-tmdb'));
+    expect(nominationRows).toHaveLength(1);
+  });
+});

--- a/apps/scrapers/src/venice-film-festival-cli.ts
+++ b/apps/scrapers/src/venice-film-festival-cli.ts
@@ -1,0 +1,127 @@
+/**
+ * ヴェネツィア国際映画祭(金獅子賞)取り込みのCLIエントリーポイント
+ */
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {Command, InvalidArgumentError} from 'commander';
+import {
+  assertDatabaseEnvironment,
+  buildEnvironment,
+  loadEnvironmentFiles,
+} from './common/environment';
+import {
+  importVeniceGoldenLion,
+  type VeniceCollectedData,
+} from './venice-film-festival';
+
+loadEnvironmentFiles();
+const environment = buildEnvironment(process.env);
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const defaultInputPath = path.resolve(
+  currentDirectory,
+  '../data/venice-golden-lion.json',
+);
+
+function parseYear(value: string): number {
+  const year = Number.parseInt(value, 10);
+
+  if (Number.isNaN(year) || year < 1932 || year > new Date().getFullYear()) {
+    throw new InvalidArgumentError(
+      '無効な年です。1932年以降の年を指定してください。',
+    );
+  }
+
+  return year;
+}
+
+function parseThrottle(value: string): number {
+  const ms = Number.parseInt(value, 10);
+
+  if (Number.isNaN(ms) || ms < 0) {
+    throw new InvalidArgumentError(
+      'throttleは0以上のミリ秒で指定してください。',
+    );
+  }
+
+  return ms;
+}
+
+const program = new Command();
+
+program
+  .name('venice-film-festival-cli')
+  .description(
+    [
+      'IMDbイベントページから収集済みのヴェネツィア国際映画祭データ',
+      '(data/venice-golden-lion.json)を読み、金獅子賞のノミネーション・',
+      '受賞情報をデータベースに保存します。',
+      '映画の詳細(ポスター・邦題)はTMDbのfind APIで補完します。',
+    ].join('\n'),
+  )
+  .option('--year <year>', '特定の年のみ処理 (例: --year 2025)', parseYear)
+  .option('--input <path>', '収集データJSONのパス', defaultInputPath)
+  .option('--dry-run', '実際の書き込みは行わず、処理内容のみ表示', false)
+  .option(
+    '--throttle <ms>',
+    'TMDbリクエスト間の待機ミリ秒 (デフォルト: 300)',
+    parseThrottle,
+    300,
+  )
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrapers:venice-film-festival
+  pnpm run scrapers:venice-film-festival --year 2025
+  pnpm run scrapers:venice-film-festival --dry-run
+`,
+  )
+  .action(
+    async (options: {
+      year?: number;
+      input: string;
+      dryRun: boolean;
+      throttle: number;
+    }) => {
+      console.log(
+        options.year
+          ? `ヴェネツィア映画祭の取り込みを開始します (対象年: ${options.year})`
+          : 'ヴェネツィア映画祭の取り込みを開始します',
+      );
+
+      assertDatabaseEnvironment(environment);
+
+      if (!environment.TMDB_API_KEY) {
+        console.warn(
+          '警告: TMDB_API_KEY が設定されていません。ポスター・邦題の取得がスキップされます。',
+        );
+      }
+
+      const data = JSON.parse(
+        readFileSync(options.input, 'utf8'),
+      ) as VeniceCollectedData;
+
+      const stats = await importVeniceGoldenLion({
+        environment,
+        data,
+        dryRun: options.dryRun,
+        year: options.year,
+        throttleMs: options.throttle,
+      });
+
+      if (stats.failed > 0) {
+        process.exitCode = 1;
+      }
+
+      console.log('ヴェネツィア映画祭の取り込みが完了しました');
+    },
+  );
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  console.error('取り込み処理中にエラーが発生しました:', error);
+  process.exitCode = 1;
+}

--- a/apps/scrapers/src/venice-film-festival.ts
+++ b/apps/scrapers/src/venice-film-festival.ts
@@ -1,0 +1,636 @@
+import {setTimeout as sleep} from 'node:timers/promises';
+import {and, eq, inArray, isNotNull} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {referenceUrls} from '@shine/database/schema/reference-urls';
+import {translations} from '@shine/database/schema/translations';
+import {
+  fetchTMDBConfiguration,
+  fetchTMDBMovieDetails,
+  findTMDBByImdbId,
+  type TMDBMovieData,
+} from './common/tmdb-utilities';
+
+const ORGANIZATION_NAME = 'Venice Film Festival';
+const CATEGORY_NAME = 'Golden Lion';
+const MINIMUM_FILMS_PER_EDITION = 2;
+
+function isCompetitionCategory(category: string | null): boolean {
+  return category === null || category === 'Best Film';
+}
+
+export type VeniceNominationTitle = {
+  imdbId: string;
+  title: string | null;
+  originalTitle: string | null;
+};
+
+export type VeniceNomination = {
+  isWinner: boolean;
+  notes: string | null;
+  titles: VeniceNominationTitle[];
+};
+
+export type VeniceEdition = {
+  year: number;
+  awardNames: string[];
+  goldenLion: Array<{
+    categories: Array<{
+      category: string | null;
+      total: number | null;
+      nominations: VeniceNomination[];
+    }>;
+  }>;
+};
+
+export type VeniceCollectedData = {
+  collectedAt: string;
+  source: string;
+  editions: VeniceEdition[];
+};
+
+export type GoldenLionFilm = {
+  imdbId: string;
+  title: string | null;
+  originalTitle: string | null;
+  isWinner: boolean;
+};
+
+export type GoldenLionEdition = {
+  year: number;
+  films: GoldenLionFilm[];
+};
+
+export type VeniceImportStats = {
+  editionsProcessed: number;
+  moviesCreated: number;
+  moviesExisting: number;
+  skippedSoftDeleted: number;
+  nominationsCreated: number;
+  winnersUpdated: number;
+  tmdbNotFound: number;
+  failed: number;
+};
+
+// 1940-1942(戦時開催)と1946年は公式回次に数えられない
+// (第8回=1947年、第36回=1979年、1973-1978年は未開催または非公式)
+export function veniceCeremonyNumber(year: number): number | undefined {
+  if (year === 1932) {
+    return 1;
+  }
+
+  if (year >= 1934 && year <= 1939) {
+    return year - 1932;
+  }
+
+  if (year >= 1947 && year <= 1972) {
+    return year - 1939;
+  }
+
+  if (year === 1979) {
+    return 36;
+  }
+
+  if (year >= 1980) {
+    return year - 1943;
+  }
+
+  return undefined;
+}
+
+export function extractGoldenLionEditions(
+  data: VeniceCollectedData,
+): GoldenLionEdition[] {
+  const editions: GoldenLionEdition[] = [];
+
+  for (const edition of data.editions) {
+    const filmsByImdbId = new Map<string, GoldenLionFilm>();
+
+    for (const award of edition.goldenLion) {
+      for (const category of award.categories) {
+        if (!isCompetitionCategory(category.category)) {
+          continue;
+        }
+
+        for (const nomination of category.nominations) {
+          for (const title of nomination.titles) {
+            const existing = filmsByImdbId.get(title.imdbId);
+            if (existing) {
+              existing.isWinner = existing.isWinner || nomination.isWinner;
+              continue;
+            }
+
+            filmsByImdbId.set(title.imdbId, {
+              imdbId: title.imdbId,
+              title: title.title,
+              originalTitle: title.originalTitle,
+              isWinner: nomination.isWinner,
+            });
+          }
+        }
+      }
+    }
+
+    const films = [...filmsByImdbId.values()];
+    if (films.length < MINIMUM_FILMS_PER_EDITION) {
+      continue;
+    }
+
+    editions.push({year: edition.year, films});
+  }
+
+  return editions;
+}
+
+type DatabaseClient = ReturnType<typeof getDatabase>;
+
+type ImportContext = {
+  database: DatabaseClient;
+  tmdbApiKey: string | undefined;
+  throttleMs: number;
+  stats: VeniceImportStats;
+};
+
+export async function importVeniceGoldenLion({
+  environment,
+  data,
+  dryRun = false,
+  year,
+  throttleMs = 300,
+}: {
+  environment: Environment;
+  data: VeniceCollectedData;
+  dryRun?: boolean;
+  year?: number;
+  throttleMs?: number;
+}): Promise<VeniceImportStats> {
+  const stats: VeniceImportStats = {
+    editionsProcessed: 0,
+    moviesCreated: 0,
+    moviesExisting: 0,
+    skippedSoftDeleted: 0,
+    nominationsCreated: 0,
+    winnersUpdated: 0,
+    tmdbNotFound: 0,
+    failed: 0,
+  };
+
+  const allEditions = extractGoldenLionEditions(data);
+  const editions =
+    year === undefined
+      ? allEditions
+      : allEditions.filter(edition => edition.year === year);
+
+  if (editions.length === 0) {
+    console.log('No editions to process.');
+    return stats;
+  }
+
+  if (dryRun) {
+    for (const edition of editions) {
+      const winners = edition.films.filter(film => film.isWinner);
+      console.log(
+        `[DRY RUN] ${edition.year} (ceremony #${veniceCeremonyNumber(edition.year) ?? '?'}): ${edition.films.length} films, winners: ${
+          winners.map(film => film.originalTitle ?? film.title).join(', ') ||
+          'none'
+        }`,
+      );
+      stats.editionsProcessed++;
+    }
+
+    return stats;
+  }
+
+  const database = getDatabase(environment);
+  const context: ImportContext = {
+    database,
+    tmdbApiKey: environment.TMDB_API_KEY,
+    throttleMs,
+    stats,
+  };
+
+  const organizationUid = await ensureOrganization(database);
+  const categoryUid = await ensureCategory(database, organizationUid);
+
+  for (const edition of editions) {
+    console.log(`\nProcessing Venice ${edition.year}...`);
+    const ceremonyUid = await ensureCeremony(
+      database,
+      organizationUid,
+      edition.year,
+    );
+    await processEdition(context, edition, ceremonyUid, categoryUid);
+    stats.editionsProcessed++;
+  }
+
+  console.log('\nImport summary:');
+  console.log(`  Editions processed: ${stats.editionsProcessed}`);
+  console.log(`  Movies created: ${stats.moviesCreated}`);
+  console.log(`  Movies existing: ${stats.moviesExisting}`);
+  console.log(`  Skipped (soft-deleted): ${stats.skippedSoftDeleted}`);
+  console.log(`  Nominations created: ${stats.nominationsCreated}`);
+  console.log(`  Winners updated: ${stats.winnersUpdated}`);
+  console.log(`  TMDb not found: ${stats.tmdbNotFound}`);
+  console.log(`  Failed: ${stats.failed}`);
+
+  return stats;
+}
+
+async function ensureOrganization(database: DatabaseClient): Promise<string> {
+  await database
+    .insert(awardOrganizations)
+    .values({
+      name: ORGANIZATION_NAME,
+      country: 'Italy',
+      establishedYear: 1932,
+    })
+    .onConflictDoNothing();
+
+  const [row] = await database
+    .select({uid: awardOrganizations.uid})
+    .from(awardOrganizations)
+    .where(eq(awardOrganizations.name, ORGANIZATION_NAME))
+    .limit(1);
+
+  if (!row) {
+    throw new Error('Failed to create Venice Film Festival organization');
+  }
+
+  return row.uid;
+}
+
+async function ensureCategory(
+  database: DatabaseClient,
+  organizationUid: string,
+): Promise<string> {
+  await database
+    .insert(awardCategories)
+    .values({
+      organizationUid,
+      name: CATEGORY_NAME,
+      shortName: CATEGORY_NAME,
+    })
+    .onConflictDoNothing();
+
+  const [row] = await database
+    .select({uid: awardCategories.uid})
+    .from(awardCategories)
+    .where(
+      and(
+        eq(awardCategories.organizationUid, organizationUid),
+        eq(awardCategories.name, CATEGORY_NAME),
+      ),
+    )
+    .limit(1);
+
+  if (!row) {
+    throw new Error('Failed to create Golden Lion category');
+  }
+
+  return row.uid;
+}
+
+async function ensureCeremony(
+  database: DatabaseClient,
+  organizationUid: string,
+  year: number,
+): Promise<string> {
+  const [row] = await database
+    .insert(awardCeremonies)
+    .values({
+      organizationUid,
+      year,
+      ceremonyNumber: veniceCeremonyNumber(year),
+    })
+    .onConflictDoUpdate({
+      target: [awardCeremonies.organizationUid, awardCeremonies.year],
+      set: {
+        ceremonyNumber: veniceCeremonyNumber(year),
+      },
+    })
+    .returning();
+
+  return row.uid;
+}
+
+async function processEdition(
+  context: ImportContext,
+  edition: GoldenLionEdition,
+  ceremonyUid: string,
+  categoryUid: string,
+): Promise<void> {
+  const {database, stats} = context;
+  const imdbIds = edition.films.map(film => film.imdbId);
+
+  const existingMovies = await database
+    .select({
+      uid: movies.uid,
+      imdbId: movies.imdbId,
+      deletedAt: movies.deletedAt,
+    })
+    .from(movies)
+    .where(and(isNotNull(movies.imdbId), inArray(movies.imdbId, imdbIds)));
+
+  const activeByImdbId = new Map<string, string>();
+  const softDeletedImdbIds = new Set<string>();
+  for (const movie of existingMovies) {
+    if (!movie.imdbId) {
+      continue;
+    }
+
+    if (movie.deletedAt === null) {
+      activeByImdbId.set(movie.imdbId, movie.uid);
+    } else {
+      softDeletedImdbIds.add(movie.imdbId);
+    }
+  }
+
+  const existingNominations = await database
+    .select({movieUid: nominations.movieUid, isWinner: nominations.isWinner})
+    .from(nominations)
+    .where(
+      and(
+        eq(nominations.ceremonyUid, ceremonyUid),
+        eq(nominations.categoryUid, categoryUid),
+      ),
+    );
+  const nominationsByMovieUid = new Map(
+    existingNominations.map(row => [row.movieUid, row.isWinner]),
+  );
+
+  for (const film of edition.films) {
+    if (softDeletedImdbIds.has(film.imdbId)) {
+      console.log(`  Skipping soft-deleted movie: ${film.imdbId}`);
+      stats.skippedSoftDeleted++;
+      continue;
+    }
+
+    try {
+      let movieUid = activeByImdbId.get(film.imdbId);
+      if (movieUid) {
+        stats.moviesExisting++;
+      } else {
+        movieUid = await createMovie(context, film, edition.year);
+        if (!movieUid) {
+          continue;
+        }
+      }
+
+      await ensureNomination(
+        context,
+        movieUid,
+        ceremonyUid,
+        categoryUid,
+        film,
+        nominationsByMovieUid,
+      );
+    } catch (error) {
+      console.error(`  Failed to process ${film.imdbId}:`, error);
+      stats.failed++;
+    }
+  }
+}
+
+async function createMovie(
+  context: ImportContext,
+  film: GoldenLionFilm,
+  editionYear: number,
+): Promise<string | undefined> {
+  const {database, tmdbApiKey, stats} = context;
+
+  let details: TMDBMovieData | undefined;
+  let detailsJa: TMDBMovieData | undefined;
+  if (tmdbApiKey) {
+    const found = await findTMDBByImdbId(film.imdbId, tmdbApiKey);
+    if (found?.mediaType === 'movie') {
+      details = await fetchTMDBMovieDetails(found.tmdbId, tmdbApiKey, 'en-US');
+      detailsJa = await fetchTMDBMovieDetails(found.tmdbId, tmdbApiKey, 'ja');
+    }
+
+    if (!details) {
+      stats.tmdbNotFound++;
+    }
+
+    if (context.throttleMs > 0) {
+      await sleep(context.throttleMs);
+    }
+  }
+
+  if (details) {
+    const reused = await reuseMovieByTmdbId(context, film, details.id);
+    if (reused !== undefined) {
+      return reused === 'soft-deleted' ? undefined : reused;
+    }
+  }
+
+  const englishTitle = details?.title || film.originalTitle || film.title;
+  if (!englishTitle) {
+    console.log(`  Skipping ${film.imdbId}: no usable title`);
+    stats.failed++;
+    return undefined;
+  }
+
+  const releaseYear = details?.release_date
+    ? Number.parseInt(details.release_date.slice(0, 4), 10)
+    : Number.NaN;
+
+  const [movie] = await database
+    .insert(movies)
+    .values({
+      imdbId: film.imdbId,
+      tmdbId: details?.id,
+      originalLanguage: details?.original_language ?? 'en',
+      year: Number.isFinite(releaseYear) ? releaseYear : editionYear,
+      releaseDate: details?.release_date || undefined,
+    })
+    .returning();
+
+  const translationValues: Array<typeof translations.$inferInsert> = [
+    {
+      resourceType: 'movie_title',
+      resourceUid: movie.uid,
+      languageCode: 'en',
+      content: englishTitle,
+      isDefault: 1,
+    },
+  ];
+
+  const japaneseTitle = detailsJa?.title;
+  if (japaneseTitle && japaneseTitle !== englishTitle) {
+    translationValues.push({
+      resourceType: 'movie_title',
+      resourceUid: movie.uid,
+      languageCode: 'ja',
+      content: japaneseTitle,
+      isDefault: 0,
+    });
+  }
+
+  await database
+    .insert(translations)
+    .values(translationValues)
+    .onConflictDoNothing();
+
+  await insertReferenceUrls(database, movie.uid, film.imdbId, details?.id);
+
+  if (details?.poster_path && context.tmdbApiKey) {
+    await insertPoster(
+      database,
+      movie.uid,
+      details.poster_path,
+      context.tmdbApiKey,
+    );
+  }
+
+  console.log(
+    `  Created movie: ${englishTitle} (${film.imdbId}${details ? `, TMDb ${details.id}` : ''})`,
+  );
+  stats.moviesCreated++;
+  return movie.uid;
+}
+
+async function reuseMovieByTmdbId(
+  context: ImportContext,
+  film: GoldenLionFilm,
+  tmdbId: number,
+): Promise<string | 'soft-deleted' | undefined> {
+  const {database, stats} = context;
+  const [existing] = await database
+    .select({
+      uid: movies.uid,
+      imdbId: movies.imdbId,
+      deletedAt: movies.deletedAt,
+    })
+    .from(movies)
+    .where(eq(movies.tmdbId, tmdbId))
+    .limit(1);
+
+  if (!existing) {
+    return undefined;
+  }
+
+  if (existing.deletedAt !== null) {
+    console.log(
+      `  Skipping soft-deleted movie (TMDb ${tmdbId}): ${film.imdbId}`,
+    );
+    stats.skippedSoftDeleted++;
+    return 'soft-deleted';
+  }
+
+  if (!existing.imdbId) {
+    await database
+      .update(movies)
+      .set({imdbId: film.imdbId})
+      .where(eq(movies.uid, existing.uid));
+    console.log(`  Set IMDb ID on existing movie (TMDb ${tmdbId})`);
+  }
+
+  stats.moviesExisting++;
+  return existing.uid;
+}
+
+async function ensureNomination(
+  context: ImportContext,
+  movieUid: string,
+  ceremonyUid: string,
+  categoryUid: string,
+  film: GoldenLionFilm,
+  nominationsByMovieUid: Map<string, number>,
+): Promise<void> {
+  const {database, stats} = context;
+  const existingIsWinner = nominationsByMovieUid.get(movieUid);
+
+  if (existingIsWinner === undefined) {
+    await database
+      .insert(nominations)
+      .values({
+        movieUid,
+        ceremonyUid,
+        categoryUid,
+        isWinner: film.isWinner ? 1 : 0,
+      })
+      .onConflictDoNothing();
+    nominationsByMovieUid.set(movieUid, film.isWinner ? 1 : 0);
+    stats.nominationsCreated++;
+    return;
+  }
+
+  if (film.isWinner && existingIsWinner === 0) {
+    await database
+      .update(nominations)
+      .set({isWinner: 1})
+      .where(
+        and(
+          eq(nominations.movieUid, movieUid),
+          eq(nominations.ceremonyUid, ceremonyUid),
+          eq(nominations.categoryUid, categoryUid),
+        ),
+      );
+    nominationsByMovieUid.set(movieUid, 1);
+    stats.winnersUpdated++;
+  }
+}
+
+async function insertReferenceUrls(
+  database: DatabaseClient,
+  movieUid: string,
+  imdbId: string,
+  tmdbId: number | undefined,
+): Promise<void> {
+  const values: Array<typeof referenceUrls.$inferInsert> = [
+    {
+      movieUid,
+      url: `https://www.imdb.com/title/${imdbId}/`,
+      sourceType: 'imdb',
+      languageCode: 'en',
+      isPrimary: 1,
+    },
+  ];
+
+  if (tmdbId !== undefined) {
+    values.push({
+      movieUid,
+      url: `https://www.themoviedb.org/movie/${tmdbId}`,
+      sourceType: 'other',
+      languageCode: 'en',
+      isPrimary: 0,
+      description: 'TMDb entry',
+    });
+  }
+
+  await database.insert(referenceUrls).values(values).onConflictDoNothing();
+}
+
+async function insertPoster(
+  database: DatabaseClient,
+  movieUid: string,
+  posterPath: string,
+  tmdbApiKey: string,
+): Promise<void> {
+  let configuration;
+  try {
+    configuration = await fetchTMDBConfiguration(tmdbApiKey);
+  } catch (error) {
+    console.error('  Failed to fetch TMDb configuration:', error);
+    return;
+  }
+
+  const size = configuration.images.poster_sizes.includes('w500')
+    ? 'w500'
+    : 'original';
+
+  await database
+    .insert(posterUrls)
+    .values({
+      movieUid,
+      url: `${configuration.images.secure_base_url}${size}${posterPath}`,
+      sourceType: 'tmdb',
+      isPrimary: 1,
+    })
+    .onConflictDoNothing();
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "scrapers:japan-academy-awards": "pnpm --filter @shine/scrapers run japan-academy-awards",
     "scrapers:japanese-translations": "pnpm --filter @shine/scrapers run japanese-translations",
     "scrapers:cannes-film-festival": "pnpm --filter @shine/scrapers run cannes-film-festival",
+    "scrapers:venice-film-festival": "pnpm --filter @shine/scrapers run venice-film-festival",
     "scrapers:movie-import": "pnpm --filter @shine/scrapers run movie-import",
     "scrapers:import-imdb-list": "pnpm --filter @shine/scrapers run import-imdb-list",
     "scrapers:availability-check": "pnpm --filter @shine/scrapers run availability-check",


### PR DESCRIPTION
世界三大映画祭のうち未収録だったヴェネツィア国際映画祭を追加する。

- IMDbイベントページ（ev0000681）から収集した全85回分のGolden Lionデータを `apps/scrapers/data/venice-golden-lion.json` としてコミット（1,442ノミネーション・1,437作品・1949〜2026）。IMDbは非ブラウザクライアントを遮断するため実ブラウザ経由で収集した
- 取り込みCLI `scrapers:venice-film-festival` を追加。imdbIdで既存映画と照合し（soft-deleted含む重複チェック）、TMDb find APIでポスター・邦題を補完、Golden Lionカテゴリでceremony/nominationを作成する。再実行時は受賞フラグの0→1昇格のみ行うので、2026年の受賞発表後にそのまま再実行できる
- 公式回次は戦時開催（1940-42）と1946年を数えない。`veniceCeremonyNumber()` はWikipediaの回次表で検証済み（1949=第10回、2025=第82回）
- 賞ページ `/awards/venice-golden-lion` と年別ページを追加（awardPageDefinitionsへの定義追加のみ。sitemap・フロントはAPI駆動なので変更不要）