### PR TITLE
OG画像生成で原寸ポスターを取得しないようにする

### DIFF
--- a/apps/front/app/lib/meta.test.ts
+++ b/apps/front/app/lib/meta.test.ts
@@ -163,10 +163,10 @@ describe('upgradePosterForSharing', () => {
     ).toBe('https://image.tmdb.org/t/p/w780/poster.jpg');
   });
 
-  it('originalサイズはそのまま返す', () => {
+  it('originalサイズもw780へ落とす', () => {
     expect(
       upgradePosterForSharing('https://image.tmdb.org/t/p/original/poster.jpg'),
-    ).toBe('https://image.tmdb.org/t/p/original/poster.jpg');
+    ).toBe('https://image.tmdb.org/t/p/w780/poster.jpg');
   });
 
   it('TMDb以外のURLはそのまま返す', () => {

--- a/apps/front/app/lib/meta.ts
+++ b/apps/front/app/lib/meta.ts
@@ -10,7 +10,7 @@ const OPEN_GRAPH_LOCALES: Record<Locale, string> = {
 };
 
 const TMDB_SIZED_POSTER_PATTERN =
-  /^(https:\/\/image\.tmdb\.org\/t\/p\/)w\d+(\/)/;
+  /^(https:\/\/image\.tmdb\.org\/t\/p\/)(?:original|w\d+)(\/)/;
 
 export function upgradePosterForSharing(url?: string): string | undefined {
   return url?.replace(TMDB_SIZED_POSTER_PATTERN, '$1w780$2');


### PR DESCRIPTION
OGカードのポスターは360x540で描画されるのに、`upgradePosterForSharing` が `w\d+` しか対象にしておらず、原寸（1枚873KB）のURLはそのまま渡していた。保存されているポスターURLの88%が原寸なので、ほとんどのOG画像生成でWorkerが873KBを取得してdata URIに変換していたことになる。

originalも書き換え対象に含めて、w780（223KB）にする。360x540の描画には十分な解像度。

生成時間は計測上ノイズの範囲（変更前1.2〜1.9秒 → 変更後1.0〜1.3秒）だが、Workerが取得するバイト数は1回あたり873KB→223KBになる。