### PR TITLE
ノミネーションに紐づかない映画を削除する

### DIFF
--- a/apps/scrapers/package.json
+++ b/apps/scrapers/package.json
@@ -10,6 +10,7 @@
     "japan-academy-awards": "tsx src/japan-academy-awards-cli.ts",
     "assign-imdb-ids": "tsx src/assign-imdb-ids-cli.ts",
     "backfill-posters": "tsx src/backfill-posters-cli.ts",
+    "delete-orphan-movies": "tsx src/delete-orphan-movies-cli.ts",
     "import-imdb-list": "tsx src/import-imdb-list-cli.ts",
     "availability-check": "tsx src/availability-check-cli.ts",
     "japanese-translations": "tsx src/japanese-translations-cli.ts",

--- a/apps/scrapers/src/__tests__/delete-orphan-movies.test.ts
+++ b/apps/scrapers/src/__tests__/delete-orphan-movies.test.ts
@@ -1,0 +1,261 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {eq} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {deleteOrphanMovies, isSameFilm} from '../delete-orphan-movies';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+async function createTestEnvironment(): Promise<{
+  environment: Environment;
+  database: ReturnType<typeof getDatabase>;
+}> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-orphan-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+    TMDB_API_KEY: 'test-key',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+  await database
+    .insert(awardOrganizations)
+    .values({uid: 'org', name: 'Cannes Film Festival'});
+  await database
+    .insert(awardCategories)
+    .values({uid: 'cat', organizationUid: 'org', name: "Palme d'Or"});
+  await database
+    .insert(awardCeremonies)
+    .values({uid: 'ceremony', organizationUid: 'org', year: 2023});
+  return {environment, database};
+}
+
+async function seedMovie(
+  database: ReturnType<typeof getDatabase>,
+  values: {
+    uid: string;
+    title: string;
+    year?: number;
+    imdbId?: string;
+    nominated?: boolean;
+  },
+): Promise<void> {
+  await database
+    .insert(movies)
+    .values({uid: values.uid, year: values.year, imdbId: values.imdbId});
+  await database.insert(translations).values({
+    resourceType: 'movie_title',
+    resourceUid: values.uid,
+    languageCode: 'en',
+    content: values.title,
+    isDefault: 1,
+  });
+  if (values.nominated) {
+    await database.insert(nominations).values({
+      movieUid: values.uid,
+      ceremonyUid: 'ceremony',
+      categoryUid: 'cat',
+    });
+  }
+}
+
+describe('isSameFilm', () => {
+  it('タイトルが一致すれば同じ作品とみなす', () => {
+    expect(isSameFilm('The Class', 'The Class')).toBe(true);
+  });
+
+  it('表記ゆれを吸収する', () => {
+    expect(isSameFilm('Rashômon', 'Rashomon')).toBe(true);
+    expect(isSameFilm('Spider-Man', 'Spider Man')).toBe(true);
+  });
+
+  it('別の作品なら一致しない', () => {
+    expect(isSameFilm('The Class', 'Front of the Class')).toBe(false);
+  });
+
+  it('IMDb側が不明なら判定できない', () => {
+    expect(isSameFilm('The Class')).toBeUndefined();
+  });
+});
+
+const stubTmdb = (byImdbId: Record<string, string | undefined>) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      for (const [imdbId, title] of Object.entries(byImdbId)) {
+        if (url.includes(`/find/${imdbId}`)) {
+          return Response.json({
+            movie_results: title ? [{id: 1, title}] : [],
+            tv_results: [],
+          });
+        }
+      }
+
+      return new Response('nf', {status: 404});
+    }),
+  );
+};
+
+describe('deleteOrphanMovies', () => {
+  let environment: Environment;
+  let database: ReturnType<typeof getDatabase>;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('ノミネーションがある映画は削除しない', async () => {
+    await seedMovie(database, {uid: 'keep', title: 'Keeper', nominated: true});
+    stubTmdb({});
+
+    const stats = await deleteOrphanMovies({environment, throttleMs: 0});
+
+    expect(stats.candidates).toBe(0);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'keep'));
+    expect(movie.deletedAt).toBeNull();
+  });
+
+  it('ノミネーションが無い映画をソフト削除する', async () => {
+    await seedMovie(database, {uid: 'orphan', title: 'Lonely', year: 2020});
+    stubTmdb({});
+
+    const stats = await deleteOrphanMovies({environment, throttleMs: 0});
+
+    expect(stats.deleted).toBe(1);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'orphan'));
+    expect(movie.deletedAt).not.toBeNull();
+  });
+
+  it('IMDb IDが誤っている映画はIDも空にする', async () => {
+    await seedMovie(database, {
+      uid: 'orphan',
+      title: 'The Class',
+      year: 2008,
+      imdbId: 'tt1292594',
+    });
+    stubTmdb({tt1292594: 'Front of the Class'});
+
+    const stats = await deleteOrphanMovies({environment, throttleMs: 0});
+
+    expect(stats.misidentified).toBe(1);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'orphan'));
+    expect(movie.deletedAt).not.toBeNull();
+    expect(movie.imdbId).toBeNull();
+    expect(movie.tmdbId).toBeNull();
+  });
+
+  it('IMDb IDが正しい映画はIDを残したまま削除する', async () => {
+    await seedMovie(database, {
+      uid: 'orphan',
+      title: 'The Class',
+      year: 2008,
+      imdbId: 'tt1068646',
+    });
+    stubTmdb({tt1068646: 'The Class'});
+
+    const stats = await deleteOrphanMovies({environment, throttleMs: 0});
+
+    expect(stats.misidentified).toBe(0);
+    expect(stats.deleted).toBe(1);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'orphan'));
+    expect(movie.deletedAt).not.toBeNull();
+    expect(movie.imdbId).toBe('tt1068646');
+  });
+
+  it('IMDb側が確認できない映画はIDを残す', async () => {
+    await seedMovie(database, {
+      uid: 'orphan',
+      title: 'Obscure',
+      year: 1950,
+      imdbId: 'tt0000001',
+    });
+    stubTmdb({tt0000001: undefined});
+
+    const stats = await deleteOrphanMovies({environment, throttleMs: 0});
+
+    expect(stats.unverified).toBe(1);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'orphan'));
+    expect(movie.imdbId).toBe('tt0000001');
+    expect(movie.deletedAt).not.toBeNull();
+  });
+
+  it('既にソフト削除済みの映画は対象にしない', async () => {
+    await seedMovie(database, {uid: 'gone', title: 'Gone'});
+    await database
+      .update(movies)
+      .set({deletedAt: 1000})
+      .where(eq(movies.uid, 'gone'));
+    stubTmdb({});
+
+    const stats = await deleteOrphanMovies({environment, throttleMs: 0});
+
+    expect(stats.candidates).toBe(0);
+  });
+
+  it('dryRunでは書き込まない', async () => {
+    await seedMovie(database, {uid: 'orphan', title: 'Lonely', year: 2020});
+    stubTmdb({});
+
+    const stats = await deleteOrphanMovies({
+      environment,
+      throttleMs: 0,
+      dryRun: true,
+    });
+
+    expect(stats.deleted).toBe(1);
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'orphan'));
+    expect(movie.deletedAt).toBeNull();
+  });
+
+  it('limitで件数を絞る', async () => {
+    await seedMovie(database, {uid: 'a', title: 'A'});
+    await seedMovie(database, {uid: 'b', title: 'B'});
+    stubTmdb({});
+
+    const stats = await deleteOrphanMovies({
+      environment,
+      throttleMs: 0,
+      limit: 1,
+    });
+
+    expect(stats.candidates).toBe(1);
+    expect(stats.deleted).toBe(1);
+  });
+});

--- a/apps/scrapers/src/delete-orphan-movies-cli.ts
+++ b/apps/scrapers/src/delete-orphan-movies-cli.ts
@@ -1,0 +1,85 @@
+/**
+ * ノミネーションに紐づかない映画をソフト削除するCLI
+ */
+import {Command, InvalidArgumentError} from 'commander';
+import {
+  assertDatabaseEnvironment,
+  buildEnvironment,
+  loadEnvironmentFiles,
+} from './common/environment';
+import {deleteOrphanMovies} from './delete-orphan-movies';
+
+loadEnvironmentFiles();
+const environment = buildEnvironment(process.env);
+
+function parsePositiveInteger(label: string) {
+  return (value: string): number => {
+    const parsed = Number.parseInt(value, 10);
+
+    if (Number.isNaN(parsed) || parsed < 0) {
+      throw new InvalidArgumentError(
+        `${label}は0以上の整数で指定してください。`,
+      );
+    }
+
+    return parsed;
+  };
+}
+
+const program = new Command();
+
+program
+  .name('delete-orphan-movies')
+  .description(
+    [
+      'ノミネーションが1件も無い映画をソフト削除します。',
+      'IMDb IDを持つ映画はIMDb側のタイトルと突き合わせ、',
+      '別作品を指していた場合はunique制約を解放するためIDも空にします。',
+    ].join('\n'),
+  )
+  .option('--limit <count>', '処理件数の上限', parsePositiveInteger('limit'))
+  .option('--dry-run', '実際の削除は行わず、対象と判定のみ表示', false)
+  .option(
+    '--throttle <ms>',
+    'IMDb照合リクエスト間の待機ミリ秒 (デフォルト: 300)',
+    parsePositiveInteger('throttle'),
+    300,
+  )
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrapers:delete-orphan-movies --dry-run
+  pnpm run scrapers:delete-orphan-movies --limit 20
+  pnpm run scrapers:delete-orphan-movies
+`,
+  )
+  .action(
+    async (options: {limit?: number; dryRun: boolean; throttle: number}) => {
+      assertDatabaseEnvironment(environment);
+
+      if (!environment.TMDB_API_KEY) {
+        console.warn(
+          '警告: TMDB_API_KEY が設定されていません。IMDbとの突き合わせはスキップされます。',
+        );
+      }
+
+      const stats = await deleteOrphanMovies({
+        environment,
+        dryRun: options.dryRun,
+        limit: options.limit,
+        throttleMs: options.throttle,
+      });
+
+      if (stats.failed > 0) {
+        process.exitCode = 1;
+      }
+    },
+  );
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  console.error('削除処理中にエラーが発生しました:', error);
+  process.exitCode = 1;
+}

--- a/apps/scrapers/src/delete-orphan-movies.ts
+++ b/apps/scrapers/src/delete-orphan-movies.ts
@@ -1,0 +1,180 @@
+import {setTimeout as sleep} from 'node:timers/promises';
+import {and, eq, isNull, notInArray, sql} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {normalizeTitle} from './backfill-posters';
+import {fetchJsonWithRetry} from './common/fetch-utilities';
+
+export type OrphanDeletionStats = {
+  candidates: number;
+  deleted: number;
+  misidentified: number;
+  unverified: number;
+  failed: number;
+};
+
+/**
+ * DBのタイトルとIMDb(TMDb経由)のタイトルが同じ作品を指しているか。
+ * IMDb側が確認できないときはundefined
+ */
+export function isSameFilm(
+  storedTitle: string,
+  imdbTitle?: string,
+): boolean | undefined {
+  if (imdbTitle === undefined) {
+    return undefined;
+  }
+
+  return normalizeTitle(storedTitle) === normalizeTitle(imdbTitle);
+}
+
+type Orphan = {
+  uid: string;
+  imdbId: string | null;
+  year: number | null;
+  title: string | null;
+};
+
+export async function deleteOrphanMovies({
+  environment,
+  dryRun = false,
+  limit,
+  throttleMs = 300,
+}: {
+  environment: Environment;
+  dryRun?: boolean;
+  limit?: number;
+  throttleMs?: number;
+}): Promise<OrphanDeletionStats> {
+  const stats: OrphanDeletionStats = {
+    candidates: 0,
+    deleted: 0,
+    misidentified: 0,
+    unverified: 0,
+    failed: 0,
+  };
+
+  const database = getDatabase(environment);
+  const nominatedUids = database
+    .select({movieUid: nominations.movieUid})
+    .from(nominations);
+
+  const rows = await database
+    .select({
+      uid: movies.uid,
+      imdbId: movies.imdbId,
+      year: movies.year,
+      title: sql<string | null>`(
+        SELECT content FROM translations
+        WHERE translations.resource_uid = movies.uid
+          AND translations.resource_type = 'movie_title'
+        ORDER BY translations.is_default DESC
+        LIMIT 1
+      )`.as('title'),
+    })
+    .from(movies)
+    .where(
+      and(isNull(movies.deletedAt), notInArray(movies.uid, nominatedUids)),
+    );
+
+  const orphans = limit === undefined ? rows : rows.slice(0, limit);
+  stats.candidates = orphans.length;
+
+  if (orphans.length === 0) {
+    console.log('No orphan movies found.');
+    return stats;
+  }
+
+  console.log(
+    `${dryRun ? '[DRY RUN] ' : ''}Deleting ${orphans.length} movies with no nominations...`,
+  );
+
+  const deletedAt = Math.floor(Date.now() / 1000);
+
+  for (const orphan of orphans) {
+    try {
+      const verdict = await verifyOrphan(orphan, environment.TMDB_API_KEY);
+      if (verdict === 'misidentified') {
+        stats.misidentified++;
+      } else if (verdict === 'unverified') {
+        stats.unverified++;
+      }
+
+      console.log(
+        `  [${verdict}] ${orphan.title ?? orphan.uid} (${orphan.year ?? '?'}) ${orphan.imdbId ?? ''}`,
+      );
+      stats.deleted++;
+
+      if (dryRun) {
+        continue;
+      }
+
+      // 誤ったIMDb IDはunique制約を占有し続けるので手放す
+      await database
+        .update(movies)
+        .set(
+          verdict === 'misidentified'
+            ? {deletedAt, imdbId: sql`NULL`, tmdbId: sql`NULL`}
+            : {deletedAt},
+        )
+        .where(eq(movies.uid, orphan.uid));
+    } catch (error) {
+      console.error(`  Failed for ${orphan.uid}:`, error);
+      stats.failed++;
+    }
+
+    if (throttleMs > 0 && orphan.imdbId) {
+      await sleep(throttleMs);
+    }
+  }
+
+  console.log('\nDeletion summary:');
+  console.log(`  Candidates: ${stats.candidates}`);
+  console.log(`  Deleted: ${stats.deleted}`);
+  console.log(`  Misidentified (IDs cleared): ${stats.misidentified}`);
+  console.log(`  Unverified on IMDb: ${stats.unverified}`);
+  console.log(`  Failed: ${stats.failed}`);
+
+  return stats;
+}
+
+type Verdict = 'no-imdb-id' | 'matches-imdb' | 'misidentified' | 'unverified';
+
+async function verifyOrphan(
+  orphan: Orphan,
+  tmdbApiKey: string | undefined,
+): Promise<Verdict> {
+  if (!orphan.imdbId || !orphan.title || !tmdbApiKey) {
+    return 'no-imdb-id';
+  }
+
+  const imdbTitle = await fetchTitleByImdbId(orphan.imdbId, tmdbApiKey);
+  const same = isSameFilm(orphan.title, imdbTitle);
+  if (same === undefined) {
+    return 'unverified';
+  }
+
+  return same ? 'matches-imdb' : 'misidentified';
+}
+
+async function fetchTitleByImdbId(
+  imdbId: string,
+  tmdbApiKey: string,
+): Promise<string | undefined> {
+  const url = new URL(`https://api.themoviedb.org/3/find/${imdbId}`);
+  url.searchParams.set('api_key', tmdbApiKey);
+  url.searchParams.set('external_source', 'imdb_id');
+
+  try {
+    const data = await fetchJsonWithRetry<{
+      movie_results?: Array<{title?: string}>;
+      tv_results?: Array<{name?: string}>;
+    }>(url.toString());
+
+    return data.movie_results?.[0]?.title ?? data.tv_results?.[0]?.name;
+  } catch (error) {
+    console.error(`  IMDb lookup failed for ${imdbId}:`, error);
+    return undefined;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "scrapers:availability-check": "pnpm --filter @shine/scrapers run availability-check",
     "scrapers:assign-imdb-ids": "pnpm --filter @shine/scrapers run assign-imdb-ids",
     "scrapers:backfill-posters": "pnpm --filter @shine/scrapers run backfill-posters",
+    "scrapers:delete-orphan-movies": "pnpm --filter @shine/scrapers run delete-orphan-movies",
     "scripts:soft-delete-orphan-movies": "tsx scripts/soft-delete-orphan-movies.ts",
     "db:studio": "node scripts/setup-database-environment.cjs drizzle-kit studio",
     "db:generate": "node scripts/setup-database-environment.cjs drizzle-kit generate",


### PR DESCRIPTION
ノミネーションが1件も無い映画が159件あった。選出（ノミネーション単位の抽選）にも賞ページにも出ないが、検索とsitemapには残っていた。多くは同じ映画の重複レコードで、ゆるいタイトル照合で作られたもの。

- `scrapers:delete-orphan-movies` を追加。ノミネーション0件の映画をソフト削除する
- IMDb IDを持つものは**IMDb側のタイトルと突き合わせて**判定する。別作品を指していた場合はunique制約を解放するためIDも空にする

IMDb照合で分かったこと（誤ったIDが振られていた26件の例）:

| DBのタイトル | 振られていたIMDb ID | その IDの実体 |
|---|---|---|
| A Hero (2021) | tt13904268 | Police × Heroine Lovepatrina! Movie Version |
| The Past (2013) | tt2663482 | The Pastor and Mrs. Jones |
| The Class (2008) | tt1292594 | Front of the Class |
| Breath (2007) | tt0997204 | A Moment to Breath |

いずれも正しい方のレコード（IMDb/TMDb ID・ポスター・ノミネーションを持つ）が別に存在する。

本番実行結果: 159件を削除（有効な映画 6,854→6,695件）。うち26件はIDも解放。ノミネーションを持つ映画の巻き添えは0件。削除済みの詳細ページは404を返し、検索からも消えたことを確認済み。