### PR TITLE
ポスターが無い映画にTMDbからポスターを補完する

### DIFF
--- a/apps/scrapers/package.json
+++ b/apps/scrapers/package.json
@@ -9,6 +9,7 @@
     "academy-awards": "tsx src/academy-awards-cli.ts",
     "japan-academy-awards": "tsx src/japan-academy-awards-cli.ts",
     "assign-imdb-ids": "tsx src/assign-imdb-ids-cli.ts",
+    "backfill-posters": "tsx src/backfill-posters-cli.ts",
     "import-imdb-list": "tsx src/import-imdb-list-cli.ts",
     "availability-check": "tsx src/availability-check-cli.ts",
     "japanese-translations": "tsx src/japanese-translations-cli.ts",

--- a/apps/scrapers/src/__tests__/backfill-posters.test.ts
+++ b/apps/scrapers/src/__tests__/backfill-posters.test.ts
@@ -1,0 +1,399 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {eq} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  backfillPosters,
+  normalizeTitle,
+  pickStrictMatch,
+} from '../backfill-posters';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+async function createTestEnvironment(): Promise<{
+  environment: Environment;
+  database: ReturnType<typeof getDatabase>;
+}> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-poster-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+    TMDB_API_KEY: 'test-key',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+  return {environment, database};
+}
+
+async function seedMovie(
+  database: ReturnType<typeof getDatabase>,
+  values: {
+    uid: string;
+    title: string;
+    year?: number;
+    imdbId?: string;
+    tmdbId?: number;
+  },
+): Promise<void> {
+  await database.insert(movies).values({
+    uid: values.uid,
+    year: values.year,
+    imdbId: values.imdbId,
+    tmdbId: values.tmdbId,
+  });
+  await database.insert(translations).values({
+    resourceType: 'movie_title',
+    resourceUid: values.uid,
+    languageCode: 'en',
+    content: values.title,
+    isDefault: 1,
+  });
+}
+
+describe('normalizeTitle', () => {
+  it('大文字小文字を無視する', () => {
+    expect(normalizeTitle('Roman Holiday')).toBe(
+      normalizeTitle('ROMAN HOLIDAY'),
+    );
+  });
+
+  it('発音記号を無視する', () => {
+    expect(normalizeTitle('Rashômon')).toBe(normalizeTitle('Rashomon'));
+  });
+
+  it('記号と空白を無視する', () => {
+    expect(normalizeTitle('Spider-Man: No Way Home')).toBe(
+      normalizeTitle('Spider Man No Way Home'),
+    );
+  });
+
+  it('前後の空白を無視する', () => {
+    expect(normalizeTitle('  Titane  ')).toBe(normalizeTitle('Titane'));
+  });
+});
+
+describe('pickStrictMatch', () => {
+  const results = [
+    {id: 1, title: 'Nostalgia', release_date: '2022-09-04'},
+    {id: 2, title: 'Nostalghia', release_date: '1983-01-01'},
+  ];
+
+  it('タイトルと年が一致する候補を返す', () => {
+    expect(pickStrictMatch(results, 'Nostalgia', 2022)).toBe(1);
+  });
+
+  it('年が数年ずれても許容する（DBの年は映画祭の開催年）', () => {
+    expect(pickStrictMatch(results, 'Nostalgia', 2019)).toBe(1);
+  });
+
+  it('年が離れすぎたら採用しない', () => {
+    expect(pickStrictMatch(results, 'Nostalgia', 2015)).toBeUndefined();
+  });
+
+  it('同名候補が複数あれば年が近い方を選ぶ', () => {
+    const sameTitle = [
+      {id: 10, title: 'Monster', release_date: '2003-05-16'},
+      {id: 11, title: 'Monster', release_date: '2005-01-01'},
+    ];
+
+    expect(pickStrictMatch(sameTitle, 'Monster', 2005)).toBe(11);
+  });
+
+  it('タイトルが違えば年が合っても採用しない', () => {
+    expect(pickStrictMatch(results, 'Nostalghia', 2022)).toBeUndefined();
+  });
+
+  it('原題での一致も認める', () => {
+    const withOriginal = [
+      {
+        id: 3,
+        title: 'The Wages of Fear',
+        original_title: 'Le salaire de la peur',
+        release_date: '1953-04-22',
+      },
+    ];
+
+    expect(pickStrictMatch(withOriginal, 'Le salaire de la peur', 1953)).toBe(
+      3,
+    );
+  });
+
+  it('公開日が無い候補は採用しない', () => {
+    expect(
+      pickStrictMatch(
+        [{id: 4, title: 'Untitled', release_date: ''}],
+        'Untitled',
+        2020,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('候補が空なら何も返さない', () => {
+    expect(pickStrictMatch([], 'Anything', 2020)).toBeUndefined();
+  });
+});
+
+const stubTmdb = (
+  handlers: Record<string, unknown>,
+  onUnmatched: () => Response = () => new Response('nf', {status: 404}),
+) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      for (const [fragment, body] of Object.entries(handlers)) {
+        if (url.includes(fragment)) {
+          return Response.json(body);
+        }
+      }
+
+      return onUnmatched();
+    }),
+  );
+};
+
+describe('backfillPosters', () => {
+  let environment: Environment;
+  let database: ReturnType<typeof getDatabase>;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const configuration = {
+    images: {
+      secure_base_url: 'https://image.tmdb.org/t/p/',
+      poster_sizes: ['w185', 'w342', 'w500', 'original'],
+    },
+  };
+
+  it('tmdbIdがある映画にポスターを保存する', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      title: '7th Heaven',
+      year: 1928,
+      tmdbId: 82_474,
+    });
+    stubTmdb({
+      '/configuration': configuration,
+      '/movie/82474': {id: 82_474, title: '7th Heaven', poster_path: '/a.jpg'},
+    });
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.postersSaved).toBe(1);
+    const [poster] = await database
+      .select()
+      .from(posterUrls)
+      .where(eq(posterUrls.movieUid, 'm1'));
+    expect(poster.url).toBe('https://image.tmdb.org/t/p/w500/a.jpg');
+    expect(poster.isPrimary).toBe(1);
+  });
+
+  it('原寸ではなくw500で保存する', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'X', year: 2000, tmdbId: 1});
+    stubTmdb({
+      '/configuration': configuration,
+      '/movie/1': {id: 1, title: 'X', poster_path: '/a.jpg'},
+    });
+
+    await backfillPosters({environment, throttleMs: 0});
+
+    const [poster] = await database.select().from(posterUrls);
+    expect(poster.url).not.toContain('/original/');
+  });
+
+  it('imdbIdからtmdbIdを解決して保存する', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      title: 'Rashomon',
+      year: 1950,
+      imdbId: 'tt0042876',
+    });
+    stubTmdb({
+      '/configuration': configuration,
+      '/find/tt0042876': {
+        movie_results: [{id: 548, media_type: 'movie'}],
+        tv_results: [],
+      },
+      '/movie/548': {id: 548, title: 'Rashomon', poster_path: '/r.jpg'},
+    });
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.postersSaved).toBe(1);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'm1'));
+    expect(movie.tmdbId).toBe(548);
+  });
+
+  it('IDが無い映画はタイトルと年で厳格に照合する', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'In Old Chicago', year: 1937});
+    stubTmdb({
+      '/configuration': configuration,
+      '/search/movie': {
+        results: [
+          {id: 43_884, title: 'In Old Chicago', release_date: '1937-04-15'},
+        ],
+      },
+      '/movie/43884': {
+        id: 43_884,
+        title: 'In Old Chicago',
+        poster_path: '/c.jpg',
+      },
+    });
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.postersSaved).toBe(1);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'm1'));
+    expect(movie.tmdbId).toBe(43_884);
+  });
+
+  it('タイトルが一致しない候補は採用しない', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'In Old Chicago', year: 1937});
+    stubTmdb({
+      '/configuration': configuration,
+      '/search/movie': {
+        results: [{id: 999, title: 'Chicago', release_date: '1937-01-01'}],
+      },
+    });
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.postersSaved).toBe(0);
+    expect(stats.unresolved).toBe(1);
+    expect(await database.select().from(posterUrls)).toHaveLength(0);
+  });
+
+  it('他の映画が使っているtmdbIdは割り当てない', async () => {
+    await seedMovie(database, {
+      uid: 'taken',
+      title: 'Taken',
+      year: 1950,
+      tmdbId: 548,
+    });
+    await database
+      .insert(posterUrls)
+      .values({movieUid: 'taken', url: 'https://x/p.jpg', sourceType: 'tmdb'});
+    await seedMovie(database, {
+      uid: 'm1',
+      title: 'Rashomon',
+      year: 1950,
+      imdbId: 'tt0042876',
+    });
+    stubTmdb({
+      '/configuration': configuration,
+      '/find/tt0042876': {
+        movie_results: [{id: 548, media_type: 'movie'}],
+        tv_results: [],
+      },
+    });
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.postersSaved).toBe(0);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'm1'));
+    expect(movie.tmdbId).toBeNull();
+  });
+
+  it('soft-deletedの映画は対象にしない', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'X', year: 2000, tmdbId: 1});
+    await database
+      .update(movies)
+      .set({deletedAt: 1000})
+      .where(eq(movies.uid, 'm1'));
+    stubTmdb({
+      '/configuration': configuration,
+      '/movie/1': {id: 1, title: 'X', poster_path: '/a.jpg'},
+    });
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.candidates).toBe(0);
+    expect(await database.select().from(posterUrls)).toHaveLength(0);
+  });
+
+  it('既にポスターがある映画は対象にしない', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'X', year: 2000, tmdbId: 1});
+    await database
+      .insert(posterUrls)
+      .values({movieUid: 'm1', url: 'https://x/p.jpg', sourceType: 'tmdb'});
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.candidates).toBe(0);
+  });
+
+  it('TMDbにポスターが無い場合は保存しない', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'X', year: 2000, tmdbId: 1});
+    stubTmdb({
+      '/configuration': configuration,
+      '/movie/1': {id: 1, title: 'X'},
+    });
+
+    const stats = await backfillPosters({environment, throttleMs: 0});
+
+    expect(stats.postersSaved).toBe(0);
+    expect(stats.noPosterOnTmdb).toBe(1);
+  });
+
+  it('dryRunでは書き込まない', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'X', year: 2000, tmdbId: 1});
+    stubTmdb({
+      '/configuration': configuration,
+      '/movie/1': {id: 1, title: 'X', poster_path: '/a.jpg'},
+    });
+
+    const stats = await backfillPosters({
+      environment,
+      throttleMs: 0,
+      dryRun: true,
+    });
+
+    expect(stats.postersSaved).toBe(1);
+    expect(await database.select().from(posterUrls)).toHaveLength(0);
+  });
+
+  it('limitで処理件数を絞る', async () => {
+    await seedMovie(database, {uid: 'm1', title: 'A', year: 2000, tmdbId: 1});
+    await seedMovie(database, {uid: 'm2', title: 'B', year: 2001, tmdbId: 2});
+    stubTmdb({
+      '/configuration': configuration,
+      '/movie/1': {id: 1, title: 'A', poster_path: '/a.jpg'},
+      '/movie/2': {id: 2, title: 'B', poster_path: '/b.jpg'},
+    });
+
+    const stats = await backfillPosters({
+      environment,
+      throttleMs: 0,
+      limit: 1,
+    });
+
+    expect(stats.candidates).toBe(1);
+    expect(stats.postersSaved).toBe(1);
+  });
+});

--- a/apps/scrapers/src/backfill-posters-cli.ts
+++ b/apps/scrapers/src/backfill-posters-cli.ts
@@ -1,0 +1,85 @@
+/**
+ * ポスターが無い映画にTMDbからポスターを補完するCLI
+ */
+import {Command, InvalidArgumentError} from 'commander';
+import {backfillPosters} from './backfill-posters';
+import {
+  assertDatabaseEnvironment,
+  buildEnvironment,
+  loadEnvironmentFiles,
+} from './common/environment';
+
+loadEnvironmentFiles();
+const environment = buildEnvironment(process.env);
+
+function parsePositiveInteger(label: string) {
+  return (value: string): number => {
+    const parsed = Number.parseInt(value, 10);
+
+    if (Number.isNaN(parsed) || parsed < 0) {
+      throw new InvalidArgumentError(
+        `${label}は0以上の整数で指定してください。`,
+      );
+    }
+
+    return parsed;
+  };
+}
+
+const program = new Command();
+
+program
+  .name('backfill-posters')
+  .description(
+    [
+      'ポスターが登録されていない映画を対象に、TMDbからポスターを補完します。',
+      'TMDb IDが無い映画はIMDb IDから、それも無ければタイトルと公開年の',
+      '厳格な一致で解決します（一致しない場合は何も書き込みません）。',
+    ].join('\n'),
+  )
+  .option('--limit <count>', '処理件数の上限', parsePositiveInteger('limit'))
+  .option('--dry-run', '実際の書き込みは行わず、処理内容のみ表示', false)
+  .option(
+    '--throttle <ms>',
+    'TMDbリクエスト間の待機ミリ秒 (デフォルト: 300)',
+    parsePositiveInteger('throttle'),
+    300,
+  )
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrapers:backfill-posters --dry-run
+  pnpm run scrapers:backfill-posters --limit 20
+  pnpm run scrapers:backfill-posters
+`,
+  )
+  .action(
+    async (options: {limit?: number; dryRun: boolean; throttle: number}) => {
+      assertDatabaseEnvironment(environment);
+
+      if (!environment.TMDB_API_KEY) {
+        console.error('TMDB_API_KEY が設定されていません。');
+        process.exitCode = 1;
+        return;
+      }
+
+      const stats = await backfillPosters({
+        environment,
+        dryRun: options.dryRun,
+        limit: options.limit,
+        throttleMs: options.throttle,
+      });
+
+      if (stats.failed > 0) {
+        process.exitCode = 1;
+      }
+    },
+  );
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  console.error('ポスター補完中にエラーが発生しました:', error);
+  process.exitCode = 1;
+}

--- a/apps/scrapers/src/backfill-posters.ts
+++ b/apps/scrapers/src/backfill-posters.ts
@@ -1,0 +1,306 @@
+import {setTimeout as sleep} from 'node:timers/promises';
+import {and, eq, isNull, notInArray, sql} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {
+  fetchTMDBConfiguration,
+  fetchTMDBMovieDetails,
+  findTMDBByImdbId,
+} from './common/tmdb-utilities';
+import {fetchJsonWithRetry} from './common/fetch-utilities';
+
+const TMDB_API_BASE_URL = 'https://api.themoviedb.org/3';
+const POSTER_SIZE = 'w500';
+const MAX_YEAR_DISTANCE = 3;
+
+export type BackfillStats = {
+  candidates: number;
+  postersSaved: number;
+  noPosterOnTmdb: number;
+  unresolved: number;
+  tmdbIdTaken: number;
+  failed: number;
+};
+
+type SearchResult = {
+  id: number;
+  title: string;
+  original_title?: string;
+  release_date: string;
+};
+
+export function normalizeTitle(title: string): string {
+  return title
+    .normalize('NFD')
+    .replaceAll(/[\u0300-\u036F]/g, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9\u3040-\u30FF\u4E00-\u9FFF]/g, '');
+}
+
+/**
+ * タイトルが正規化して完全一致し、かつ公開年が近い候補だけを採用する。
+ * DBのyearは映画祭の開催年で、TMDbの公開年と数年ずれることがある
+ */
+export function pickStrictMatch(
+  results: SearchResult[],
+  title: string,
+  year: number,
+): number | undefined {
+  const wanted = normalizeTitle(title);
+  let best: {id: number; distance: number} | undefined;
+
+  for (const result of results) {
+    if (!result.release_date) {
+      continue;
+    }
+
+    const resultYear = Number.parseInt(result.release_date.slice(0, 4), 10);
+    if (!Number.isFinite(resultYear)) {
+      continue;
+    }
+
+    const distance = Math.abs(resultYear - year);
+    if (distance > MAX_YEAR_DISTANCE) {
+      continue;
+    }
+
+    const titles = [result.title, result.original_title].filter(
+      (value): value is string => typeof value === 'string',
+    );
+    if (!titles.some(candidate => normalizeTitle(candidate) === wanted)) {
+      continue;
+    }
+
+    if (!best || distance < best.distance) {
+      best = {id: result.id, distance};
+    }
+  }
+
+  return best?.id;
+}
+
+type Candidate = {
+  uid: string;
+  imdbId: string | null;
+  tmdbId: number | null;
+  year: number | null;
+  title: string | null;
+};
+
+export async function backfillPosters({
+  environment,
+  dryRun = false,
+  limit,
+  throttleMs = 300,
+}: {
+  environment: Environment;
+  dryRun?: boolean;
+  limit?: number;
+  throttleMs?: number;
+}): Promise<BackfillStats> {
+  const stats: BackfillStats = {
+    candidates: 0,
+    postersSaved: 0,
+    noPosterOnTmdb: 0,
+    unresolved: 0,
+    tmdbIdTaken: 0,
+    failed: 0,
+  };
+
+  const tmdbApiKey = environment.TMDB_API_KEY;
+  if (!tmdbApiKey) {
+    throw new Error('TMDB_API_KEY is required to backfill posters.');
+  }
+
+  const database = getDatabase(environment);
+  const withPoster = database
+    .select({movieUid: posterUrls.movieUid})
+    .from(posterUrls);
+
+  const rows = await database
+    .select({
+      uid: movies.uid,
+      imdbId: movies.imdbId,
+      tmdbId: movies.tmdbId,
+      year: movies.year,
+      title: sql<string | null>`(
+        SELECT content FROM translations
+        WHERE translations.resource_uid = movies.uid
+          AND translations.resource_type = 'movie_title'
+        ORDER BY translations.is_default DESC
+        LIMIT 1
+      )`.as('title'),
+    })
+    .from(movies)
+    .where(and(isNull(movies.deletedAt), notInArray(movies.uid, withPoster)));
+
+  const candidates = limit === undefined ? rows : rows.slice(0, limit);
+  stats.candidates = candidates.length;
+
+  if (candidates.length === 0) {
+    console.log('No movies need a poster.');
+    return stats;
+  }
+
+  console.log(
+    `${dryRun ? '[DRY RUN] ' : ''}Backfilling posters for ${candidates.length} movies...`,
+  );
+
+  const configuration = await fetchTMDBConfiguration(tmdbApiKey);
+  const size = configuration.images.poster_sizes.includes(POSTER_SIZE)
+    ? POSTER_SIZE
+    : 'original';
+
+  for (const candidate of candidates) {
+    try {
+      await processCandidate({
+        database,
+        candidate,
+        tmdbApiKey,
+        baseUrl: configuration.images.secure_base_url,
+        size,
+        dryRun,
+        stats,
+      });
+    } catch (error) {
+      console.error(`  Failed for ${candidate.uid}:`, error);
+      stats.failed++;
+    }
+
+    if (throttleMs > 0) {
+      await sleep(throttleMs);
+    }
+  }
+
+  console.log('\nBackfill summary:');
+  console.log(`  Candidates: ${stats.candidates}`);
+  console.log(`  Posters saved: ${stats.postersSaved}`);
+  console.log(`  No poster on TMDb: ${stats.noPosterOnTmdb}`);
+  console.log(`  Unresolved: ${stats.unresolved}`);
+  console.log(`  TMDb ID already taken: ${stats.tmdbIdTaken}`);
+  console.log(`  Failed: ${stats.failed}`);
+
+  return stats;
+}
+
+type DatabaseClient = ReturnType<typeof getDatabase>;
+
+async function processCandidate({
+  database,
+  candidate,
+  tmdbApiKey,
+  baseUrl,
+  size,
+  dryRun,
+  stats,
+}: {
+  database: DatabaseClient;
+  candidate: Candidate;
+  tmdbApiKey: string;
+  baseUrl: string;
+  size: string;
+  dryRun: boolean;
+  stats: BackfillStats;
+}): Promise<void> {
+  const resolved = await resolveTmdbId(candidate, tmdbApiKey);
+  if (resolved === undefined) {
+    console.log(`  Unresolved: ${candidate.title ?? candidate.uid}`);
+    stats.unresolved++;
+    return;
+  }
+
+  if (
+    resolved !== candidate.tmdbId &&
+    (await isTmdbIdTaken(database, resolved, candidate.uid))
+  ) {
+    console.log(
+      `  TMDb ${resolved} already used by another movie: ${candidate.title ?? candidate.uid}`,
+    );
+    stats.tmdbIdTaken++;
+    return;
+  }
+
+  const details = await fetchTMDBMovieDetails(resolved, tmdbApiKey);
+  if (!details?.poster_path) {
+    console.log(`  No poster on TMDb: ${candidate.title ?? candidate.uid}`);
+    stats.noPosterOnTmdb++;
+    return;
+  }
+
+  const url = `${baseUrl}${size}${details.poster_path}`;
+  console.log(`  ${candidate.title ?? candidate.uid} -> ${url}`);
+  stats.postersSaved++;
+
+  if (dryRun) {
+    return;
+  }
+
+  if (resolved !== candidate.tmdbId) {
+    await database
+      .update(movies)
+      .set({tmdbId: resolved})
+      .where(eq(movies.uid, candidate.uid));
+  }
+
+  await database
+    .insert(posterUrls)
+    .values({
+      movieUid: candidate.uid,
+      url,
+      sourceType: 'tmdb',
+      isPrimary: 1,
+    })
+    .onConflictDoNothing();
+}
+
+async function resolveTmdbId(
+  candidate: Candidate,
+  tmdbApiKey: string,
+): Promise<number | undefined> {
+  if (candidate.tmdbId !== null) {
+    return candidate.tmdbId;
+  }
+
+  if (candidate.imdbId) {
+    const found = await findTMDBByImdbId(candidate.imdbId, tmdbApiKey);
+    if (found?.mediaType === 'movie') {
+      return found.tmdbId;
+    }
+
+    return undefined;
+  }
+
+  if (!candidate.title || candidate.year === null) {
+    return undefined;
+  }
+
+  const searchUrl = new URL(`${TMDB_API_BASE_URL}/search/movie`);
+  searchUrl.searchParams.set('api_key', tmdbApiKey);
+  searchUrl.searchParams.set('query', candidate.title);
+  searchUrl.searchParams.set('include_adult', 'false');
+
+  try {
+    const data = await fetchJsonWithRetry<{results: SearchResult[]}>(
+      searchUrl.toString(),
+    );
+    return pickStrictMatch(data.results ?? [], candidate.title, candidate.year);
+  } catch (error) {
+    console.error(`  Search failed for ${candidate.title}:`, error);
+    return undefined;
+  }
+}
+
+async function isTmdbIdTaken(
+  database: DatabaseClient,
+  tmdbId: number,
+  ownUid: string,
+): Promise<boolean> {
+  const [row] = await database
+    .select({uid: movies.uid})
+    .from(movies)
+    .where(eq(movies.tmdbId, tmdbId))
+    .limit(1);
+
+  return row !== undefined && row.uid !== ownUid;
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "scrapers:import-imdb-list": "pnpm --filter @shine/scrapers run import-imdb-list",
     "scrapers:availability-check": "pnpm --filter @shine/scrapers run availability-check",
     "scrapers:assign-imdb-ids": "pnpm --filter @shine/scrapers run assign-imdb-ids",
+    "scrapers:backfill-posters": "pnpm --filter @shine/scrapers run backfill-posters",
     "scripts:soft-delete-orphan-movies": "tsx scripts/soft-delete-orphan-movies.ts",
     "db:studio": "node scripts/setup-database-environment.cjs drizzle-kit studio",
     "db:generate": "node scripts/setup-database-environment.cjs drizzle-kit generate",


### PR DESCRIPTION
ポスターが1枚も登録されていない映画が344件あった（全6,854件中5%）。詳細ページや賞ページで「No Poster」の箱が出る。

- `scrapers:backfill-posters` を追加。TMDb IDがあればそのまま、無ければIMDb IDから、それも無ければタイトルと公開年で解決する
- タイトル照合は正規化した完全一致のみ（大文字小文字・発音記号・記号を無視）。年は候補の絞り込みではなく近さの判定に使い、同名候補が複数あれば年が近い方を選ぶ。**DBのyearは映画祭の開催年でTMDbの公開年と数年ずれる**ため、検索時に年で絞ると取りこぼす（In Old Chicago は開催年1937・公開1938）
- 他の映画が既に使っているTMDb IDは割り当てない
- 保存はw500。既存の `savePosterUrls` が原寸で保存していたのが、DBのポスターURLの88%が原寸だった原因

本番実行結果: 344件中80件にポスターを保存（欠落344→264件）。103件はTMDbにもポスターが無く、45件は解決できず、116件は別レコードが同じTMDb IDを使用（後述）。

**あわせて重複レコードが116件見つかった。** 例えば「Judas and the Black Messiah」は、開催年2020でIDもポスターも無くノミネーションも0件のレコードと、公開年2021でIMDb/TMDb ID・ポスター52枚・ノミネーション1件のレコードが別々に存在する。ノミネーションを持たない孤立レコードはDB全体で159件。このPRでは触っていない。