### PR TITLE
ポスター画像の配信を軽くする

### DIFF
--- a/apps/front/app/components/editorial/film-card.test.tsx
+++ b/apps/front/app/components/editorial/film-card.test.tsx
@@ -24,6 +24,16 @@ describe('FilmCard', () => {
     expect(screen.getByText('PARASITE')).toBeInTheDocument();
   });
 
+  it('既定ではポスターを遅延読み込みする', () => {
+    render(<FilmCard movie={movie} variant="hero" locale="en" />);
+    expect(screen.getByAltText(/PARASITE/)).toHaveAttribute('loading', 'lazy');
+  });
+
+  it('priority を渡すとポスターを即時読み込みする', () => {
+    render(<FilmCard movie={movie} variant="hero" locale="en" priority />);
+    expect(screen.getByAltText(/PARASITE/)).toHaveAttribute('loading', 'eager');
+  });
+
   it('hero variant で視聴可否バッジを描画する', () => {
     render(
       <FilmCard

--- a/apps/front/app/components/editorial/film-card.tsx
+++ b/apps/front/app/components/editorial/film-card.tsx
@@ -33,12 +33,14 @@ export function FilmCard({
   locale = 'en',
   label,
   index,
+  priority = false,
 }: {
   movie: FilmCardMovie;
   variant: 'hero' | 'compact';
   locale?: string;
   label?: string;
   index?: string;
+  priority?: boolean;
 }) {
   const title = pickTitle(movie, locale);
   const posterUrl =
@@ -69,6 +71,7 @@ export function FilmCard({
             posterUrl={posterUrl}
             alt={`${title} poster`}
             className="w-16 shrink-0"
+            priority={priority}
           />
           <div className="min-w-0">
             <BigYear year={movie.year} className="text-4xl" />
@@ -98,6 +101,7 @@ export function FilmCard({
           posterUrl={posterUrl}
           alt={`${title} poster`}
           className="w-full"
+          priority={priority}
         />
         <div className="mt-3 flex items-end justify-between gap-2">
           <div className="min-w-0">

--- a/apps/front/app/components/editorial/film-card.tsx
+++ b/apps/front/app/components/editorial/film-card.tsx
@@ -72,6 +72,7 @@ export function FilmCard({
             alt={`${title} poster`}
             className="w-16 shrink-0"
             priority={priority}
+            displaySize="w185"
           />
           <div className="min-w-0">
             <BigYear year={movie.year} className="text-4xl" />

--- a/apps/front/app/components/editorial/poster-frame.test.tsx
+++ b/apps/front/app/components/editorial/poster-frame.test.tsx
@@ -45,6 +45,33 @@ describe('PosterFrame', () => {
     );
   });
 
+  it('既定では表示幅に合わせてw500まで落とす', () => {
+    render(
+      <PosterFrame
+        posterUrl="https://image.tmdb.org/t/p/original/p.jpg"
+        alt="Parasite poster"
+      />,
+    );
+    expect(screen.getByAltText('Parasite poster')).toHaveAttribute(
+      'src',
+      'https://image.tmdb.org/t/p/w500/p.jpg',
+    );
+  });
+
+  it('displaySize でサムネイル向けサイズを指定できる', () => {
+    render(
+      <PosterFrame
+        posterUrl="https://image.tmdb.org/t/p/original/p.jpg"
+        alt="Parasite poster"
+        displaySize="w185"
+      />,
+    );
+    expect(screen.getByAltText('Parasite poster')).toHaveAttribute(
+      'src',
+      'https://image.tmdb.org/t/p/w185/p.jpg',
+    );
+  });
+
   it('priority を渡すと取得優先度を上げる', () => {
     render(
       <PosterFrame

--- a/apps/front/app/components/editorial/poster-frame.test.tsx
+++ b/apps/front/app/components/editorial/poster-frame.test.tsx
@@ -14,4 +14,48 @@ describe('PosterFrame', () => {
     render(<PosterFrame alt="No poster" placeholderLabel="ポスターなし" />);
     expect(screen.getByText('ポスターなし')).toBeInTheDocument();
   });
+
+  it('既定では遅延読み込みする', () => {
+    render(<PosterFrame posterUrl="https://x/p.jpg" alt="Parasite poster" />);
+    expect(screen.getByAltText('Parasite poster')).toHaveAttribute(
+      'loading',
+      'lazy',
+    );
+  });
+
+  it('既定ではデコードを非同期にする', () => {
+    render(<PosterFrame posterUrl="https://x/p.jpg" alt="Parasite poster" />);
+    expect(screen.getByAltText('Parasite poster')).toHaveAttribute(
+      'decoding',
+      'async',
+    );
+  });
+
+  it('priority を渡すと即時読み込みする', () => {
+    render(
+      <PosterFrame
+        posterUrl="https://x/p.jpg"
+        alt="Parasite poster"
+        priority
+      />,
+    );
+    expect(screen.getByAltText('Parasite poster')).toHaveAttribute(
+      'loading',
+      'eager',
+    );
+  });
+
+  it('priority を渡すと取得優先度を上げる', () => {
+    render(
+      <PosterFrame
+        posterUrl="https://x/p.jpg"
+        alt="Parasite poster"
+        priority
+      />,
+    );
+    expect(screen.getByAltText('Parasite poster')).toHaveAttribute(
+      'fetchpriority',
+      'high',
+    );
+  });
 });

--- a/apps/front/app/components/editorial/poster-frame.tsx
+++ b/apps/front/app/components/editorial/poster-frame.tsx
@@ -3,6 +3,7 @@ type PosterFrameProperties = {
   alt: string;
   placeholderLabel?: string;
   className?: string;
+  priority?: boolean;
 };
 
 export function PosterFrame({
@@ -10,6 +11,7 @@ export function PosterFrame({
   alt,
   placeholderLabel = 'No Poster',
   className = '',
+  priority = false,
 }: PosterFrameProperties) {
   return (
     <div className={`relative ${className}`}>
@@ -25,6 +27,9 @@ export function PosterFrame({
           <img
             src={posterUrl}
             alt={alt}
+            loading={priority ? 'eager' : 'lazy'}
+            decoding={priority ? 'auto' : 'async'}
+            fetchPriority={priority ? 'high' : 'auto'}
             className="h-full w-full object-cover"
           />
         ) : (

--- a/apps/front/app/components/editorial/poster-frame.tsx
+++ b/apps/front/app/components/editorial/poster-frame.tsx
@@ -1,9 +1,12 @@
+import {posterUrlForDisplay, type PosterDisplaySize} from '@/lib/poster-size';
+
 type PosterFrameProperties = {
   posterUrl?: string;
   alt: string;
   placeholderLabel?: string;
   className?: string;
   priority?: boolean;
+  displaySize?: PosterDisplaySize;
 };
 
 export function PosterFrame({
@@ -12,7 +15,10 @@ export function PosterFrame({
   placeholderLabel = 'No Poster',
   className = '',
   priority = false,
+  displaySize = 'w500',
 }: PosterFrameProperties) {
+  const source = posterUrlForDisplay(posterUrl, displaySize);
+
   return (
     <div className={`relative ${className}`}>
       <div
@@ -23,9 +29,9 @@ export function PosterFrame({
       <div
         className="poster-glow-target relative aspect-2/3 overflow-hidden border-2 border-ink"
         style={{background: 'var(--poster-bg)'}}>
-        {posterUrl ? (
+        {source ? (
           <img
-            src={posterUrl}
+            src={source}
             alt={alt}
             loading={priority ? 'eager' : 'lazy'}
             decoding={priority ? 'auto' : 'async'}

--- a/apps/front/app/components/editorial/search-row.tsx
+++ b/apps/front/app/components/editorial/search-row.tsx
@@ -37,6 +37,7 @@ export function SearchRow({
         posterUrl={movie.posterUrl}
         alt={`${title} poster`}
         className="w-9 shrink-0"
+        displaySize="w185"
       />
       <span className="flex-1 font-display font-extrabold text-sm leading-none">
         {title}

--- a/apps/front/app/lib/poster-size.test.ts
+++ b/apps/front/app/lib/poster-size.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest';
+import {posterUrlForDisplay} from './poster-size';
+
+describe('posterUrlForDisplay', () => {
+  it('原寸のTMDb URLを表示サイズに落とす', () => {
+    expect(
+      posterUrlForDisplay(
+        'https://image.tmdb.org/t/p/original/abc.jpg',
+        'w500',
+      ),
+    ).toBe('https://image.tmdb.org/t/p/w500/abc.jpg');
+  });
+
+  it('表示サイズより大きいものを落とす', () => {
+    expect(
+      posterUrlForDisplay('https://image.tmdb.org/t/p/w780/abc.jpg', 'w342'),
+    ).toBe('https://image.tmdb.org/t/p/w342/abc.jpg');
+  });
+
+  it('表示サイズより小さいものは拡大しない', () => {
+    expect(
+      posterUrlForDisplay('https://image.tmdb.org/t/p/w185/abc.jpg', 'w500'),
+    ).toBe('https://image.tmdb.org/t/p/w185/abc.jpg');
+  });
+
+  it('同じサイズはそのまま返す', () => {
+    expect(
+      posterUrlForDisplay('https://image.tmdb.org/t/p/w500/abc.jpg', 'w500'),
+    ).toBe('https://image.tmdb.org/t/p/w500/abc.jpg');
+  });
+
+  it('TMDb以外のURLは書き換えない', () => {
+    expect(
+      posterUrlForDisplay('https://example.com/t/p/original/abc.jpg', 'w500'),
+    ).toBe('https://example.com/t/p/original/abc.jpg');
+  });
+
+  it('undefinedはそのまま返す', () => {
+    expect(posterUrlForDisplay(undefined, 'w500')).toBeUndefined();
+  });
+
+  it('サイズ表記が想定外でも壊さない', () => {
+    expect(
+      posterUrlForDisplay('https://image.tmdb.org/t/p/h632/abc.jpg', 'w500'),
+    ).toBe('https://image.tmdb.org/t/p/h632/abc.jpg');
+  });
+});

--- a/apps/front/app/lib/poster-size.ts
+++ b/apps/front/app/lib/poster-size.ts
@@ -1,0 +1,35 @@
+const TMDB_POSTER_PATTERN =
+  /^(https:\/\/image\.tmdb\.org\/t\/p\/)(original|w(\d+))(\/)/;
+
+export type PosterDisplaySize = 'w185' | 'w342' | 'w500';
+
+const DISPLAY_WIDTHS: Record<PosterDisplaySize, number> = {
+  w185: 185,
+  w342: 342,
+  w500: 500,
+};
+
+/**
+ * TMDbのポスターURLを表示幅相当まで落とす。原寸は1枚800KB超あり、
+ * サムネイル表示には過大なため。元より大きいサイズへの引き上げはしない。
+ */
+export function posterUrlForDisplay(
+  url: string | undefined,
+  size: PosterDisplaySize,
+): string | undefined {
+  if (!url) {
+    return url;
+  }
+
+  const match = TMDB_POSTER_PATTERN.exec(url);
+  if (!match) {
+    return url;
+  }
+
+  const [, prefix, current, currentWidth, suffix] = match;
+  if (current !== 'original' && Number(currentWidth) <= DISPLAY_WIDTHS[size]) {
+    return url;
+  }
+
+  return url.replace(TMDB_POSTER_PATTERN, `${prefix}${size}${suffix}`);
+}

--- a/apps/front/app/routes/awards.$slug.tsx
+++ b/apps/front/app/routes/awards.$slug.tsx
@@ -124,6 +124,7 @@ export function MovieRow({movie}: {movie: AwardMovieEntryData}) {
           posterUrl={movie.posterUrl}
           alt={`${title} poster`}
           className="w-16 shrink-0"
+          displaySize="w185"
         />
         <span className="flex-1 font-display font-extrabold text-base md:text-lg leading-tight">
           {title}
@@ -155,6 +156,7 @@ function ListRow({movie}: {movie: AwardMovieEntryData}) {
         posterUrl={movie.posterUrl}
         alt={`${title} poster`}
         className="w-9 shrink-0"
+        displaySize="w185"
       />
       <span className="flex-1 font-display font-extrabold text-sm leading-none">
         {title}

--- a/apps/front/app/routes/home.tsx
+++ b/apps/front/app/routes/home.tsx
@@ -648,6 +648,7 @@ function Movies({
                   locale={locale}
                   label={periodLabels[period]}
                   index={`NO.00${index + 1}`}
+                  priority
                 />
               ) : (
                 <p className="text-sm text-ink/50 font-mono">{noMovieLabel}</p>

--- a/apps/front/app/routes/movies.$id.tsx
+++ b/apps/front/app/routes/movies.$id.tsx
@@ -704,6 +704,7 @@ export default function MovieDetail({
             posterUrl={movieDetail.posterUrl}
             alt={`${title} poster`}
             className="w-28 md:w-36 shrink-0"
+            priority
           />
           <div className="flex flex-col justify-end gap-2">
             <BigYear year={movieDetail.year} className="text-6xl md:text-7xl" />

--- a/apps/front/app/routes/movies.$id.tsx
+++ b/apps/front/app/routes/movies.$id.tsx
@@ -705,6 +705,7 @@ export default function MovieDetail({
             alt={`${title} poster`}
             className="w-28 md:w-36 shrink-0"
             priority
+            displaySize="w342"
           />
           <div className="flex flex-col justify-end gap-2">
             <BigYear year={movieDetail.year} className="text-6xl md:text-7xl" />
@@ -756,6 +757,7 @@ export default function MovieDetail({
                     posterUrl={relatedMovie.posterUrl}
                     alt={`${relatedMovie.title} poster`}
                     className="w-full"
+                    displaySize="w342"
                   />
                   <span className="block font-display font-bold text-xs leading-tight mt-1.5">
                     {relatedMovie.title}


### PR DESCRIPTION
保存されているポスターURLの88%（65,952件中58,189件）がTMDbの原寸で、1枚あたり873KBある。これを144px幅のヒーローや64px幅のサムネイルにもそのまま使っていた。加えて全ポスターが遅延読み込みなしだった。

- PosterFrameに遅延読み込みと非同期デコードを既定で入れ、ファーストビューに出るホームの選出3枚と映画詳細のヒーローだけ即時読み込み＋取得優先度highにする
- 表示幅に応じてTMDbのURLをw185/w342/w500へ落とす。元より大きいサイズへの引き上げはしない

実測（本番デプロイ後）:

| ページ | 変更前 | 変更後 |
|---|---|---|
| 映画詳細 | 3,048KB（ヒーロー単体で873KB） | 286KB |
| 賞ページ（金熊賞・94枚） | 9,027KB | 1,558KB |

賞ページは加えて、表示領域に入るまで読み込まなくなった。