### PR TITLE
Wikidataから日本語タイトルを取得する

### DIFF
--- a/apps/scrapers/package.json
+++ b/apps/scrapers/package.json
@@ -14,6 +14,7 @@
     "import-imdb-list": "tsx src/import-imdb-list-cli.ts",
     "availability-check": "tsx src/availability-check-cli.ts",
     "japanese-translations": "tsx src/japanese-translations-cli.ts",
+    "wikidata-japanese-titles": "tsx src/wikidata-japanese-titles-cli.ts",
     "cannes-film-festival": "tsx src/cannes-film-festival-cli.ts",
     "venice-film-festival": "tsx src/venice-film-festival-cli.ts",
     "berlin-film-festival": "tsx src/berlin-film-festival-cli.ts",

--- a/apps/scrapers/src/__tests__/wikidata-japanese-titles.test.ts
+++ b/apps/scrapers/src/__tests__/wikidata-japanese-titles.test.ts
@@ -1,0 +1,357 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {and, eq} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  buildSparqlQuery,
+  cleanWikidataLabel,
+  importJapaneseTitlesFromWikidata,
+  parseSparqlResponse,
+} from '../wikidata-japanese-titles';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+async function createTestEnvironment(): Promise<{
+  environment: Environment;
+  database: ReturnType<typeof getDatabase>;
+}> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-wikidata-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+  return {environment, database};
+}
+
+async function seedMovie(
+  database: ReturnType<typeof getDatabase>,
+  values: {uid: string; imdbId?: string; enTitle: string; jaTitle?: string},
+): Promise<void> {
+  await database
+    .insert(movies)
+    .values({uid: values.uid, imdbId: values.imdbId, year: 1950});
+  await database.insert(translations).values({
+    resourceType: 'movie_title',
+    resourceUid: values.uid,
+    languageCode: 'en',
+    content: values.enTitle,
+    isDefault: 1,
+  });
+  if (values.jaTitle) {
+    await database.insert(translations).values({
+      resourceType: 'movie_title',
+      resourceUid: values.uid,
+      languageCode: 'ja',
+      content: values.jaTitle,
+    });
+  }
+}
+
+function sparqlResponse(pairs: Array<[string, string]>) {
+  return {
+    results: {
+      bindings: pairs.map(([imdb, label]) => ({
+        imdb: {value: imdb},
+        jaLabel: {value: label},
+      })),
+    },
+  };
+}
+
+describe('buildSparqlQuery', () => {
+  it('渡したIMDb IDをすべて含む', () => {
+    const query = buildSparqlQuery(['tt0042876', 'tt0043338']);
+    expect(query).toContain('"tt0042876"');
+    expect(query).toContain('"tt0043338"');
+  });
+
+  it('IMDb IDのプロパティで引く', () => {
+    expect(buildSparqlQuery(['tt0042876'])).toContain('wdt:P345');
+  });
+
+  it('日本語ラベルに絞る', () => {
+    expect(buildSparqlQuery(['tt0042876'])).toContain('"ja"');
+  });
+
+  it('IMDb ID形式でないものは問い合わせに含めない', () => {
+    const query = buildSparqlQuery(['tt0042876', 'not-an-id', '"; DROP']);
+    expect(query).toContain('"tt0042876"');
+    expect(query).not.toContain('not-an-id');
+    expect(query).not.toContain('DROP');
+  });
+});
+
+describe('cleanWikidataLabel', () => {
+  it('曖昧さ回避の「(映画)」を落とす', () => {
+    expect(cleanWikidataLabel('ミュージック・マン (映画)')).toBe(
+      'ミュージック・マン',
+    );
+  });
+
+  it('年つきの曖昧さ回避も落とす', () => {
+    expect(cleanWikidataLabel('タキシード (1986年の映画)')).toBe('タキシード');
+  });
+
+  it('全角括弧にも対応する', () => {
+    expect(cleanWikidataLabel('オテロ（1986年の映画）')).toBe('オテロ');
+  });
+
+  it('映画と無関係な括弧は残す', () => {
+    expect(cleanWikidataLabel('ヱヴァンゲリヲン新劇場版:序 (前編)')).toBe(
+      'ヱヴァンゲリヲン新劇場版:序 (前編)',
+    );
+  });
+
+  it('タイトル途中の括弧は残す', () => {
+    expect(cleanWikidataLabel('恋する惑星 (映画) の続編')).toBe(
+      '恋する惑星 (映画) の続編',
+    );
+  });
+});
+
+describe('parseSparqlResponse', () => {
+  it('IMDb IDと日本語ラベルの対応を返す', () => {
+    const result = parseSparqlResponse(
+      sparqlResponse([['tt0042876', '羅生門']]),
+    );
+    expect(result.get('tt0042876')).toBe('羅生門');
+  });
+
+  it('日本語文字を含まないラベルは捨てる', () => {
+    const result = parseSparqlResponse(
+      sparqlResponse([['tt0042876', 'Rashomon']]),
+    );
+    expect(result.has('tt0042876')).toBe(false);
+  });
+
+  it('曖昧さ回避の接尾辞を落として保存する', () => {
+    const result = parseSparqlResponse(
+      sparqlResponse([['tt0056262', 'ミュージック・マン (映画)']]),
+    );
+    expect(result.get('tt0056262')).toBe('ミュージック・マン');
+  });
+
+  it('接尾辞を落とすと日本語が残らないラベルは捨てる', () => {
+    const result = parseSparqlResponse(
+      sparqlResponse([['tt0000001', 'Summer of 85 (映画)']]),
+    );
+    expect(result.has('tt0000001')).toBe(false);
+  });
+
+  it('前後の空白を落とす', () => {
+    const result = parseSparqlResponse(
+      sparqlResponse([['tt0042876', '  羅生門  ']]),
+    );
+    expect(result.get('tt0042876')).toBe('羅生門');
+  });
+
+  it('空の結果でも壊れない', () => {
+    expect(parseSparqlResponse(sparqlResponse([])).size).toBe(0);
+    expect(parseSparqlResponse({}).size).toBe(0);
+  });
+});
+
+const stubWikidata = (pairs: Array<[string, string]>) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => Response.json(sparqlResponse(pairs))),
+  );
+};
+
+async function japaneseTitleOf(
+  database: ReturnType<typeof getDatabase>,
+  uid: string,
+): Promise<string | undefined> {
+  const [row] = await database
+    .select()
+    .from(translations)
+    .where(
+      and(
+        eq(translations.resourceUid, uid),
+        eq(translations.resourceType, 'movie_title'),
+        eq(translations.languageCode, 'ja'),
+      ),
+    );
+  return row?.content;
+}
+
+describe('importJapaneseTitlesFromWikidata', () => {
+  let environment: Environment;
+  let database: ReturnType<typeof getDatabase>;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('邦題が無い映画に保存する', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      imdbId: 'tt0042876',
+      enTitle: 'Rashomon',
+    });
+    stubWikidata([['tt0042876', '羅生門']]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+    });
+
+    expect(stats.saved).toBe(1);
+    expect(await japaneseTitleOf(database, 'm1')).toBe('羅生門');
+  });
+
+  it('ローマ字のまま保存されている邦題を置き換える', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      imdbId: 'tt0042876',
+      enTitle: 'Rashomon',
+      jaTitle: 'Rashômon',
+    });
+    stubWikidata([['tt0042876', '羅生門']]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+    });
+
+    expect(stats.replaced).toBe(1);
+    expect(await japaneseTitleOf(database, 'm1')).toBe('羅生門');
+  });
+
+  it('既に日本語の邦題がある映画は対象にしない', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      imdbId: 'tt0042876',
+      enTitle: 'Rashomon',
+      jaTitle: '羅生門',
+    });
+    stubWikidata([['tt0042876', '別のタイトル']]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+    });
+
+    expect(stats.candidates).toBe(0);
+    expect(await japaneseTitleOf(database, 'm1')).toBe('羅生門');
+  });
+
+  it('IMDb IDが無い映画は対象にしない', async () => {
+    await seedMovie(database, {uid: 'm1', enTitle: 'No Id'});
+    stubWikidata([]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+    });
+
+    expect(stats.candidates).toBe(0);
+  });
+
+  it('soft-deletedの映画は対象にしない', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      imdbId: 'tt0042876',
+      enTitle: 'Rashomon',
+    });
+    await database
+      .update(movies)
+      .set({deletedAt: 1000})
+      .where(eq(movies.uid, 'm1'));
+    stubWikidata([['tt0042876', '羅生門']]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+    });
+
+    expect(stats.candidates).toBe(0);
+  });
+
+  it('Wikidataに無い映画は何も書かない', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      imdbId: 'tt0042876',
+      enTitle: 'Obscure',
+    });
+    stubWikidata([]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+    });
+
+    expect(stats.saved).toBe(0);
+    expect(stats.notFound).toBe(1);
+    expect(await japaneseTitleOf(database, 'm1')).toBeUndefined();
+  });
+
+  it('バッチに分けて問い合わせる', async () => {
+    for (let index = 0; index < 5; index++) {
+      await seedMovie(database, {
+        uid: `m${index}`,
+        imdbId: `tt000000${index}`,
+        enTitle: `Film ${index}`,
+      });
+    }
+
+    const fetchMock = vi.fn(async () => Response.json(sparqlResponse([])));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+      batchSize: 2,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('dryRunでは書き込まない', async () => {
+    await seedMovie(database, {
+      uid: 'm1',
+      imdbId: 'tt0042876',
+      enTitle: 'Rashomon',
+    });
+    stubWikidata([['tt0042876', '羅生門']]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+      dryRun: true,
+    });
+
+    expect(stats.saved).toBe(1);
+    expect(await japaneseTitleOf(database, 'm1')).toBeUndefined();
+  });
+
+  it('limitで件数を絞る', async () => {
+    await seedMovie(database, {uid: 'm1', imdbId: 'tt0000001', enTitle: 'A'});
+    await seedMovie(database, {uid: 'm2', imdbId: 'tt0000002', enTitle: 'B'});
+    stubWikidata([]);
+
+    const stats = await importJapaneseTitlesFromWikidata({
+      environment,
+      throttleMs: 0,
+      limit: 1,
+    });
+
+    expect(stats.candidates).toBe(1);
+  });
+});

--- a/apps/scrapers/src/wikidata-japanese-titles-cli.ts
+++ b/apps/scrapers/src/wikidata-japanese-titles-cli.ts
@@ -1,0 +1,91 @@
+/**
+ * Wikidataから日本語タイトルを取得するCLI
+ */
+import {Command, InvalidArgumentError} from 'commander';
+import {
+  assertDatabaseEnvironment,
+  buildEnvironment,
+  loadEnvironmentFiles,
+} from './common/environment';
+import {importJapaneseTitlesFromWikidata} from './wikidata-japanese-titles';
+
+loadEnvironmentFiles();
+const environment = buildEnvironment(process.env);
+
+function parsePositiveInteger(label: string) {
+  return (value: string): number => {
+    const parsed = Number.parseInt(value, 10);
+
+    if (Number.isNaN(parsed) || parsed < 0) {
+      throw new InvalidArgumentError(
+        `${label}は0以上の整数で指定してください。`,
+      );
+    }
+
+    return parsed;
+  };
+}
+
+const program = new Command();
+
+program
+  .name('wikidata-japanese-titles')
+  .description(
+    [
+      'IMDb ID (Wikidataのプロパティ P345) を手がかりに、',
+      'Wikidataの日本語ラベルを邦題として保存します。',
+      '邦題が無い映画に加えて、原題がそのまま ja として',
+      '保存されている映画も対象にします。',
+    ].join('\n'),
+  )
+  .option('--limit <count>', '処理件数の上限', parsePositiveInteger('limit'))
+  .option(
+    '--batch-size <count>',
+    '1回のSPARQLで引くIMDb IDの数 (デフォルト: 50)',
+    parsePositiveInteger('batch-size'),
+    50,
+  )
+  .option('--dry-run', '実際の書き込みは行わず、取得結果のみ表示', false)
+  .option(
+    '--throttle <ms>',
+    'バッチ間の待機ミリ秒 (デフォルト: 1000)',
+    parsePositiveInteger('throttle'),
+    1000,
+  )
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrapers:wikidata-japanese-titles --dry-run --limit 50
+  pnpm run scrapers:wikidata-japanese-titles
+`,
+  )
+  .action(
+    async (options: {
+      limit?: number;
+      batchSize: number;
+      dryRun: boolean;
+      throttle: number;
+    }) => {
+      assertDatabaseEnvironment(environment);
+
+      const stats = await importJapaneseTitlesFromWikidata({
+        environment,
+        dryRun: options.dryRun,
+        limit: options.limit,
+        batchSize: options.batchSize,
+        throttleMs: options.throttle,
+      });
+
+      if (stats.failed > 0) {
+        process.exitCode = 1;
+      }
+    },
+  );
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  console.error('取得処理中にエラーが発生しました:', error);
+  process.exitCode = 1;
+}

--- a/apps/scrapers/src/wikidata-japanese-titles.ts
+++ b/apps/scrapers/src/wikidata-japanese-titles.ts
@@ -1,0 +1,239 @@
+import {setTimeout as sleep} from 'node:timers/promises';
+import {hasJapaneseText} from '@shine/availability';
+import {and, eq, isNotNull, isNull, sql} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {translations} from '@shine/database/schema/translations';
+import {fetchJsonWithRetry} from './common/fetch-utilities';
+
+const SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
+const USER_AGENT = 'shine-film.com movie database (https://shine-film.com)';
+const DEFAULT_BATCH_SIZE = 50;
+const IMDB_ID_PATTERN = /^tt\d+$/;
+
+export type WikidataImportStats = {
+  candidates: number;
+  saved: number;
+  replaced: number;
+  notFound: number;
+  failed: number;
+};
+
+type SparqlResponse = {
+  results?: {
+    bindings?: Array<{
+      imdb?: {value?: string};
+      jaLabel?: {value?: string};
+    }>;
+  };
+};
+
+export function buildSparqlQuery(imdbIds: string[]): string {
+  const values = imdbIds
+    .filter(id => IMDB_ID_PATTERN.test(id))
+    .map(id => `"${id}"`)
+    .join(' ');
+
+  return `SELECT ?imdb ?jaLabel WHERE {
+  VALUES ?imdb { ${values} }
+  ?item wdt:P345 ?imdb.
+  ?item rdfs:label ?jaLabel.
+  FILTER(LANG(?jaLabel) = "ja")
+}`;
+}
+
+/** Wikidataのラベルは同名作品を区別するため「(映画)」等が付くことがある */
+export function cleanWikidataLabel(label: string): string {
+  return label.replace(/\s*[（(][^（()）]*映画[^（()）]*[）)]\s*$/, '').trim();
+}
+
+export function parseSparqlResponse(
+  response: SparqlResponse,
+): Map<string, string> {
+  const titles = new Map<string, string>();
+
+  for (const binding of response.results?.bindings ?? []) {
+    const imdbId = binding.imdb?.value;
+    const label = binding.jaLabel?.value;
+    if (!imdbId || !label) {
+      continue;
+    }
+
+    const cleaned = cleanWikidataLabel(label);
+    if (!cleaned || !hasJapaneseText(cleaned)) {
+      continue;
+    }
+
+    titles.set(imdbId, cleaned);
+  }
+
+  return titles;
+}
+
+async function fetchBatch(imdbIds: string[]): Promise<Map<string, string>> {
+  const url = `${SPARQL_ENDPOINT}?format=json&query=${encodeURIComponent(
+    buildSparqlQuery(imdbIds),
+  )}`;
+
+  const response = await fetchJsonWithRetry<SparqlResponse>(url, {
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'application/sparql-results+json',
+    },
+  });
+
+  return parseSparqlResponse(response);
+}
+
+type Candidate = {
+  uid: string;
+  imdbId: string;
+  existingJa: string | undefined;
+};
+
+export async function importJapaneseTitlesFromWikidata({
+  environment,
+  dryRun = false,
+  limit,
+  batchSize = DEFAULT_BATCH_SIZE,
+  throttleMs = 1000,
+}: {
+  environment: Environment;
+  dryRun?: boolean;
+  limit?: number;
+  batchSize?: number;
+  throttleMs?: number;
+}): Promise<WikidataImportStats> {
+  const stats: WikidataImportStats = {
+    candidates: 0,
+    saved: 0,
+    replaced: 0,
+    notFound: 0,
+    failed: 0,
+  };
+
+  const database = getDatabase(environment);
+  const rows = await database
+    .select({
+      uid: movies.uid,
+      imdbId: movies.imdbId,
+      existingJa: sql<string | null>`(
+        SELECT content FROM translations
+        WHERE translations.resource_uid = movies.uid
+          AND translations.resource_type = 'movie_title'
+          AND translations.language_code = 'ja'
+        LIMIT 1
+      )`.as('existingJa'),
+    })
+    .from(movies)
+    .where(and(isNull(movies.deletedAt), isNotNull(movies.imdbId)));
+
+  // 邦題が無いものと、原題がそのままjaとして入っているものが対象
+  const allCandidates: Candidate[] = rows
+    .filter(row => row.existingJa === null || !hasJapaneseText(row.existingJa))
+    .map(row => ({
+      uid: row.uid,
+      imdbId: row.imdbId ?? '',
+      existingJa: row.existingJa ?? undefined,
+    }))
+    .filter(candidate => IMDB_ID_PATTERN.test(candidate.imdbId));
+
+  const candidates =
+    limit === undefined ? allCandidates : allCandidates.slice(0, limit);
+  stats.candidates = candidates.length;
+
+  if (candidates.length === 0) {
+    console.log('No movies need a Japanese title.');
+    return stats;
+  }
+
+  const batches = Math.ceil(candidates.length / batchSize);
+  console.log(
+    `${dryRun ? '[DRY RUN] ' : ''}Looking up ${candidates.length} movies on Wikidata (${batches} batches)...`,
+  );
+
+  for (let index = 0; index < candidates.length; index += batchSize) {
+    const batch = candidates.slice(index, index + batchSize);
+    const batchNumber = Math.floor(index / batchSize) + 1;
+
+    let titles: Map<string, string>;
+    try {
+      titles = await fetchBatch(batch.map(candidate => candidate.imdbId));
+    } catch (error) {
+      console.error(`  Batch ${batchNumber}/${batches} failed:`, error);
+      stats.failed += batch.length;
+      continue;
+    }
+
+    for (const candidate of batch) {
+      const title = titles.get(candidate.imdbId);
+      if (!title) {
+        stats.notFound++;
+        continue;
+      }
+
+      const isReplacement = candidate.existingJa !== undefined;
+      console.log(
+        `  ${candidate.imdbId}: ${isReplacement ? `${candidate.existingJa} -> ` : ''}${title}`,
+      );
+
+      if (isReplacement) {
+        stats.replaced++;
+      } else {
+        stats.saved++;
+      }
+
+      if (dryRun) {
+        continue;
+      }
+
+      await saveJapaneseTitle(database, candidate, title);
+    }
+
+    console.log(`  Batch ${batchNumber}/${batches} done`);
+
+    if (throttleMs > 0 && index + batchSize < candidates.length) {
+      await sleep(throttleMs);
+    }
+  }
+
+  console.log('\nWikidata import summary:');
+  console.log(`  Candidates: ${stats.candidates}`);
+  console.log(`  Saved (new): ${stats.saved}`);
+  console.log(`  Replaced (was romanized): ${stats.replaced}`);
+  console.log(`  Not on Wikidata: ${stats.notFound}`);
+  console.log(`  Failed: ${stats.failed}`);
+
+  return stats;
+}
+
+async function saveJapaneseTitle(
+  database: ReturnType<typeof getDatabase>,
+  candidate: Candidate,
+  title: string,
+): Promise<void> {
+  if (candidate.existingJa === undefined) {
+    await database
+      .insert(translations)
+      .values({
+        resourceType: 'movie_title',
+        resourceUid: candidate.uid,
+        languageCode: 'ja',
+        content: title,
+        isDefault: 0,
+      })
+      .onConflictDoNothing();
+    return;
+  }
+
+  await database
+    .update(translations)
+    .set({content: title})
+    .where(
+      and(
+        eq(translations.resourceUid, candidate.uid),
+        eq(translations.resourceType, 'movie_title'),
+        eq(translations.languageCode, 'ja'),
+      ),
+    );
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "scrapers:academy-awards": "pnpm --filter @shine/scrapers run academy-awards",
     "scrapers:japan-academy-awards": "pnpm --filter @shine/scrapers run japan-academy-awards",
     "scrapers:japanese-translations": "pnpm --filter @shine/scrapers run japanese-translations",
+    "scrapers:wikidata-japanese-titles": "pnpm --filter @shine/scrapers run wikidata-japanese-titles",
     "scrapers:cannes-film-festival": "pnpm --filter @shine/scrapers run cannes-film-festival",
     "scrapers:venice-film-festival": "pnpm --filter @shine/scrapers run venice-film-festival",
     "scrapers:berlin-film-festival": "pnpm --filter @shine/scrapers run berlin-film-festival",


### PR DESCRIPTION
既存の日本語タイトル取得は TMDb → ja.wikipedia の順で試すが、**Wikipedia側がIMDb IDでの全文検索という実装でほぼヒットしない**。実際に流すと0件が続く（試した2バッチとも0/15・0/12）。「自動取得はほぼ取り切った」という認識はこの経路を前提にしたものだった。

WikidataならIMDb ID（プロパティ P345）で直接引けて、1リクエストで50件まとめて取得できる。

- `scrapers:wikidata-japanese-titles` を追加。バッチSPARQLで日本語ラベルを取得する
- 対象は邦題が無い映画に加えて、**原題がそのまま ja として保存されている映画**も含む。『羅生門』が `Rashômon` で保存されていて日本語で検索できない状態だった
- Wikidataのラベルに付く「(映画)」「(1986年の映画)」等の曖昧さ回避は落とす。落とした結果日本語が残らないラベルは採用しない

本番実行結果: 3,298件を照会し、740件を新規保存、461件をローマ字表記から実際の邦題に置き換え。日本語文字を含む邦題を持つ映画は4,502件（有効な映画6,695件の67.2%）になった。

検索の改善（実行前はいずれも0件）:

| 検索語 | 結果 |
|---|---|
| 羅生門 | 羅生門 |
| 自転車泥棒 | 自転車泥棒 |
| 無防備都市 | 無防備都市 ほか1件 |
| 大地のうた | 大地のうた |

既存の `japanese-translations` CLI は残してある（TMDbのユーザー投稿翻訳を拾う経路として別物のため）。