### PR TITLE
賞ページの一覧を軽くする

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -323,7 +323,7 @@ paths:
         - name: page
           in: query
           required: false
-          description: Page number for list-grouped awards (100 per page). Ignored for year-grouped awards
+          description: Page number for list-grouped awards (100 per page). Out-of-range pages return 404. Ignored for year-grouped awards
           schema:
             type: integer
             minimum: 1

--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -306,7 +306,10 @@ paths:
   /awards/{slug}:
     get:
       summary: Get an award page
-      description: Returns the movies of an award or editorial list grouped by ceremony year
+      description: |
+        Returns the movies of an award or editorial list grouped by ceremony year.
+        Year-grouped awards return winners only (with `filmCount` per year); use
+        `/awards/{slug}/{year}` for the full lineup. List awards are paginated.
       operationId: getAwardBySlug
       tags:
         - Awards
@@ -317,6 +320,14 @@ paths:
           required: true
           schema:
             type: string
+        - name: page
+          in: query
+          required: false
+          description: Page number for list-grouped awards (100 per page). Ignored for year-grouped awards
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
       responses:
         '200':
           description: Successfully retrieved the award page
@@ -1865,13 +1876,34 @@ components:
           type: integer
         ceremonyNumber:
           type: integer
+        filmCount:
+          type: integer
+          description: Total films of that ceremony. `movies` holds winners only for year-grouped awards
         movies:
           type: array
           items:
             $ref: '#/components/schemas/AwardMovieEntry'
       required:
         - year
+        - filmCount
         - movies
+
+    AwardPagination:
+      type: object
+      properties:
+        page:
+          type: integer
+        perPage:
+          type: integer
+        totalCount:
+          type: integer
+        totalPages:
+          type: integer
+      required:
+        - page
+        - perPage
+        - totalCount
+        - totalPages
 
     AwardSummary:
       type: object
@@ -1921,6 +1953,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AwardYearGroup'
+        pagination:
+          allOf:
+            - $ref: '#/components/schemas/AwardPagination'
+          description: Present only when grouping is `list`
       required:
         - slug
         - name

--- a/apps/api/src/routes/awards.ts
+++ b/apps/api/src/routes/awards.ts
@@ -14,7 +14,7 @@ const AWARDS_CACHE_TTL = 604_800;
 
 awardsRoutes.get('/', async c => {
   const cache = new EdgeCache(undefined, c.env.CACHE_KV);
-  const cacheKey = 'awards:list:v1';
+  const cacheKey = 'awards:list:v2';
   const cached = await cache.get(cacheKey);
   const result = (cached?.data as {awards: unknown[]} | undefined) ?? {
     awards: await new AwardsService(c.env).listAwards(),
@@ -35,10 +35,14 @@ awardsRoutes.get('/', async c => {
 awardsRoutes.get('/:slug', async c => {
   const cache = new EdgeCache(undefined, c.env.CACHE_KV);
   const slug = c.req.param('slug');
-  const cacheKey = `awards:${slug}:v1`;
+  const pageParameter = Number.parseInt(c.req.query('page') ?? '1', 10);
+  const page =
+    Number.isInteger(pageParameter) && pageParameter > 0 ? pageParameter : 1;
+  const cacheKey = `awards:${slug}:p${page}:v2`;
   const cached = await cache.get(cacheKey);
   const award =
-    cached?.data ?? (await new AwardsService(c.env).getAwardBySlug(slug));
+    cached?.data ??
+    (await new AwardsService(c.env).getAwardBySlug(slug, {page}));
 
   if (!award) {
     return c.json({error: 'Award not found'}, 404);

--- a/apps/api/src/routes/awards.ts
+++ b/apps/api/src/routes/awards.ts
@@ -1,6 +1,8 @@
 import type {Environment} from '@shine/database';
 import {Hono} from 'hono';
+import type {AwardDetail} from '@shine/types';
 import {AwardsService} from '../services';
+import {paginateAwardDetail} from '../services/awards-service';
 import {
   checkETag,
   createCachedResponse,
@@ -38,18 +40,26 @@ awardsRoutes.get('/:slug', async c => {
   const pageParameter = Number.parseInt(c.req.query('page') ?? '1', 10);
   const page =
     Number.isInteger(pageParameter) && pageParameter > 0 ? pageParameter : 1;
-  const cacheKey = `awards:${slug}:p${page}:v2`;
-  const cached = await cache.get(cacheKey);
-  const award =
-    cached?.data ??
-    (await new AwardsService(c.env).getAwardBySlug(slug, {page}));
 
-  if (!award) {
+  // ページはキャッシュキーに含めない。利用者入力でキー空間が広がるのを避けるため、
+  // 全件を1キーに載せて読み出し後に切り出す
+  const cacheKey = `awards:${slug}:v2`;
+  const cached = await cache.get(cacheKey);
+  const full =
+    (cached?.data as AwardDetail | undefined) ??
+    (await new AwardsService(c.env).getAwardBySlug(slug));
+
+  if (!full) {
     return c.json({error: 'Award not found'}, 404);
   }
 
   if (!cached) {
-    await cache.set(cacheKey, award, AWARDS_CACHE_TTL);
+    await cache.set(cacheKey, full, AWARDS_CACHE_TTL);
+  }
+
+  const award = paginateAwardDetail(full, page);
+  if (!award) {
+    return c.json({error: 'Award not found'}, 404);
   }
 
   const etag = createETag(award);

--- a/apps/api/src/services/__tests__/awards-service.test.ts
+++ b/apps/api/src/services/__tests__/awards-service.test.ts
@@ -181,6 +181,7 @@ describe('AwardsService.getAwardBySlug', () => {
       movieUid: 'movie-a',
       ceremonyUid: 'ceremony-2023',
       categoryUid: 'cat-palme',
+      isWinner: 1,
     });
 
     const result = await service.getAwardBySlug('palme-dor');
@@ -196,6 +197,7 @@ describe('AwardsService.getAwardBySlug', () => {
       movieUid: 'movie-a',
       ceremonyUid: 'ceremony-2023',
       categoryUid: 'cat-palme',
+      isWinner: 1,
     });
 
     const result = await service.getAwardBySlug('palme-dor');
@@ -219,6 +221,7 @@ describe('AwardsService.getAwardBySlug', () => {
       movieUid: 'movie-a',
       ceremonyUid: 'ceremony-2023',
       categoryUid: 'cat-palme',
+      isWinner: 1,
     });
 
     const result = await service.getAwardBySlug('palme-dor');
@@ -263,11 +266,168 @@ describe('AwardsService.getAwardBySlug', () => {
     const result = await service.getAwardBySlug('japan-academy-best-picture');
 
     const yearGroup = result?.years[0];
-    expect(yearGroup?.movies).toHaveLength(2);
+    expect(yearGroup?.filmCount).toBe(2);
+    expect(yearGroup?.movies).toHaveLength(1);
     expect(yearGroup?.movies[0]).toMatchObject({
       uid: 'movie-winner',
       isWinner: true,
     });
+  });
+});
+
+describe('AwardsService.getAwardBySlug 年別グルーピング', () => {
+  let environment: Environment;
+  let database: TestDatabase;
+  let service: AwardsService;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+    service = new AwardsService(environment);
+    await seedCannes(database);
+    await seedCannesCeremony(database, 'ceremony-2023', 2023, 76);
+    await seedMovie(database, 'movie-winner', 'Anatomy of a Fall');
+    await seedMovie(database, 'movie-a', 'The Zone of Interest');
+    await seedMovie(database, 'movie-b', 'Perfect Days');
+    await database.insert(nominations).values([
+      {
+        movieUid: 'movie-winner',
+        ceremonyUid: 'ceremony-2023',
+        categoryUid: 'cat-palme',
+        isWinner: 1,
+      },
+      {
+        movieUid: 'movie-a',
+        ceremonyUid: 'ceremony-2023',
+        categoryUid: 'cat-palme',
+      },
+      {
+        movieUid: 'movie-b',
+        ceremonyUid: 'ceremony-2023',
+        categoryUid: 'cat-palme',
+      },
+    ]);
+  });
+
+  it('受賞作のみを返す', async () => {
+    const result = await service.getAwardBySlug('palme-dor');
+
+    expect(result?.years[0]?.movies.map(movie => movie.uid)).toEqual([
+      'movie-winner',
+    ]);
+  });
+
+  it('出品作の総数をfilmCountで返す', async () => {
+    const result = await service.getAwardBySlug('palme-dor');
+
+    expect(result?.years[0]?.filmCount).toBe(3);
+  });
+
+  it('受賞作がない回も回次と件数を返す', async () => {
+    await seedCannesCeremony(database, 'ceremony-1968', 1968, 21);
+    await seedMovie(database, 'movie-c', 'Aborted Year Film');
+    await database.insert(nominations).values({
+      movieUid: 'movie-c',
+      ceremonyUid: 'ceremony-1968',
+      categoryUid: 'cat-palme',
+    });
+
+    const result = await service.getAwardBySlug('palme-dor');
+
+    const group = result?.years.find(entry => entry.year === 1968);
+    expect(group?.movies).toEqual([]);
+    expect(group?.filmCount).toBe(1);
+    expect(group?.ceremonyNumber).toBe(21);
+  });
+
+  it('ページ情報は返さない', async () => {
+    const result = await service.getAwardBySlug('palme-dor');
+
+    expect(result?.pagination).toBeUndefined();
+  });
+});
+
+describe('AwardsService.getAwardBySlug リスト型のページ分割', () => {
+  let environment: Environment;
+  let database: TestDatabase;
+  let service: AwardsService;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+    service = new AwardsService(environment);
+    await database.insert(awardOrganizations).values({
+      uid: 'org-1001',
+      name: '1001 Movies You Must See Before You Die',
+    });
+    await database.insert(awardCategories).values({
+      uid: 'cat-1001',
+      organizationUid: 'org-1001',
+      name: 'Selected Films',
+    });
+    await database
+      .insert(awardCeremonies)
+      .values({uid: 'ceremony-1001', organizationUid: 'org-1001', year: 2025});
+
+    for (let index = 0; index < 150; index++) {
+      const uid = `movie-${String(index).padStart(3, '0')}`;
+      await seedMovie(database, uid, `Film ${index}`, {year: 2000 + index});
+      await database.insert(nominations).values({
+        movieUid: uid,
+        ceremonyUid: 'ceremony-1001',
+        categoryUid: 'cat-1001',
+      });
+    }
+  });
+
+  it('1ページ目は100件を返す', async () => {
+    const result = await service.getAwardBySlug('1001-movies');
+
+    expect(result?.years[0]?.movies).toHaveLength(100);
+    expect(result?.pagination).toMatchObject({
+      page: 1,
+      perPage: 100,
+      totalCount: 150,
+      totalPages: 2,
+    });
+  });
+
+  it('2ページ目は残りを返す', async () => {
+    const result = await service.getAwardBySlug('1001-movies', {page: 2});
+
+    expect(result?.years[0]?.movies).toHaveLength(50);
+    expect(result?.pagination?.page).toBe(2);
+  });
+
+  it('ページをまたいで重複しない', async () => {
+    const first = await service.getAwardBySlug('1001-movies');
+    const second = await service.getAwardBySlug('1001-movies', {page: 2});
+
+    const uids = [
+      ...(first?.years[0]?.movies ?? []),
+      ...(second?.years[0]?.movies ?? []),
+    ].map(movie => movie.uid);
+
+    expect(new Set(uids).size).toBe(150);
+  });
+
+  it('公開年の新しい順に並べる', async () => {
+    const result = await service.getAwardBySlug('1001-movies');
+
+    const years = (result?.years[0]?.movies ?? []).map(
+      movie => movie.movieYear,
+    );
+    expect(years).toEqual(years.toSorted((a, b) => (b ?? 0) - (a ?? 0)));
+  });
+
+  it('範囲外のページは最終ページに丸める', async () => {
+    const result = await service.getAwardBySlug('1001-movies', {page: 99});
+
+    expect(result?.pagination?.page).toBe(2);
+  });
+
+  it('filmCountは総数を返す', async () => {
+    const result = await service.getAwardBySlug('1001-movies', {page: 2});
+
+    expect(result?.years[0]?.filmCount).toBe(150);
   });
 });
 

--- a/apps/api/src/services/__tests__/awards-service.test.ts
+++ b/apps/api/src/services/__tests__/awards-service.test.ts
@@ -15,6 +15,7 @@ import {beforeEach, describe, expect, it} from 'vitest';
 import {
   AwardsService,
   awardPageLinkForOrganizationName,
+  paginateAwardDetail,
 } from '../awards-service';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
@@ -378,8 +379,16 @@ describe('AwardsService.getAwardBySlug リスト型のページ分割', () => {
     }
   });
 
-  it('1ページ目は100件を返す', async () => {
+  it('サービスは全件を返しページ情報を持たない', async () => {
     const result = await service.getAwardBySlug('1001-movies');
+
+    expect(result?.years[0]?.movies).toHaveLength(150);
+    expect(result?.pagination).toBeUndefined();
+  });
+
+  it('1ページ目は100件を返す', async () => {
+    const full = await service.getAwardBySlug('1001-movies');
+    const result = paginateAwardDetail(full!, 1);
 
     expect(result?.years[0]?.movies).toHaveLength(100);
     expect(result?.pagination).toMatchObject({
@@ -391,43 +400,54 @@ describe('AwardsService.getAwardBySlug リスト型のページ分割', () => {
   });
 
   it('2ページ目は残りを返す', async () => {
-    const result = await service.getAwardBySlug('1001-movies', {page: 2});
+    const full = await service.getAwardBySlug('1001-movies');
+    const result = paginateAwardDetail(full!, 2);
 
     expect(result?.years[0]?.movies).toHaveLength(50);
     expect(result?.pagination?.page).toBe(2);
   });
 
   it('ページをまたいで重複しない', async () => {
-    const first = await service.getAwardBySlug('1001-movies');
-    const second = await service.getAwardBySlug('1001-movies', {page: 2});
-
+    const full = await service.getAwardBySlug('1001-movies');
     const uids = [
-      ...(first?.years[0]?.movies ?? []),
-      ...(second?.years[0]?.movies ?? []),
+      ...(paginateAwardDetail(full!, 1)?.years[0]?.movies ?? []),
+      ...(paginateAwardDetail(full!, 2)?.years[0]?.movies ?? []),
     ].map(movie => movie.uid);
 
     expect(new Set(uids).size).toBe(150);
   });
 
   it('公開年の新しい順に並べる', async () => {
-    const result = await service.getAwardBySlug('1001-movies');
+    const full = await service.getAwardBySlug('1001-movies');
+    const years = (full?.years[0]?.movies ?? []).map(movie => movie.movieYear);
 
-    const years = (result?.years[0]?.movies ?? []).map(
-      movie => movie.movieYear,
-    );
     expect(years).toEqual(years.toSorted((a, b) => (b ?? 0) - (a ?? 0)));
   });
 
-  it('範囲外のページは最終ページに丸める', async () => {
-    const result = await service.getAwardBySlug('1001-movies', {page: 99});
+  it('範囲外のページはundefinedを返す', async () => {
+    const full = await service.getAwardBySlug('1001-movies');
 
-    expect(result?.pagination?.page).toBe(2);
+    expect(paginateAwardDetail(full!, 3)).toBeUndefined();
   });
 
   it('filmCountは総数を返す', async () => {
-    const result = await service.getAwardBySlug('1001-movies', {page: 2});
+    const full = await service.getAwardBySlug('1001-movies');
+    const result = paginateAwardDetail(full!, 2);
 
     expect(result?.years[0]?.filmCount).toBe(150);
+  });
+
+  it('年別グルーピングの賞はそのまま返す', async () => {
+    const award = {
+      slug: 'palme-dor',
+      name: 'x',
+      organization: 'y',
+      description: 'z',
+      grouping: 'year' as const,
+      years: [{year: 2023, ceremonyNumber: 76, filmCount: 21, movies: []}],
+    };
+
+    expect(paginateAwardDetail(award, 1)).toBe(award);
   });
 });
 

--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -8,6 +8,7 @@ import {BaseService} from './base-service';
 import type {
   AwardDetail,
   AwardMovieEntry,
+  AwardPagination,
   AwardSummary,
   AwardYearDetail,
   AwardYearGroup,
@@ -151,8 +152,47 @@ export const awardPageDefinitions: AwardPageDefinition[] = [
   },
 ];
 
+export const AWARD_LIST_PAGE_SIZE = 100;
+
+function paginateListAward(
+  years: AwardYearGroup[],
+  requestedPage: number | undefined,
+): {years: AwardYearGroup[]; pagination: AwardPagination} {
+  const allMovies = years
+    .flatMap(group => group.movies)
+    .toSorted(
+      (a, b) =>
+        (b.movieYear ?? 0) - (a.movieYear ?? 0) || a.uid.localeCompare(b.uid),
+    );
+
+  const totalCount = allMovies.length;
+  const totalPages = Math.max(1, Math.ceil(totalCount / AWARD_LIST_PAGE_SIZE));
+  const page = Math.min(Math.max(requestedPage ?? 1, 1), totalPages);
+  const start = (page - 1) * AWARD_LIST_PAGE_SIZE;
+
+  return {
+    years: [
+      {
+        year: years[0].year,
+        ceremonyNumber: years[0].ceremonyNumber,
+        filmCount: totalCount,
+        movies: allMovies.slice(start, start + AWARD_LIST_PAGE_SIZE),
+      },
+    ],
+    pagination: {
+      page,
+      perPage: AWARD_LIST_PAGE_SIZE,
+      totalCount,
+      totalPages,
+    },
+  };
+}
+
 export class AwardsService extends BaseService {
-  async getAwardBySlug(slug: string): Promise<AwardDetail | undefined> {
+  async getAwardBySlug(
+    slug: string,
+    options: {page?: number} = {},
+  ): Promise<AwardDetail | undefined> {
     const definition = awardPageDefinitions.find(entry => entry.slug === slug);
     if (!definition) {
       return undefined;
@@ -215,6 +255,7 @@ export class AwardsService extends BaseService {
         group = {
           year: row.ceremonyYear,
           ceremonyNumber: row.ceremonyNumber ?? undefined,
+          filmCount: 0,
           movies: [],
         };
         groups.set(row.ceremonyYear, group);
@@ -237,17 +278,29 @@ export class AwardsService extends BaseService {
 
     const years = [...groups.values()].toSorted((a, b) => b.year - a.year);
     for (const group of years) {
+      group.filmCount = group.movies.length;
       group.movies.sort((a, b) => Number(b.isWinner) - Number(a.isWinner));
     }
 
-    return {
+    const base = {
       slug: definition.slug,
       name: definition.name,
       organization: definition.organization,
       description: definition.description,
       grouping: definition.grouping,
-      years,
     };
+
+    if (definition.grouping === 'year') {
+      return {
+        ...base,
+        years: years.map(group => ({
+          ...group,
+          movies: group.movies.filter(movie => movie.isWinner),
+        })),
+      };
+    }
+
+    return {...base, ...paginateListAward(years, options.page)};
   }
 
   async getAwardYear(

--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -8,7 +8,6 @@ import {BaseService} from './base-service';
 import type {
   AwardDetail,
   AwardMovieEntry,
-  AwardPagination,
   AwardSummary,
   AwardYearDetail,
   AwardYearGroup,
@@ -152,31 +151,64 @@ export const awardPageDefinitions: AwardPageDefinition[] = [
   },
 ];
 
-export const AWARD_LIST_PAGE_SIZE = 100;
+const AWARD_LIST_PAGE_SIZE = 100;
 
-function paginateListAward(
-  years: AwardYearGroup[],
-  requestedPage: number | undefined,
-): {years: AwardYearGroup[]; pagination: AwardPagination} {
-  const allMovies = years
-    .flatMap(group => group.movies)
-    .toSorted(
-      (a, b) =>
-        (b.movieYear ?? 0) - (a.movieYear ?? 0) || a.uid.localeCompare(b.uid),
-    );
+function flattenListAward(years: AwardYearGroup[]): AwardYearGroup[] {
+  const byUid = new Map<string, AwardMovieEntry>();
+  for (const group of years) {
+    for (const movie of group.movies) {
+      const existing = byUid.get(movie.uid);
+      if (existing) {
+        existing.isWinner = existing.isWinner || movie.isWinner;
+        continue;
+      }
 
-  const totalCount = allMovies.length;
+      byUid.set(movie.uid, movie);
+    }
+  }
+
+  const movies = [...byUid.values()].toSorted(
+    (a, b) =>
+      (b.movieYear ?? 0) - (a.movieYear ?? 0) || (a.uid < b.uid ? -1 : 1),
+  );
+
+  return [
+    {
+      year: years[0].year,
+      ceremonyNumber: years[0].ceremonyNumber,
+      filmCount: movies.length,
+      movies,
+    },
+  ];
+}
+
+/**
+ * リスト型の賞をページに切り出す。範囲外のページはundefined(=404)。
+ * キャッシュ済みの全件データに対して適用する前提の純粋関数
+ */
+export function paginateAwardDetail(
+  award: AwardDetail,
+  page: number,
+): AwardDetail | undefined {
+  if (award.grouping !== 'list') {
+    return award;
+  }
+
+  const [group] = award.years;
+  const totalCount = group?.filmCount ?? 0;
   const totalPages = Math.max(1, Math.ceil(totalCount / AWARD_LIST_PAGE_SIZE));
-  const page = Math.min(Math.max(requestedPage ?? 1, 1), totalPages);
+  if (page > totalPages) {
+    return undefined;
+  }
+
   const start = (page - 1) * AWARD_LIST_PAGE_SIZE;
 
   return {
+    ...award,
     years: [
       {
-        year: years[0].year,
-        ceremonyNumber: years[0].ceremonyNumber,
-        filmCount: totalCount,
-        movies: allMovies.slice(start, start + AWARD_LIST_PAGE_SIZE),
+        ...group,
+        movies: group.movies.slice(start, start + AWARD_LIST_PAGE_SIZE),
       },
     ],
     pagination: {
@@ -189,10 +221,7 @@ function paginateListAward(
 }
 
 export class AwardsService extends BaseService {
-  async getAwardBySlug(
-    slug: string,
-    options: {page?: number} = {},
-  ): Promise<AwardDetail | undefined> {
+  async getAwardBySlug(slug: string): Promise<AwardDetail | undefined> {
     const definition = awardPageDefinitions.find(entry => entry.slug === slug);
     if (!definition) {
       return undefined;
@@ -300,7 +329,7 @@ export class AwardsService extends BaseService {
       };
     }
 
-    return {...base, ...paginateListAward(years, options.page)};
+    return {...base, years: flattenListAward(years)};
   }
 
   async getAwardYear(

--- a/apps/front/app/routes/awards.$slug.test.tsx
+++ b/apps/front/app/routes/awards.$slug.test.tsx
@@ -25,6 +25,7 @@ const mockAwardDetail = {
     {
       year: 2023,
       ceremonyNumber: 76,
+      filmCount: 21,
       movies: [
         {
           uid: 'movie-winner',
@@ -33,18 +34,12 @@ const mockAwardDetail = {
           posterUrl: 'https://example.com/poster.jpg',
           isWinner: true,
         },
-        {
-          uid: 'movie-nominee',
-          title: '怪物',
-          movieYear: 2023,
-          posterUrl: undefined,
-          isWinner: false,
-        },
       ],
     },
     {
       year: 2022,
       ceremonyNumber: 75,
+      filmCount: 18,
       movies: [
         {
           uid: 'movie-2022',
@@ -58,6 +53,7 @@ const mockAwardDetail = {
     {
       year: 2021,
       ceremonyNumber: 74,
+      filmCount: 24,
       movies: [
         {
           uid: 'movie-2021',
@@ -120,7 +116,7 @@ describe('Award detail page', () => {
       );
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8787/awards/palme-dor',
+        'http://localhost:8787/awards/palme-dor?page=1',
         {signal: request.signal},
       );
       expect(result).toEqual({award: mockAwardDetail, locale: 'ja'});
@@ -167,7 +163,7 @@ describe('Award detail page', () => {
       ) as {title: string};
 
       expect(titleDescriptor.title).toBe(
-        'カンヌ国際映画祭 パルム・ドール 歴代一覧（2021–2023） | SHINE',
+        'カンヌ国際映画祭 パルム・ドール 歴代受賞作一覧（2021–2023） | SHINE',
       );
     });
   });
@@ -200,6 +196,103 @@ describe('Award detail page', () => {
 
       expect(screen.getByText('落下の解剖学')).toBeInTheDocument();
       expect(screen.getAllByText('WINNER')).toHaveLength(3);
+    });
+
+    it('各年から出品作一覧へのリンクを表示する', () => {
+      render(
+        <AwardDetailPage
+          {...createComponentProperties(
+            cast<LoaderData>({award: mockAwardDetail, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      const link = screen.getByRole('link', {name: /出品作21本を見る/});
+      expect(link).toHaveAttribute('href', '/awards/palme-dor/2023');
+    });
+
+    it('受賞作がない年は受賞作なしと表示する', () => {
+      const award = {
+        ...mockAwardDetail,
+        years: [{year: 1970, ceremonyNumber: 20, filmCount: 22, movies: []}],
+      };
+
+      render(
+        <AwardDetailPage
+          {...createComponentProperties(
+            cast<LoaderData>({award, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      expect(screen.getByText('受賞作なし')).toBeInTheDocument();
+    });
+
+    it('リスト型の賞ではページ送りを表示する', () => {
+      const award = {
+        ...mockAwardDetail,
+        slug: '1001-movies',
+        grouping: 'list' as const,
+        years: [
+          {
+            year: 2025,
+            ceremonyNumber: undefined,
+            filmCount: 150,
+            movies: [
+              {
+                uid: 'movie-list',
+                title: '市民ケーン',
+                movieYear: 1941,
+                posterUrl: undefined,
+                isWinner: false,
+              },
+            ],
+          },
+        ],
+        pagination: {page: 1, perPage: 100, totalCount: 150, totalPages: 2},
+      };
+
+      render(
+        <AwardDetailPage
+          {...createComponentProperties(
+            cast<LoaderData>({award, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      const next = screen.getByRole('link', {name: /次の100件/});
+      expect(next).toHaveAttribute('href', '/awards/1001-movies?page=2');
+    });
+
+    it('最終ページでは次へのリンクを出さない', () => {
+      const award = {
+        ...mockAwardDetail,
+        slug: '1001-movies',
+        grouping: 'list' as const,
+        years: [
+          {
+            year: 2025,
+            ceremonyNumber: undefined,
+            filmCount: 150,
+            movies: [],
+          },
+        ],
+        pagination: {page: 2, perPage: 100, totalCount: 150, totalPages: 2},
+      };
+
+      render(
+        <AwardDetailPage
+          {...createComponentProperties(
+            cast<LoaderData>({award, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      expect(screen.queryByRole('link', {name: /次の100件/})).toBeNull();
+      expect(screen.getByRole('link', {name: /前の100件/})).toHaveAttribute(
+        'href',
+        '/awards/1001-movies',
+      );
     });
 
     it('各作品が映画詳細ページへリンクする', () => {

--- a/apps/front/app/routes/awards.$slug.tsx
+++ b/apps/front/app/routes/awards.$slug.tsx
@@ -17,7 +17,15 @@ export type AwardMovieEntryData = {
 export type AwardYearGroupData = {
   year: number;
   ceremonyNumber?: number;
+  filmCount: number;
   movies: AwardMovieEntryData[];
+};
+
+export type AwardPaginationData = {
+  page: number;
+  perPage: number;
+  totalCount: number;
+  totalPages: number;
 };
 
 export type AwardDetailData = {
@@ -27,6 +35,7 @@ export type AwardDetailData = {
   description: string;
   grouping: 'year' | 'list';
   years: AwardYearGroupData[];
+  pagination?: AwardPaginationData;
 };
 
 const STRUCTURED_DATA_ITEM_LIMIT = 100;
@@ -38,6 +47,15 @@ function yearRange(award: AwardDetailData): {first?: number; last?: number} {
 function countMovies(award: AwardDetailData): number {
   let count = 0;
   for (const group of award.years) {
+    count += group.filmCount;
+  }
+
+  return count;
+}
+
+function countWinners(award: AwardDetailData): number {
+  let count = 0;
+  for (const group of award.years) {
     count += group.movies.length;
   }
 
@@ -45,12 +63,10 @@ function countMovies(award: AwardDetailData): number {
 }
 
 function buildItemList(award: AwardDetailData): Record<string, unknown> {
-  const movies =
-    award.grouping === 'year'
-      ? award.years.flatMap(group =>
-          group.movies.filter(movie => movie.isWinner),
-        )
-      : award.years.flatMap(group => group.movies);
+  const movies = award.years.flatMap(group => group.movies);
+  const offset = award.pagination
+    ? (award.pagination.page - 1) * award.pagination.perPage
+    : 0;
 
   return {
     '@context': 'https://schema.org',
@@ -60,28 +76,37 @@ function buildItemList(award: AwardDetailData): Record<string, unknown> {
       .slice(0, STRUCTURED_DATA_ITEM_LIMIT)
       .map((movie, index) => ({
         '@type': 'ListItem',
-        position: index + 1,
+        position: offset + index + 1,
         url: `${SITE_URL}/movies/${movie.uid}`,
         name: movie.title,
       })),
   };
 }
 
+function awardPath(award: AwardDetailData): string {
+  const page = award.pagination?.page ?? 1;
+  return page > 1
+    ? `/awards/${award.slug}?page=${page}`
+    : `/awards/${award.slug}`;
+}
+
 export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
   const {award, locale} = data as {award: AwardDetailData; locale?: Locale};
   const heading = awardHeading(award);
   const {first, last} = yearRange(award);
+  const page = award.pagination?.page ?? 1;
+  const pageSuffix = page > 1 ? `（${page}ページ目）` : '';
 
   const title =
     award.grouping === 'year'
-      ? `${heading} 歴代一覧（${first}–${last}） | SHINE`
-      : `${heading} 全${countMovies(award)}作品 | SHINE`;
+      ? `${heading} 歴代受賞作一覧（${first}–${last}） | SHINE`
+      : `${heading} 全${countMovies(award)}作品${pageSuffix} | SHINE`;
 
   return [
     ...buildSocialMeta({
       title,
       description: award.description,
-      path: `/awards/${award.slug}`,
+      path: awardPath(award),
       locale: locale ?? DEFAULT_LOCALE,
       imageUrl: `${SITE_URL}/og/home.png`,
       largeImage: true,
@@ -96,9 +121,11 @@ export async function loader({context, request, params}: Route.LoaderArgs) {
     (context.cloudflare as {env?: {PUBLIC_API_URL?: string}}).env
       ?.PUBLIC_API_URL || 'http://localhost:8787';
 
-  const response = await fetch(`${apiUrl}/awards/${params.slug}`, {
-    signal: request.signal,
-  });
+  const page = new URL(request.url).searchParams.get('page') ?? '1';
+  const response = await fetch(
+    `${apiUrl}/awards/${params.slug}?page=${encodeURIComponent(page)}`,
+    {signal: request.signal},
+  );
 
   if (response.status === 404) {
     throw new Response('Not Found', {status: 404});
@@ -170,6 +197,82 @@ function ListRow({movie}: {movie: AwardMovieEntryData}) {
   );
 }
 
+function YearSection({
+  award,
+  group,
+}: {
+  award: AwardDetailData;
+  group: AwardYearGroupData;
+}) {
+  const yearHref = `/awards/${award.slug}/${group.year}`;
+
+  return (
+    <section>
+      <div className="flex items-baseline gap-3 border-t-[3px] border-ink pt-2 mb-2">
+        <h2 className="font-display font-black text-3xl md:text-4xl tracking-[-0.06em] leading-none">
+          <a href={yearHref} className="text-ink no-underline">
+            {group.year}
+          </a>
+        </h2>
+        {group.ceremonyNumber && (
+          <span className="font-mono text-[10px] text-ink-muted">
+            第{group.ceremonyNumber}回
+          </span>
+        )}
+        <a
+          href={yearHref}
+          className="ml-auto font-mono text-[10px] text-ink-muted no-underline shrink-0">
+          出品作{group.filmCount}本を見る →
+        </a>
+      </div>
+      <div>
+        {group.movies.length > 0 ? (
+          group.movies.map(movie => <MovieRow key={movie.uid} movie={movie} />)
+        ) : (
+          <p className="font-mono text-xs text-ink-muted py-3">受賞作なし</p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Pagination({
+  award,
+  pagination,
+}: {
+  award: AwardDetailData;
+  pagination: AwardPaginationData;
+}) {
+  if (pagination.totalPages <= 1) {
+    return;
+  }
+
+  const pageHref = (page: number) =>
+    page === 1 ? `/awards/${award.slug}` : `/awards/${award.slug}?page=${page}`;
+
+  return (
+    <nav className="flex items-center justify-between gap-4 border-t-2 border-ink pt-4 mt-6 font-mono text-xs">
+      {pagination.page > 1 ? (
+        <a href={pageHref(pagination.page - 1)} className="text-ink">
+          ← 前の{pagination.perPage}件
+        </a>
+      ) : (
+        <span />
+      )}
+      <span className="text-ink-muted">
+        {pagination.page} / {pagination.totalPages}
+      </span>
+      {pagination.page < pagination.totalPages ? (
+        <a href={pageHref(pagination.page + 1)} className="text-ink">
+          次の{pagination.perPage}件 →
+        </a>
+      ) : (
+        <span />
+      )}
+    </nav>
+  );
+}
+
 export default function AwardDetailPage({loaderData}: Route.ComponentProps) {
   const {award} = loaderData as {award: AwardDetailData};
   const locale = 'ja';
@@ -191,35 +294,15 @@ export default function AwardDetailPage({loaderData}: Route.ComponentProps) {
           {heading}
         </h1>
         <p className="font-mono text-xs text-ink-muted mb-8">
-          {award.grouping === 'year' && first !== last
-            ? `${first}–${last} / ${countMovies(award)} FILMS`
+          {award.grouping === 'year'
+            ? `${first}–${last} / ${countWinners(award)} WINNERS / ${countMovies(award)} FILMS`
             : `${countMovies(award)} FILMS`}
         </p>
 
         {award.grouping === 'year' ? (
           <div className="space-y-10">
             {award.years.map(group => (
-              <section key={group.year}>
-                <div className="flex items-baseline gap-3 border-t-[3px] border-ink pt-2 mb-2">
-                  <h2 className="font-display font-black text-3xl md:text-4xl tracking-[-0.06em] leading-none">
-                    <a
-                      href={`/awards/${award.slug}/${group.year}`}
-                      className="text-ink no-underline">
-                      {group.year}
-                    </a>
-                  </h2>
-                  {group.ceremonyNumber && (
-                    <span className="font-mono text-[10px] text-ink-muted">
-                      第{group.ceremonyNumber}回
-                    </span>
-                  )}
-                </div>
-                <div>
-                  {group.movies.map(movie => (
-                    <MovieRow key={movie.uid} movie={movie} />
-                  ))}
-                </div>
-              </section>
+              <YearSection key={group.year} award={award} group={group} />
             ))}
           </div>
         ) : (
@@ -230,6 +313,10 @@ export default function AwardDetailPage({loaderData}: Route.ComponentProps) {
               )),
             )}
           </div>
+        )}
+
+        {award.pagination && (
+          <Pagination award={award} pagination={award.pagination} />
         )}
 
         <SiteFooter locale={locale} />

--- a/apps/front/app/routes/sitemap-awards.tsx
+++ b/apps/front/app/routes/sitemap-awards.tsx
@@ -2,9 +2,12 @@ import type {Route} from './+types/sitemap-awards';
 import {buildUrlSet, type SitemapEntry} from '@/lib/sitemap';
 import {resolveApiUrl, sitemapResponse} from '@/lib/sitemap-source';
 
+const AWARD_LIST_PAGE_SIZE = 100;
+
 type AwardListing = {
   slug: string;
   grouping: 'year' | 'list';
+  movieCount?: number;
 };
 
 async function fetchAwards(
@@ -69,6 +72,17 @@ export async function loader({context, request}: Route.LoaderArgs) {
         changefreq: 'monthly' as const,
       })),
     ),
+    ...awards.flatMap(award => {
+      if (award.grouping !== 'list') {
+        return [];
+      }
+
+      const pages = Math.ceil((award.movieCount ?? 0) / AWARD_LIST_PAGE_SIZE);
+      return Array.from({length: Math.max(0, pages - 1)}, (_, index) => ({
+        path: `/awards/${award.slug}?page=${index + 2}`,
+        changefreq: 'weekly' as const,
+      }));
+    }),
   ];
 
   return sitemapResponse(buildUrlSet(entries));

--- a/apps/front/app/routes/sitemap-awards.tsx
+++ b/apps/front/app/routes/sitemap-awards.tsx
@@ -2,12 +2,14 @@ import type {Route} from './+types/sitemap-awards';
 import {buildUrlSet, type SitemapEntry} from '@/lib/sitemap';
 import {resolveApiUrl, sitemapResponse} from '@/lib/sitemap-source';
 
-const AWARD_LIST_PAGE_SIZE = 100;
-
 type AwardListing = {
   slug: string;
   grouping: 'year' | 'list';
-  movieCount?: number;
+};
+
+type AwardDetailShape = {
+  years?: Array<{year: number}>;
+  pagination?: {totalPages: number};
 };
 
 async function fetchAwards(
@@ -27,33 +29,49 @@ async function fetchAwards(
   }
 }
 
-async function fetchAwardYears(
+async function fetchAwardDetail(
   context: unknown,
   slug: string,
   signal?: AbortSignal,
-): Promise<number[]> {
+): Promise<AwardDetailShape> {
   try {
     const response = await fetch(`${resolveApiUrl(context)}/awards/${slug}`, {
       signal,
     });
     if (!response.ok) {
-      return [];
+      return {};
     }
 
-    const body = (await response.json()) as {years?: Array<{year: number}>};
-    return (body.years ?? []).map(group => group.year);
+    return (await response.json()) as AwardDetailShape;
   } catch {
-    return [];
+    return {};
   }
+}
+
+function subPageEntries(
+  award: AwardListing,
+  detail: AwardDetailShape,
+): SitemapEntry[] {
+  if (award.grouping === 'year') {
+    return (detail.years ?? []).map(group => ({
+      path: `/awards/${award.slug}/${group.year}`,
+      changefreq: 'monthly',
+    }));
+  }
+
+  const totalPages = detail.pagination?.totalPages ?? 1;
+  return Array.from({length: Math.max(0, totalPages - 1)}, (_, index) => ({
+    path: `/awards/${award.slug}?page=${index + 2}`,
+    changefreq: 'weekly',
+  }));
 }
 
 export async function loader({context, request}: Route.LoaderArgs) {
   const awards = await fetchAwards(context, request.signal);
-  const yearAwards = awards.filter(award => award.grouping === 'year');
-  const yearLists = await Promise.all(
-    yearAwards.map(async award => ({
-      slug: award.slug,
-      years: await fetchAwardYears(context, award.slug, request.signal),
+  const details = await Promise.all(
+    awards.map(async award => ({
+      award,
+      detail: await fetchAwardDetail(context, award.slug, request.signal),
     })),
   );
 
@@ -66,23 +84,7 @@ export async function loader({context, request}: Route.LoaderArgs) {
       path: `/awards/${award.slug}`,
       changefreq: 'weekly' as const,
     })),
-    ...yearLists.flatMap(({slug, years}) =>
-      years.map(year => ({
-        path: `/awards/${slug}/${year}`,
-        changefreq: 'monthly' as const,
-      })),
-    ),
-    ...awards.flatMap(award => {
-      if (award.grouping !== 'list') {
-        return [];
-      }
-
-      const pages = Math.ceil((award.movieCount ?? 0) / AWARD_LIST_PAGE_SIZE);
-      return Array.from({length: Math.max(0, pages - 1)}, (_, index) => ({
-        path: `/awards/${award.slug}?page=${index + 2}`,
-        changefreq: 'weekly' as const,
-      }));
-    }),
+    ...details.flatMap(({award, detail}) => subPageEntries(award, detail)),
   ];
 
   return sitemapResponse(buildUrlSet(entries));

--- a/apps/front/app/routes/sitemap.test.ts
+++ b/apps/front/app/routes/sitemap.test.ts
@@ -143,11 +143,14 @@ describe('sitemap/awards.xml', () => {
   it('賞一覧と各賞ページのURLを列挙する', async () => {
     mockSearchResponse({
       awards: [
-        {slug: 'palme-dor'},
-        {slug: 'academy-best-picture'},
-        {slug: 'japan-academy-best-picture'},
+        {slug: 'palme-dor', grouping: 'year'},
+        {slug: 'academy-best-picture', grouping: 'year'},
+        {slug: 'japan-academy-best-picture', grouping: 'year'},
       ],
     });
+    mockSearchResponse({years: [{year: 2023}]});
+    mockSearchResponse({years: [{year: 2023}]});
+    mockSearchResponse({years: [{year: 2023}]});
 
     const response = await sitemapAwardsLoader(createAwardsArguments());
     const xml = await response.text();
@@ -160,6 +163,35 @@ describe('sitemap/awards.xml', () => {
     expect(xml).toContain(
       '<loc>https://shine-film.com/awards/japan-academy-best-picture</loc>',
     );
+  });
+
+  it('リスト型の賞は2ページ目以降のURLも列挙する', async () => {
+    mockSearchResponse({awards: [{slug: '1001-movies', grouping: 'list'}]});
+    mockSearchResponse({pagination: {totalPages: 3}});
+
+    const response = await sitemapAwardsLoader(createAwardsArguments());
+    const xml = await response.text();
+
+    expect(xml).toContain(
+      '<loc>https://shine-film.com/awards/1001-movies</loc>',
+    );
+    expect(xml).toContain(
+      '<loc>https://shine-film.com/awards/1001-movies?page=2</loc>',
+    );
+    expect(xml).toContain(
+      '<loc>https://shine-film.com/awards/1001-movies?page=3</loc>',
+    );
+    expect(xml).not.toContain('?page=4');
+  });
+
+  it('1ページに収まるリスト型の賞はページURLを出さない', async () => {
+    mockSearchResponse({awards: [{slug: 'variety-top-100', grouping: 'list'}]});
+    mockSearchResponse({pagination: {totalPages: 1}});
+
+    const response = await sitemapAwardsLoader(createAwardsArguments());
+    const xml = await response.text();
+
+    expect(xml).not.toContain('?page=');
   });
 
   it('API取得に失敗しても200で/awardsのみのurlsetを返す', async () => {

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -77,7 +77,16 @@ export type AwardMovieEntry = {
 export type AwardYearGroup = {
   year: number;
   ceremonyNumber: number | undefined;
+  /** その回の全出品作数。moviesは年別グルーピングでは受賞作のみを含む */
+  filmCount: number;
   movies: AwardMovieEntry[];
+};
+
+export type AwardPagination = {
+  page: number;
+  perPage: number;
+  totalCount: number;
+  totalPages: number;
 };
 
 export type AwardDetail = {
@@ -87,6 +96,8 @@ export type AwardDetail = {
   description: string;
   grouping: 'year' | 'list';
   years: AwardYearGroup[];
+  /** grouping === 'list' のときのみ返る */
+  pagination?: AwardPagination;
 };
 
 export type AwardYearDetail = {


### PR DESCRIPTION
賞の一覧ページが1ページに全ノミネート作品を並べていて、死ぬまでに観たい映画1001本は1,254KB、金熊賞は721KB（実HTML 379KB＋loaderデータ323KB）あった。金熊賞ページには映画リンクが1,550本並んでいた。

- 年別グルーピングの賞（カンヌ・ヴェネツィア・ベルリン・アカデミー・日本アカデミー）は一覧を**受賞作のみ**にし、各年から年別ページへ「出品作N本を見る」の導線を出す。API は各年の出品数を `filmCount` で返す。受賞作がない年（ベルリン1970年の審査中止など）は「受賞作なし」と表示する
- リスト型の賞（1001本・POPEYE等、年別ページがない）は100件ずつのページ分割にする。`GET /awards/{slug}?page=N` を追加し、公開年の新しい順で安定した並びにした。2ページ目以降も sitemap に登録
- レスポンス形状が変わるのでキャッシュキーを v2 に更新

実測（本番デプロイ後）:

| ページ | 変更前 | 変更後 |
|---|---|---|
| 死ぬまでに観たい映画1001本 | 1,254KB | 125KB |
| 金熊賞 | 721KB | 160KB |
| パルム・ドール | 773KB | 109KB |
| 金獅子賞 | 659KB | 127KB |
| POPEYE | 608KB | 123KB |

金熊賞ページの映画リンクは1,550本から94本になり、代わりに年別76ページへの導線が立った。