### PR TITLE
キネマ旬報ベスト・テンを追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,16 +8,6 @@ SHINE is a comprehensive movie database project designed to be the world's most 
 
 ## Architecture
 
-pnpm workspace monorepo:
-
-- **apps/api/** – Hono-based REST API on Cloudflare Workers
-- **apps/front/** – React Router v7 frontend with SSR on Cloudflare Workers (Tailwind CSS v4)
-- **apps/scrapers/** – CLI-based data collection tools (Wikipedia, TMDb, Cannes, Academy Awards, Japan Academy Awards, availability checks)
-- **packages/database/** – Drizzle ORM schema, migrations, seeds, shared DB helpers
-- **packages/types/** – Shared domain types
-- **packages/utils/** – Cross-application utilities
-- **scripts/** – One-off DB maintenance scripts (run with tsx; type-checked and linted)
-
 Key design patterns:
 
 - Date-seeded movie selection (daily/weekly/monthly) with deterministic hash-based randomization, persisted in `movie_selections`
@@ -29,22 +19,6 @@ Key design patterns:
 ## Common Commands
 
 ```bash
-pnpm run dev              # API + front dev servers
-pnpm run api:dev          # API only (wrangler, loads .dev.vars)
-pnpm run front:dev        # front only
-
-# Scrapers (CLI, run locally)
-pnpm run scrapers:academy-awards
-pnpm run scrapers:cannes-film-festival [--year YYYY] [--winners-only]
-pnpm run scrapers:japanese-translations
-pnpm run scrapers:japan-academy-awards [--year YYYY] [--dry-run] [--seed]
-pnpm run scrapers:movie-import
-pnpm run scrapers:availability-check
-
-# Database (dev / prod)
-pnpm run db:studio / db:generate / db:migrate / db:push
-pnpm run db:studio:prod / db:generate:prod / db:migrate:prod / db:push:prod
-
 # Quality gates — run before every commit
 pnpm lint:fix && pnpm check   # eslint --fix + prettier --write, then lint + tsc build
 pnpm run test                 # vitest (node + jsdom projects)
@@ -53,23 +27,9 @@ pnpm run test:api / test:front / test:scrapers / test:database
 # Deploy (production only — dev environment is not used)
 pnpm run api:deploy:prod
 pnpm run front:deploy:prod
-
-# API docs
-pnpm run docs:validate   # redocly lint apps/api/openapi.yml (keep it green)
-pnpm run docs:serve
 ```
 
 ## Database Schema
-
-```
-movies ←→ translations (movie titles/descriptions)
-  ↓ 1:N     ↓ 1:N
-nominations  movie_selections (daily/weekly/monthly picks)
-  ↓ N:1         ↓ 1:N
-award_categories  poster_urls, reference_urls, article_links,
-  ↓ N:1           movie_availability_checks
-award_organizations → award_ceremonies
-```
 
 Important schema rules:
 
@@ -91,36 +51,26 @@ Cloudflare Workers: non-secret vars go in `wrangler.jsonc`/`wrangler.toml` `vars
 
 ## API Design
 
-- `GET /` – date-seeded selections (daily / weekly starting Friday / monthly), locale-aware
-- `GET /movies/:id` – movie details with translations
-- `POST /auth/login` – admin login (rate-limited per IP)
-- `POST /fetch-url-title` – URL title fetch (SSRF-guarded via `utils/url-safety.ts`)
-- `/admin/*` – JWT-protected admin CRUD (movies, ceremonies, nominations, posters, translations, TMDb sync, selection overrides). See `apps/api/openapi.yml` for the full list — keep it in sync with implementations
+- `apps/api/openapi.yml` documents the full endpoint list — keep it in sync with implementations (`pnpm run docs:validate` must stay green)
 - Edge caching via `EdgeCache` (`apps/api/src/utils/cache.ts`): cache keys include locale; writes use `set()`, reads use `get()`. When invalidating movie caches use `getMovieCacheKeysForAllLocales()`
 
 ## Frontend (React Router v7)
 
-- Public: `/` (selections), `/movies/:id`, `/search`, sitemaps, OG images (`/og/*`)
-- Admin (localStorage JWT): `/admin/login`, `/admin/movies`, `/admin/movies/:id`, `/admin/movies/selections`, `/admin/ceremonies`, `/admin/ceremonies/:uid`
+- Admin pages authenticate with a JWT held in localStorage
 - API URL resolution: always `resolveApiUrl(context)` from `@/lib/api` — never hand-cast `context.cloudflare`
 - Tests: Vitest + React Testing Library, co-located `*.test.tsx`
 
 ## Code Style and Conventions
 
-- TypeScript strict; ESLint flat config (js/ts recommended + unicorn + react-hooks) with `--max-warnings 0`; Prettier for formatting
 - Run `pnpm lint:fix && pnpm check` before every commit
 - No comments in code unless explicitly requested
 - API URL convention: base URLs without trailing slash, paths start with `/`
-- Follow existing patterns for DB queries (Drizzle) and API responses (Hono)
 
 ## Development Guidelines
 
 - TSエラーとLintエラーを絶対に無視するな
 - **Foreign keys / cascading deletes**: most tables lack `onDelete: 'cascade'`. Movie deletion order: article_links → movie_selections → nominations → reference_urls → translations → poster_urls → movies. When adding delete operations, grep the whole schema for FK references first
-- **Soft delete**: scrapers must skip soft-deleted movies when attaching data (see `isNull(movies.deletedAt)` filters and skip guards); do not "resurrect" them
-- **TMDb integration**: use the utilities in `apps/scrapers/src/common/tmdb-utilities.ts`; don't re-implement search/save logic per scraper
-- **Scraper CLIs**: load env via `loadScraperEnvironment()` / `loadEnvironmentFiles()` from `common/environment.ts` (never `config({path: '../.dev.vars'})` — cwd-relative paths escape the repo root); always check `Response.ok` when calling worker-style handlers from CLIs
+- **Scrapers**: `apps/scrapers/` 配下を編集する前に `new-scraper` スキルを読む（env読み込み・soft-deleteスキップ・TMDbユーティリティ・Wikipedia重複防止の必須パターン）
 - **Rate limiting / security**: public submission endpoints need rate limiting; external URL fetches must go through `validateExternalUrl()`
-- **Wikipedia scraping**: use duplicate-prevention `Set`s, multiple year-detection patterns, and handle text-format special cases (e.g. 2024 Japan Academy Awards)
 - **Favicon**: `apps/front/public/favicon.svg` is the master; `favicon.ico` and `apple-touch-icon.png` are rasterized from it
 - **Testing DB code**: prefer real libsql `file:` databases with `migrate()` over deep drizzle mocks

--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -1865,6 +1865,9 @@ components:
           format: uri
         isWinner:
           type: boolean
+        specialMention:
+          type: string
+          description: ランキング形式の賞で「N位」が入る
       required:
         - uid
         - isWinner

--- a/apps/api/src/services/__tests__/awards-service.test.ts
+++ b/apps/api/src/services/__tests__/awards-service.test.ts
@@ -86,6 +86,79 @@ async function seedMovie(
   }
 }
 
+async function seedKinemaJunpo(database: TestDatabase): Promise<void> {
+  await database
+    .insert(awardOrganizations)
+    .values({uid: 'org-kinejun', name: 'Kinema Junpo'});
+  await database.insert(awardCategories).values({
+    uid: 'cat-kj-japanese',
+    organizationUid: 'org-kinejun',
+    name: 'Best Japanese Film',
+  });
+  await database.insert(awardCeremonies).values({
+    uid: 'ceremony-kj-1956',
+    organizationUid: 'org-kinejun',
+    year: 1956,
+    ceremonyNumber: 30,
+  });
+  await seedMovie(database, 'movie-kj-1', 'Darkness at Noon');
+  await seedMovie(database, 'movie-kj-2', 'Yoru no kawa');
+  await seedMovie(database, 'movie-kj-3', 'Karakoram');
+  await database.insert(nominations).values([
+    {
+      movieUid: 'movie-kj-3',
+      ceremonyUid: 'ceremony-kj-1956',
+      categoryUid: 'cat-kj-japanese',
+      specialMention: '3位',
+    },
+    {
+      movieUid: 'movie-kj-1',
+      ceremonyUid: 'ceremony-kj-1956',
+      categoryUid: 'cat-kj-japanese',
+      isWinner: 1,
+      specialMention: '1位',
+    },
+    {
+      movieUid: 'movie-kj-2',
+      ceremonyUid: 'ceremony-kj-1956',
+      categoryUid: 'cat-kj-japanese',
+      specialMention: '2位',
+    },
+  ]);
+}
+
+describe('AwardsService.getAwardYear ランキング', () => {
+  let environment: Environment;
+  let database: TestDatabase;
+  let service: AwardsService;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+    service = new AwardsService(environment);
+    await seedKinemaJunpo(database);
+  });
+
+  it('順位の昇順で並べる', async () => {
+    const result = await service.getAwardYear('kinema-junpo-japanese', 1956);
+
+    expect(result?.movies.map(movie => movie.uid)).toEqual([
+      'movie-kj-1',
+      'movie-kj-2',
+      'movie-kj-3',
+    ]);
+  });
+
+  it('順位を返す', async () => {
+    const result = await service.getAwardYear('kinema-junpo-japanese', 1956);
+
+    expect(result?.movies.map(movie => movie.specialMention)).toEqual([
+      '1位',
+      '2位',
+      '3位',
+    ]);
+  });
+});
+
 describe('AwardsService.getAwardBySlug', () => {
   let environment: Environment;
   let database: TestDatabase;
@@ -530,6 +603,28 @@ describe('awardPageLinkForOrganizationName', () => {
 
   it('returns no slug for an organization without an award page', () => {
     expect(awardPageLinkForOrganizationName('Unknown Org')).toEqual({
+      slug: undefined,
+      hasYearPages: false,
+    });
+  });
+
+  it('picks the page matching the category when an organization has several', () => {
+    expect(
+      awardPageLinkForOrganizationName('Kinema Junpo', 'Best Foreign Film'),
+    ).toEqual({
+      slug: 'kinema-junpo-foreign',
+      hasYearPages: true,
+    });
+    expect(
+      awardPageLinkForOrganizationName('Kinema Junpo', 'Best Japanese Film'),
+    ).toEqual({
+      slug: 'kinema-junpo-japanese',
+      hasYearPages: true,
+    });
+  });
+
+  it('returns no slug when the category of a multi-page organization is unknown', () => {
+    expect(awardPageLinkForOrganizationName('Kinema Junpo')).toEqual({
       slug: undefined,
       hasYearPages: false,
     });

--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -13,18 +13,46 @@ import type {
   AwardYearGroup,
 } from '@shine/types';
 
-export function awardPageLinkForOrganizationName(organizationName: string): {
+export function awardPageLinkForOrganizationName(
+  organizationName: string,
+  categoryName?: string,
+): {
   slug: string | undefined;
   hasYearPages: boolean;
 } {
-  const definition = awardPageDefinitions.find(
+  const candidates = awardPageDefinitions.filter(
     entry => entry.organizationName === organizationName,
   );
+
+  const definition =
+    candidates.length > 1
+      ? candidates.find(
+          entry =>
+            categoryName !== undefined &&
+            entry.categoryNames.includes(categoryName),
+        )
+      : candidates[0];
 
   return {
     slug: definition?.slug,
     hasYearPages: definition?.grouping === 'year',
   };
+}
+
+const RANK_PATTERN = /^(\d+)位$/;
+
+function rankOf(entry: AwardMovieEntry): number {
+  const matched = RANK_PATTERN.exec(entry.specialMention ?? '');
+  return matched ? Number.parseInt(matched[1], 10) : Number.POSITIVE_INFINITY;
+}
+
+function compareAwardMovies(a: AwardMovieEntry, b: AwardMovieEntry): number {
+  const rankA = rankOf(a);
+  const rankB = rankOf(b);
+
+  return rankA === rankB
+    ? Number(b.isWinner) - Number(a.isWinner)
+    : rankA - rankB;
 }
 
 type AwardPageDefinition = {
@@ -86,6 +114,26 @@ export const awardPageDefinitions: AwardPageDefinition[] = [
     organization: '日本アカデミー賞',
     description:
       '日本アカデミー賞 最優秀作品賞の歴代受賞作と優秀作品賞ノミネートの一覧。',
+    grouping: 'year',
+  },
+  {
+    slug: 'kinema-junpo-japanese',
+    organizationName: 'Kinema Junpo',
+    categoryNames: ['Best Japanese Film'],
+    name: '日本映画ベスト・テン',
+    organization: 'キネマ旬報',
+    description:
+      'キネマ旬報ベスト・テン日本映画部門の歴代ベストワンと年別ランキングの一覧。',
+    grouping: 'year',
+  },
+  {
+    slug: 'kinema-junpo-foreign',
+    organizationName: 'Kinema Junpo',
+    categoryNames: ['Best Foreign Film'],
+    name: '外国映画ベスト・テン',
+    organization: 'キネマ旬報',
+    description:
+      'キネマ旬報ベスト・テン外国映画部門の歴代ベストワンと年別ランキングの一覧。',
     grouping: 'year',
   },
   {
@@ -237,6 +285,7 @@ export class AwardsService extends BaseService {
         movieUid: movies.uid,
         movieYear: movies.year,
         isWinner: nominations.isWinner,
+        specialMention: nominations.specialMention,
         ceremonyYear: awardCeremonies.year,
         ceremonyNumber: awardCeremonies.ceremonyNumber,
         jaTitle: sql<string | null>`(
@@ -302,13 +351,14 @@ export class AwardsService extends BaseService {
         movieYear: row.movieYear ?? undefined,
         posterUrl: row.posterUrl ?? undefined,
         isWinner: row.isWinner === 1,
+        specialMention: row.specialMention ?? undefined,
       });
     }
 
     const years = [...groups.values()].toSorted((a, b) => b.year - a.year);
     for (const group of years) {
       group.filmCount = group.movies.length;
-      group.movies.sort((a, b) => Number(b.isWinner) - Number(a.isWinner));
+      group.movies.sort(compareAwardMovies);
     }
 
     const base = {
@@ -351,6 +401,7 @@ export class AwardsService extends BaseService {
         movieUid: movies.uid,
         movieYear: movies.year,
         isWinner: nominations.isWinner,
+        specialMention: nominations.specialMention,
         ceremonyNumber: awardCeremonies.ceremonyNumber,
         jaTitle: sql<string | null>`(
           SELECT content FROM translations
@@ -405,10 +456,11 @@ export class AwardsService extends BaseService {
         movieYear: row.movieYear ?? undefined,
         posterUrl: row.posterUrl ?? undefined,
         isWinner: row.isWinner === 1,
+        specialMention: row.specialMention ?? undefined,
       });
     }
 
-    movieEntries.sort((a, b) => Number(b.isWinner) - Number(a.isWinner));
+    movieEntries.sort(compareAwardMovies);
 
     const yearRows = await this.database
       .selectDistinct({year: awardCeremonies.year})

--- a/apps/api/src/services/movies-service.ts
+++ b/apps/api/src/services/movies-service.ts
@@ -322,7 +322,10 @@ export class MoviesService extends BaseService {
           uid: nom.organizationUid,
           name: nom.organizationName,
           shortName: nom.organizationShortName ?? undefined,
-          ...awardPageLinkForOrganizationName(nom.organizationName),
+          ...awardPageLinkForOrganizationName(
+            nom.organizationName,
+            nom.categoryName,
+          ),
         },
       })),
       articleLinks: topArticles.map(article => ({

--- a/apps/api/src/services/selections-service.ts
+++ b/apps/api/src/services/selections-service.ts
@@ -541,7 +541,10 @@ export class SelectionsService extends BaseService {
           uid: nom.organizationUid,
           name: nom.organizationName,
           shortName: nom.organizationShortName ?? undefined,
-          ...awardPageLinkForOrganizationName(nom.organizationName),
+          ...awardPageLinkForOrganizationName(
+            nom.organizationName,
+            nom.categoryName,
+          ),
         },
       })),
       articleLinks: topArticles.map(article => ({

--- a/apps/front/app/routes/awards.$slug.$year.test.tsx
+++ b/apps/front/app/routes/awards.$slug.$year.test.tsx
@@ -174,6 +174,27 @@ describe('Award year page', () => {
       expect(screen.getByText('WINNER')).toBeInTheDocument();
     });
 
+    it('順位を持つ賞は順位を表示する', () => {
+      const award = {
+        ...mockAwardYear,
+        movies: [
+          {...mockAwardYear.movies[0], specialMention: '1位'},
+          {...mockAwardYear.movies[1], specialMention: '2位'},
+        ],
+      };
+
+      render(
+        <AwardYearPage
+          {...createComponentProperties(
+            cast<LoaderData>({award, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      expect(screen.getByText('1位')).toBeInTheDocument();
+      expect(screen.getByText('2位')).toBeInTheDocument();
+    });
+
     it('前年へのリンクを表示し、次年がなければ出さない', () => {
       render(
         <AwardYearPage

--- a/apps/front/app/routes/awards.$slug.$year.test.tsx
+++ b/apps/front/app/routes/awards.$slug.$year.test.tsx
@@ -195,6 +195,23 @@ describe('Award year page', () => {
       expect(screen.getByText('2位')).toBeInTheDocument();
     });
 
+    it('順位を持つ賞はWINNERバッジを出さない', () => {
+      const award = {
+        ...mockAwardYear,
+        movies: [{...mockAwardYear.movies[0], specialMention: '1位'}],
+      };
+
+      render(
+        <AwardYearPage
+          {...createComponentProperties(
+            cast<LoaderData>({award, locale: 'ja'}),
+          )}
+        />,
+      );
+
+      expect(screen.queryByText('WINNER')).not.toBeInTheDocument();
+    });
+
     it('前年へのリンクを表示し、次年がなければ出さない', () => {
       render(
         <AwardYearPage

--- a/apps/front/app/routes/awards.$slug.tsx
+++ b/apps/front/app/routes/awards.$slug.tsx
@@ -166,9 +166,11 @@ export function MovieRow({movie}: {movie: AwardMovieEntryData}) {
         <span className="flex-1 font-display font-extrabold text-base md:text-lg leading-tight">
           {title}
         </span>
-        <span className="font-mono text-[9px] bg-brand text-brand-on px-1.5 py-0.5 shrink-0">
-          WINNER
-        </span>
+        {!movie.specialMention && (
+          <span className="font-mono text-[9px] bg-brand text-brand-on px-1.5 py-0.5 shrink-0">
+            WINNER
+          </span>
+        )}
       </a>
     );
   }

--- a/apps/front/app/routes/awards.$slug.tsx
+++ b/apps/front/app/routes/awards.$slug.tsx
@@ -12,6 +12,7 @@ export type AwardMovieEntryData = {
   movieYear?: number;
   posterUrl?: string;
   isWinner: boolean;
+  specialMention?: string;
 };
 
 export type AwardYearGroupData = {
@@ -139,6 +140,14 @@ export async function loader({context, request, params}: Route.LoaderArgs) {
   return {award, locale};
 }
 
+function RankLabel({rank}: {rank: string}) {
+  return (
+    <span className="font-mono text-[10px] text-ink-muted w-7 shrink-0 tabular-nums">
+      {rank}
+    </span>
+  );
+}
+
 export function MovieRow({movie}: {movie: AwardMovieEntryData}) {
   const title = movie.title ?? 'Unknown Title';
 
@@ -147,6 +156,7 @@ export function MovieRow({movie}: {movie: AwardMovieEntryData}) {
       <a
         href={`/movies/${movie.uid}`}
         className="flex items-center gap-4 py-3 no-underline text-ink">
+        {movie.specialMention && <RankLabel rank={movie.specialMention} />}
         <PosterFrame
           posterUrl={movie.posterUrl}
           alt={`${title} poster`}
@@ -167,6 +177,7 @@ export function MovieRow({movie}: {movie: AwardMovieEntryData}) {
     <a
       href={`/movies/${movie.uid}`}
       className="flex items-center gap-4 py-1.5 no-underline text-ink">
+      {movie.specialMention && <RankLabel rank={movie.specialMention} />}
       <span className="flex-1 font-mono text-sm leading-tight">{title}</span>
     </a>
   );

--- a/apps/scrapers/package.json
+++ b/apps/scrapers/package.json
@@ -18,6 +18,7 @@
     "cannes-film-festival": "tsx src/cannes-film-festival-cli.ts",
     "venice-film-festival": "tsx src/venice-film-festival-cli.ts",
     "berlin-film-festival": "tsx src/berlin-film-festival-cli.ts",
+    "kinema-junpo": "tsx src/kinema-junpo-cli.ts",
     "sns-post": "tsx src/sns-post-cli.ts"
   },
   "dependencies": {

--- a/apps/scrapers/src/__tests__/kinema-junpo-titles.test.ts
+++ b/apps/scrapers/src/__tests__/kinema-junpo-titles.test.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {and, eq} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {describe, expect, it} from 'vitest';
+import {
+  backfillJapaneseTitles,
+  type KinemaJunpoEdition,
+  type ResolvedFilm,
+} from '../kinema-junpo';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+async function createTestEnvironment(): Promise<{
+  environment: Environment;
+  database: ReturnType<typeof getDatabase>;
+}> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-kinejun-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+  return {environment, database};
+}
+
+const edition: KinemaJunpoEdition = {
+  year: 1956,
+  japanese: [
+    {rank: 1, page: '真昼の暗黒', title: '真昼の暗黒'},
+    {rank: 2, page: '夜の河', title: '夜の河'},
+    {rank: 3, page: 'ビルマの竪琴', title: 'ビルマの竪琴'},
+    {rank: 4, page: 'Karakoram', title: 'Karakoram'},
+  ],
+  foreign: [],
+};
+
+const resolved = new Map<string, ResolvedFilm>([
+  ['真昼の暗黒', {imdbId: 'tt0049464'}],
+  ['夜の河', {imdbId: 'tt0049796'}],
+  ['ビルマの竪琴', {imdbId: 'tt0049012'}],
+  ['Karakoram', {imdbId: 'tt0359542'}],
+]);
+
+const japaneseTitleOf = async (
+  database: ReturnType<typeof getDatabase>,
+  movieUid: string,
+) => {
+  const [row] = await database
+    .select({content: translations.content})
+    .from(translations)
+    .where(
+      and(
+        eq(translations.resourceUid, movieUid),
+        eq(translations.resourceType, 'movie_title'),
+        eq(translations.languageCode, 'ja'),
+      ),
+    );
+  return row?.content;
+};
+
+describe('backfillJapaneseTitles', () => {
+  it('邦題が無い映画にWikipediaの表記を入れる', async () => {
+    const {environment, database} = await createTestEnvironment();
+    await database
+      .insert(movies)
+      .values({uid: 'movie-1', imdbId: 'tt0049464', year: 1956});
+
+    await backfillJapaneseTitles({environment, editions: [edition], resolved});
+
+    expect(await japaneseTitleOf(database, 'movie-1')).toBe('真昼の暗黒');
+  });
+
+  it('原題のまま保存されている邦題を置き換える', async () => {
+    const {environment, database} = await createTestEnvironment();
+    await database
+      .insert(movies)
+      .values({uid: 'movie-2', imdbId: 'tt0049796', year: 1956});
+    await database.insert(translations).values({
+      resourceType: 'movie_title',
+      resourceUid: 'movie-2',
+      languageCode: 'ja',
+      content: 'Yoru no kawa',
+      isDefault: 0,
+    });
+
+    await backfillJapaneseTitles({environment, editions: [edition], resolved});
+
+    expect(await japaneseTitleOf(database, 'movie-2')).toBe('夜の河');
+  });
+
+  it('日本語の邦題がすでにある映画は書き換えない', async () => {
+    const {environment, database} = await createTestEnvironment();
+    await database
+      .insert(movies)
+      .values({uid: 'movie-3', imdbId: 'tt0049012', year: 1956});
+    await database.insert(translations).values({
+      resourceType: 'movie_title',
+      resourceUid: 'movie-3',
+      languageCode: 'ja',
+      content: 'ビルマの竪琴 (1956年の映画)',
+      isDefault: 0,
+    });
+
+    await backfillJapaneseTitles({environment, editions: [edition], resolved});
+
+    expect(await japaneseTitleOf(database, 'movie-3')).toBe(
+      'ビルマの竪琴 (1956年の映画)',
+    );
+  });
+
+  it('日本語を含まない表記は邦題として使わない', async () => {
+    const {environment, database} = await createTestEnvironment();
+    await database
+      .insert(movies)
+      .values({uid: 'movie-4', imdbId: 'tt0359542', year: 1956});
+
+    await backfillJapaneseTitles({environment, editions: [edition], resolved});
+
+    expect(await japaneseTitleOf(database, 'movie-4')).toBeUndefined();
+  });
+
+  it('削除済みの映画には書き込まない', async () => {
+    const {environment, database} = await createTestEnvironment();
+    await database.insert(movies).values({
+      uid: 'movie-5',
+      imdbId: 'tt0049464',
+      year: 1956,
+      deletedAt: 1_700_000_000,
+    });
+
+    await backfillJapaneseTitles({environment, editions: [edition], resolved});
+
+    expect(await japaneseTitleOf(database, 'movie-5')).toBeUndefined();
+  });
+
+  it('更新件数を返す', async () => {
+    const {environment, database} = await createTestEnvironment();
+    await database
+      .insert(movies)
+      .values({uid: 'movie-6', imdbId: 'tt0049464', year: 1956});
+
+    const stats = await backfillJapaneseTitles({
+      environment,
+      editions: [edition],
+      resolved,
+    });
+
+    expect(stats.saved).toBe(1);
+  });
+});

--- a/apps/scrapers/src/__tests__/kinema-junpo.test.ts
+++ b/apps/scrapers/src/__tests__/kinema-junpo.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, it} from 'vitest';
+import {extractAwardEditions} from '../imdb-event-award';
 import {
   kinemaJunpoCeremonyNumber,
+  kinemaJunpoJapaneseConfig,
   parseKinemaJunpoWikitext,
+  selectTmdbMatch,
   toImdbEventData,
 } from '../kinema-junpo';
 
@@ -231,5 +234,87 @@ describe('toImdbEventData', () => {
     expect(categoryOf(1932, 'Best Japanese Film')?.nominations[1].notes).toBe(
       '2位',
     );
+  });
+});
+
+describe('selectTmdbMatch', () => {
+  const kokuho = {
+    id: 1,
+    title: '国宝',
+    original_title: '国宝',
+    release_date: '2025-06-06',
+    original_language: 'ja',
+  };
+
+  it('邦題・公開年・日本映画がそろった候補を返す', () => {
+    expect(selectTmdbMatch([kokuho], '国宝', 2025)).toEqual(kokuho);
+  });
+
+  it('前年公開のずれを許容する', () => {
+    expect(selectTmdbMatch([kokuho], '国宝', 2026)).toEqual(kokuho);
+  });
+
+  it('公開年が離れた候補を採用しない', () => {
+    expect(selectTmdbMatch([kokuho], '国宝', 2020)).toBeUndefined();
+  });
+
+  it('邦題が一致しない候補を採用しない', () => {
+    expect(selectTmdbMatch([kokuho], '国宝 序章', 2025)).toBeUndefined();
+  });
+
+  it('空白の違いを無視して一致させる', () => {
+    const spaced = {...kokuho, title: '国宝 '};
+    expect(selectTmdbMatch([spaced], '国宝', 2025)).toEqual(spaced);
+  });
+
+  it('日本映画でない候補を採用しない', () => {
+    expect(
+      selectTmdbMatch([{...kokuho, original_language: 'en'}], '国宝', 2025),
+    ).toBeUndefined();
+  });
+
+  it('同名の候補が複数あるときは採用しない', () => {
+    expect(
+      selectTmdbMatch([kokuho, {...kokuho, id: 2}], '国宝', 2025),
+    ).toBeUndefined();
+  });
+
+  it('原題側の一致も見る', () => {
+    const original = {...kokuho, title: 'Kokuho'};
+    expect(selectTmdbMatch([original], '国宝', 2025)).toEqual(original);
+  });
+});
+
+describe('extractAwardEditions', () => {
+  const editions = parseKinemaJunpoWikitext(sampleWikitext);
+  const resolved = new Map([
+    [
+      '大人の見る繪本 生れてはみたけれど',
+      {imdbId: 'tt0023139', englishTitle: 'I Was Born, But...'},
+    ],
+    [
+      '御誂次郎吉格子',
+      {imdbId: 'tt0023375', englishTitle: 'Jirokichi the Rat'},
+    ],
+  ]);
+  const data = toImdbEventData(editions, resolved);
+
+  it('順位をspecialMentionとして取り込む', () => {
+    const films =
+      extractAwardEditions(data, kinemaJunpoJapaneseConfig).find(
+        edition => edition.year === 1932,
+      )?.films ?? [];
+
+    expect(films.map(film => film.specialMention)).toEqual(['1位', '2位']);
+  });
+
+  it('specialMentionを使わない賞では順位を持たない', () => {
+    const films =
+      extractAwardEditions(data, {
+        ...kinemaJunpoJapaneseConfig,
+        useNotesAsSpecialMention: false,
+      }).find(edition => edition.year === 1932)?.films ?? [];
+
+    expect(films.every(film => film.specialMention === undefined)).toBe(true);
   });
 });

--- a/apps/scrapers/src/__tests__/kinema-junpo.test.ts
+++ b/apps/scrapers/src/__tests__/kinema-junpo.test.ts
@@ -283,6 +283,51 @@ describe('selectTmdbMatch', () => {
     const original = {...kokuho, title: 'Kokuho'};
     expect(selectTmdbMatch([original], '国宝', 2025)).toEqual(original);
   });
+
+  describe('外国映画', () => {
+    const laConfidential = {
+      id: 3,
+      title: 'L.A.コンフィデンシャル',
+      original_title: 'L.A. Confidential',
+      release_date: '1997-09-19',
+      original_language: 'en',
+    };
+
+    it('本国公開から日本公開までのずれを許容する', () => {
+      expect(
+        selectTmdbMatch([laConfidential], 'L.A.コンフィデンシャル', 1998, {
+          foreign: true,
+        }),
+      ).toEqual(laConfidential);
+    });
+
+    it('公開が古すぎる候補は採用しない', () => {
+      expect(
+        selectTmdbMatch([laConfidential], 'L.A.コンフィデンシャル', 2020, {
+          foreign: true,
+        }),
+      ).toBeUndefined();
+    });
+
+    it('日本映画を外国映画として採用しない', () => {
+      expect(
+        selectTmdbMatch(
+          [{...laConfidential, original_language: 'ja'}],
+          'L.A.コンフィデンシャル',
+          1998,
+          {foreign: true},
+        ),
+      ).toBeUndefined();
+    });
+
+    it('日本公開より後の作品は採用しない', () => {
+      expect(
+        selectTmdbMatch([laConfidential], 'L.A.コンフィデンシャル', 1995, {
+          foreign: true,
+        }),
+      ).toBeUndefined();
+    });
+  });
 });
 
 describe('extractAwardEditions', () => {

--- a/apps/scrapers/src/__tests__/kinema-junpo.test.ts
+++ b/apps/scrapers/src/__tests__/kinema-junpo.test.ts
@@ -1,0 +1,235 @@
+import {describe, expect, it} from 'vitest';
+import {
+  kinemaJunpoCeremonyNumber,
+  parseKinemaJunpoWikitext,
+  toImdbEventData,
+} from '../kinema-junpo';
+
+const sampleWikitext = `== キネマ旬報ベスト・テン ==
+本文。
+
+=== 1920年代 ===
+==== 第1回（1924年度） ====
+{{col|
+'''芸術的に最も優れた映画'''
+#[[巴里の女性]]（[[チャールズ・チャップリン]]監督）
+#[[結婚哲学]]（[[エルンスト・ルビッチ]]監督）
+|
+'''娯楽的に最も優れた映画'''
+#[[幌馬車 (1923年の映画)|幌馬車]]（[[ジェイムズ・クルーズ]]監督）
+#心なき女性（レックス・イングラム監督）
+}}
+
+==== 第9回（1932年度） ====
+{{col|
+'''日本映画ベスト・テン'''
+#[[大人の見る繪本 生れてはみたけれど|生れてはみたけれど]]（小津安二郎監督）
+#[[御誂次郎吉格子]]（伊藤大輔監督）<br />[[弥太郎笠]]（稲垣浩監督）
+# -
+#[[國士無双]]（[[伊丹万作]]監督）
+|
+'''外国映画ベスト・テン'''
+#[[自由を我等に]]（ルネ・クレール監督）
+}}
+
+==== 第20回（1946年度） ====
+{{col|
+'''日本映画'''
+#[[大曾根家の朝]]（[[木下惠介]]監督）
+|
+'''外国映画'''
+#[[我が道を往く]]（レオ・マッケリー監督）
+}}
+
+==== 第99回（2025年度） ====
+* 日本映画監督賞 [[李相日]]（『[[国宝 (映画)|国宝]]』）
+{{col|
+'''日本映画ベスト・テン'''
+#[[旅と日々]]（[[三宅唱]]監督）
+#[[敵 (小説)#映画|敵]]（吉田大八監督）|
+'''外国映画ベスト・テン'''
+#[[ワン・バトル・アフター・アナザー]]（ポール・トーマス・アンダーソン監督）
+}}
+'''読者選出日本映画ベスト・テン'''
+#[[国宝 (映画)|国宝]]（李相日監督）
+
+== 歴代1位 ==
+'''日本映画ベスト・テン'''
+#[[羅生門 (1950年の映画)|羅生門]]
+`;
+
+describe('kinemaJunpoCeremonyNumber', () => {
+  it('第1回は1924年度', () => {
+    expect(kinemaJunpoCeremonyNumber(1924)).toBe(1);
+  });
+
+  it('中断前の1942年度は第19回', () => {
+    expect(kinemaJunpoCeremonyNumber(1942)).toBe(19);
+  });
+
+  it('戦争で中断した1943〜1945年度は回次を持たない', () => {
+    expect(kinemaJunpoCeremonyNumber(1943)).toBeUndefined();
+    expect(kinemaJunpoCeremonyNumber(1945)).toBeUndefined();
+  });
+
+  it('再開した1946年度は第20回', () => {
+    expect(kinemaJunpoCeremonyNumber(1946)).toBe(20);
+  });
+
+  it('2025年度は第99回', () => {
+    expect(kinemaJunpoCeremonyNumber(2025)).toBe(99);
+  });
+
+  it('第1回より前は回次を持たない', () => {
+    expect(kinemaJunpoCeremonyNumber(1923)).toBeUndefined();
+  });
+});
+
+describe('parseKinemaJunpoWikitext', () => {
+  const editions = parseKinemaJunpoWikitext(sampleWikitext);
+  const editionOf = (year: number) =>
+    editions.find(edition => edition.year === year);
+
+  it('回ごとに分割する', () => {
+    expect(editions.map(edition => edition.year)).toEqual([
+      1924, 1932, 1946, 2025,
+    ]);
+  });
+
+  it('記事名と表示名を分けて取り込む', () => {
+    expect(editionOf(1932)?.japanese[0]).toEqual({
+      rank: 1,
+      page: '大人の見る繪本 生れてはみたけれど',
+      title: '生れてはみたけれど',
+    });
+  });
+
+  it('同順位の作品を同じ順位で取り込む', () => {
+    const second = editionOf(1932)?.japanese.filter(film => film.rank === 2);
+    expect(second?.map(film => film.title)).toEqual([
+      '御誂次郎吉格子',
+      '弥太郎笠',
+    ]);
+  });
+
+  it('空欄の順位を作品として数えない', () => {
+    expect(editionOf(1932)?.japanese.map(film => film.rank)).toEqual([
+      1, 2, 2, 4,
+    ]);
+  });
+
+  it('監督名のリンクを作品として取り込まない', () => {
+    const titles = editionOf(1932)?.japanese.map(film => film.title);
+    expect(titles).not.toContain('伊丹万作');
+  });
+
+  it('記事が存在しない作品は記事名を持たない', () => {
+    const film = editionOf(1924)?.foreign.find(
+      entry => entry.title === '心なき女性',
+    );
+    expect(film?.page).toBeUndefined();
+  });
+
+  it('セクションアンカー付きのリンクから記事名を取り出す', () => {
+    expect(editionOf(2025)?.japanese[1]).toEqual({
+      rank: 2,
+      page: '敵 (小説)',
+      title: '敵',
+    });
+  });
+
+  it('日本映画部門を持たない初期の回は外国映画だけを取り込む', () => {
+    expect(editionOf(1924)?.japanese).toEqual([]);
+    expect(editionOf(1924)?.foreign.map(film => film.title)).toEqual([
+      '巴里の女性',
+      '結婚哲学',
+      '幌馬車',
+      '心なき女性',
+    ]);
+  });
+
+  it('旧部門名を日本映画・外国映画に振り分ける', () => {
+    expect(editionOf(1946)?.japanese.map(film => film.title)).toEqual([
+      '大曾根家の朝',
+    ]);
+    expect(editionOf(1946)?.foreign.map(film => film.title)).toEqual([
+      '我が道を往く',
+    ]);
+  });
+
+  it('読者選出部門を取り込まない', () => {
+    expect(editionOf(2025)?.japanese.map(film => film.title)).toEqual([
+      '旅と日々',
+      '敵',
+    ]);
+  });
+
+  it('最終回のセクションを次の見出しで打ち切る', () => {
+    expect(
+      editionOf(2025)?.japanese.some(film => film.title === '羅生門'),
+    ).toBe(false);
+  });
+});
+
+describe('toImdbEventData', () => {
+  const editions = parseKinemaJunpoWikitext(sampleWikitext);
+  const resolved = new Map([
+    [
+      '大人の見る繪本 生れてはみたけれど',
+      {imdbId: 'tt0023139', englishTitle: 'I Was Born, But...'},
+    ],
+    [
+      '御誂次郎吉格子',
+      {imdbId: 'tt0023375', englishTitle: 'Jirokichi the Rat'},
+    ],
+    ['自由を我等に', {imdbId: 'tt0021785', englishTitle: 'À nous la liberté'}],
+  ]);
+  const data = toImdbEventData(editions, resolved);
+  const editionOf = (year: number) =>
+    data.editions.find(edition => edition.year === year);
+  const categoryOf = (year: number, name: string) =>
+    editionOf(year)?.targetAward[0].categories.find(
+      category => category.category === name,
+    );
+
+  it('IMDb IDを解決できた作品だけを取り込む', () => {
+    expect(
+      categoryOf(1932, 'Best Japanese Film')?.nominations.flatMap(
+        nomination => nomination.titles,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('1位を受賞として取り込む', () => {
+    const nominations =
+      categoryOf(1932, 'Best Japanese Film')?.nominations ?? [];
+    expect(nominations[0].isWinner).toBe(true);
+    expect(nominations[1].isWinner).toBe(false);
+  });
+
+  it('Wikidataの英語ラベルを原題として持つ', () => {
+    expect(
+      categoryOf(1932, 'Best Japanese Film')?.nominations[0].titles[0],
+    ).toEqual({
+      imdbId: 'tt0023139',
+      title: '生れてはみたけれど',
+      originalTitle: 'I Was Born, But...',
+    });
+  });
+
+  it('日本映画と外国映画を別カテゴリにする', () => {
+    expect(
+      categoryOf(1932, 'Best Foreign Film')?.nominations[0].titles[0].imdbId,
+    ).toBe('tt0021785');
+  });
+
+  it('解決できた作品が無い回を取り込まない', () => {
+    expect(editionOf(2025)).toBeUndefined();
+  });
+
+  it('順位を注記として残す', () => {
+    expect(categoryOf(1932, 'Best Japanese Film')?.nominations[1].notes).toBe(
+      '2位',
+    );
+  });
+});

--- a/apps/scrapers/src/imdb-event-award.ts
+++ b/apps/scrapers/src/imdb-event-award.ts
@@ -24,6 +24,8 @@ export type ImdbEventAwardConfig = {
   ceremonyNumber: (year: number) => number | undefined;
   isCompetitionCategory: (category: string | null) => boolean;
   minimumFilmsPerEdition: number;
+  /** ノミネーションのnotesをspecialMentionとして保存する */
+  useNotesAsSpecialMention?: boolean;
   winnerCorrections?: Array<{
     year: number;
     imdbId: string;
@@ -66,6 +68,7 @@ export type AwardFilm = {
   title: string | null;
   originalTitle: string | null;
   isWinner: boolean;
+  specialMention?: string;
 };
 
 export type AwardEdition = {
@@ -112,6 +115,10 @@ export function extractAwardEditions(
               title: title.title,
               originalTitle: title.originalTitle,
               isWinner: nomination.isWinner,
+              specialMention:
+                config.useNotesAsSpecialMention && nomination.notes
+                  ? nomination.notes
+                  : undefined,
             });
           }
         }
@@ -349,7 +356,11 @@ async function processEdition(
   }
 
   const existingNominations = await database
-    .select({movieUid: nominations.movieUid, isWinner: nominations.isWinner})
+    .select({
+      movieUid: nominations.movieUid,
+      isWinner: nominations.isWinner,
+      specialMention: nominations.specialMention,
+    })
     .from(nominations)
     .where(
       and(
@@ -358,7 +369,10 @@ async function processEdition(
       ),
     );
   const nominationsByMovieUid = new Map(
-    existingNominations.map(row => [row.movieUid, row.isWinner]),
+    existingNominations.map(row => [
+      row.movieUid,
+      {isWinner: row.isWinner, specialMention: row.specialMention},
+    ]),
   );
 
   for (const film of edition.films) {
@@ -538,38 +552,65 @@ async function ensureNomination(
   ceremonyUid: string,
   categoryUid: string,
   film: AwardFilm,
-  nominationsByMovieUid: Map<string, number>,
+  nominationsByMovieUid: Map<
+    string,
+    {isWinner: number; specialMention: string | null}
+  >,
 ): Promise<void> {
   const {database, stats} = context;
-  const existingIsWinner = nominationsByMovieUid.get(movieUid);
+  const existing = nominationsByMovieUid.get(movieUid);
+  const isWinner = film.isWinner ? 1 : 0;
 
-  if (existingIsWinner === undefined) {
+  if (existing === undefined) {
     await database
       .insert(nominations)
       .values({
         movieUid,
         ceremonyUid,
         categoryUid,
-        isWinner: film.isWinner ? 1 : 0,
+        isWinner,
+        specialMention: film.specialMention,
       })
       .onConflictDoNothing();
-    nominationsByMovieUid.set(movieUid, film.isWinner ? 1 : 0);
+    nominationsByMovieUid.set(movieUid, {
+      isWinner,
+      specialMention: film.specialMention ?? null, // eslint-disable-line unicorn/no-null -- DBのnullable列に合わせる
+    });
     stats.nominationsCreated++;
     return;
   }
 
-  if (film.isWinner && existingIsWinner === 0) {
-    await database
-      .update(nominations)
-      .set({isWinner: 1})
-      .where(
-        and(
-          eq(nominations.movieUid, movieUid),
-          eq(nominations.ceremonyUid, ceremonyUid),
-          eq(nominations.categoryUid, categoryUid),
-        ),
-      );
-    nominationsByMovieUid.set(movieUid, 1);
+  const promoteWinner = film.isWinner && existing.isWinner === 0;
+  const updateMention =
+    film.specialMention !== undefined &&
+    film.specialMention !== existing.specialMention;
+
+  if (!promoteWinner && !updateMention) {
+    return;
+  }
+
+  await database
+    .update(nominations)
+    .set({
+      ...(promoteWinner && {isWinner: 1}),
+      ...(updateMention && {specialMention: film.specialMention}),
+    })
+    .where(
+      and(
+        eq(nominations.movieUid, movieUid),
+        eq(nominations.ceremonyUid, ceremonyUid),
+        eq(nominations.categoryUid, categoryUid),
+      ),
+    );
+
+  nominationsByMovieUid.set(movieUid, {
+    isWinner: promoteWinner ? 1 : existing.isWinner,
+    specialMention: updateMention
+      ? (film.specialMention ?? null) // eslint-disable-line unicorn/no-null -- DBのnullable列に合わせる
+      : existing.specialMention,
+  });
+
+  if (promoteWinner) {
     stats.winnersUpdated++;
   }
 }

--- a/apps/scrapers/src/kinema-junpo-cli.ts
+++ b/apps/scrapers/src/kinema-junpo-cli.ts
@@ -1,0 +1,80 @@
+/**
+ * キネマ旬報ベスト・テン取り込みのCLIエントリーポイント
+ */
+import {Command, InvalidArgumentError} from 'commander';
+import {
+  assertDatabaseEnvironment,
+  buildEnvironment,
+  loadEnvironmentFiles,
+} from './common/environment';
+import {importKinemaJunpo} from './kinema-junpo';
+
+loadEnvironmentFiles();
+const environment = buildEnvironment(process.env);
+
+function parseYear(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+
+  if (Number.isNaN(parsed) || parsed < 1924) {
+    throw new InvalidArgumentError('yearは1924以上の整数で指定してください。');
+  }
+
+  return parsed;
+}
+
+function parseThrottle(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+
+  if (Number.isNaN(parsed) || parsed < 0) {
+    throw new InvalidArgumentError('throttleは0以上の整数で指定してください。');
+  }
+
+  return parsed;
+}
+
+const program = new Command();
+
+program
+  .name('kinema-junpo')
+  .description(
+    [
+      '日本語版Wikipediaの「キネマ旬報」からベスト・テンを取り込みます。',
+      '記事名からWikidataのIMDb ID (P345) を引いて映画を同定するため、',
+      'IMDb IDを持たない作品は取り込みません。',
+    ].join('\n'),
+  )
+  .option('--year <year>', '取り込む年度を1つに絞る', parseYear)
+  .option('--dry-run', '実際の書き込みは行わず、取得結果のみ表示', false)
+  .option('--throttle <ms>', 'TMDb呼び出し間の待機ミリ秒', parseThrottle, 300)
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrapers:kinema-junpo --dry-run
+  pnpm run scrapers:kinema-junpo --year 2025
+`,
+  );
+
+program.parse();
+
+const options = program.opts<{
+  year?: number;
+  dryRun: boolean;
+  throttle: number;
+}>();
+
+if (!options.dryRun) {
+  assertDatabaseEnvironment(environment);
+}
+
+const stats = await importKinemaJunpo({
+  environment,
+  dryRun: options.dryRun,
+  year: options.year,
+  throttleMs: options.throttle,
+});
+
+const failed = stats.japanese.failed + stats.foreign.failed;
+if (failed > 0) {
+  process.exitCode = 1;
+}

--- a/apps/scrapers/src/kinema-junpo.ts
+++ b/apps/scrapers/src/kinema-junpo.ts
@@ -1,5 +1,9 @@
 import {setTimeout as sleep} from 'node:timers/promises';
-import type {Environment} from '@shine/database';
+import {hasJapaneseText} from '@shine/availability';
+import {and, eq, inArray, isNull} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {movies} from '@shine/database/schema/movies';
+import {translations} from '@shine/database/schema/translations';
 import {buildUrl, fetchJsonWithRetry} from './common/fetch-utilities';
 import {fetchTMDBMovieDetails} from './common/tmdb-utilities';
 import {
@@ -479,6 +483,84 @@ export async function resolveJapaneseFilmsByTmdb(
   return resolved;
 }
 
+/** Wikipediaの表記は邦題として信頼できるので、TMDb由来の原題を上書きする */
+export async function backfillJapaneseTitles({
+  environment,
+  editions,
+  resolved,
+}: {
+  environment: Environment;
+  editions: KinemaJunpoEdition[];
+  resolved: Map<string, ResolvedFilm>;
+}): Promise<{saved: number; replaced: number}> {
+  const titleByImdbId = new Map<string, string>();
+  for (const edition of editions) {
+    for (const film of [...edition.japanese, ...edition.foreign]) {
+      const match = resolved.get(filmKey(film));
+      if (!match || !hasJapaneseText(film.title)) {
+        continue;
+      }
+
+      if (!titleByImdbId.has(match.imdbId)) {
+        titleByImdbId.set(match.imdbId, film.title);
+      }
+    }
+  }
+
+  const database = getDatabase(environment);
+  const stats = {saved: 0, replaced: 0};
+  const imdbIds = [...titleByImdbId.keys()];
+
+  for (let index = 0; index < imdbIds.length; index += BATCH_SIZE) {
+    const batch = imdbIds.slice(index, index + BATCH_SIZE);
+    const rows = await database
+      .select({uid: movies.uid, imdbId: movies.imdbId})
+      .from(movies)
+      .where(and(inArray(movies.imdbId, batch), isNull(movies.deletedAt)));
+
+    for (const row of rows) {
+      const title = row.imdbId ? titleByImdbId.get(row.imdbId) : undefined;
+      if (!title) {
+        continue;
+      }
+
+      const [existing] = await database
+        .select({uid: translations.uid, content: translations.content})
+        .from(translations)
+        .where(
+          and(
+            eq(translations.resourceUid, row.uid),
+            eq(translations.resourceType, 'movie_title'),
+            eq(translations.languageCode, 'ja'),
+          ),
+        )
+        .limit(1);
+
+      if (existing === undefined) {
+        await database.insert(translations).values({
+          resourceType: 'movie_title',
+          resourceUid: row.uid,
+          languageCode: 'ja',
+          content: title,
+          isDefault: 0,
+        });
+        stats.saved++;
+        continue;
+      }
+
+      if (!hasJapaneseText(existing.content)) {
+        await database
+          .update(translations)
+          .set({content: title})
+          .where(eq(translations.uid, existing.uid));
+        stats.replaced++;
+      }
+    }
+  }
+
+  return stats;
+}
+
 export async function importKinemaJunpo({
   environment,
   dryRun = false,
@@ -557,6 +639,17 @@ export async function importKinemaJunpo({
     year,
     throttleMs,
   });
+
+  if (!dryRun) {
+    const titles = await backfillJapaneseTitles({
+      environment,
+      editions,
+      resolved,
+    });
+    console.log(
+      `\nJapanese titles: ${titles.saved} saved, ${titles.replaced} replaced`,
+    );
+  }
 
   return {japanese, foreign};
 }

--- a/apps/scrapers/src/kinema-junpo.ts
+++ b/apps/scrapers/src/kinema-junpo.ts
@@ -403,15 +403,19 @@ function normalizeTitle(value: string | undefined): string {
   return (value ?? '').replaceAll(/[\s\u3000]/g, '').toLowerCase();
 }
 
+/** 外国映画は本国公開から日本公開までのずれがあるので過去側に幅を持たせる */
+const FOREIGN_YEAR_WINDOW = 15;
+
 /** 同名のリメイクが多いので、絞り込んだ結果が1件のときだけ採用する */
 export function selectTmdbMatch(
   results: TmdbSearchResult[],
   title: string,
   year: number,
+  {foreign = false}: {foreign?: boolean} = {},
 ): TmdbSearchResult | undefined {
   const normalized = normalizeTitle(title);
   const matches = results.filter(result => {
-    if (result.original_language !== 'ja') {
+    if (foreign === (result.original_language === 'ja')) {
       return false;
     }
 
@@ -419,7 +423,12 @@ export function selectTmdbMatch(
       result.release_date?.slice(0, 4) ?? '',
       10,
     );
-    if (!Number.isFinite(releaseYear) || Math.abs(releaseYear - year) > 1) {
+    if (!Number.isFinite(releaseYear)) {
+      return false;
+    }
+
+    const earliest = foreign ? year - FOREIGN_YEAR_WINDOW : year - 1;
+    if (releaseYear < earliest || releaseYear > year + 1) {
       return false;
     }
 
@@ -450,8 +459,8 @@ async function searchTmdbByJapaneseTitle(
   return response.results ?? [];
 }
 
-export async function resolveJapaneseFilmsByTmdb(
-  entries: Array<{key: string; title: string; year: number}>,
+export async function resolveFilmsByTmdb(
+  entries: Array<{key: string; title: string; year: number; foreign: boolean}>,
   tmdbApiKey: string,
   throttleMs: number,
 ): Promise<Map<string, ResolvedFilm>> {
@@ -460,7 +469,9 @@ export async function resolveJapaneseFilmsByTmdb(
   for (const entry of entries) {
     try {
       const results = await searchTmdbByJapaneseTitle(entry.title, tmdbApiKey);
-      const match = selectTmdbMatch(results, entry.title, entry.year);
+      const match = selectTmdbMatch(results, entry.title, entry.year, {
+        foreign: entry.foreign,
+      });
       if (match) {
         const details = await fetchTMDBMovieDetails(match.id, tmdbApiKey);
         const imdbId = details?.imdb_id;
@@ -597,17 +608,25 @@ export async function importKinemaJunpo({
   if (environment.TMDB_API_KEY) {
     const pending = new Map(
       editions.flatMap(edition =>
-        edition.japanese
-          .filter(film => !resolved.has(filmKey(film)))
-          .map(film => [
+        [
+          ...edition.japanese.map(film => ({film, foreign: false})),
+          ...edition.foreign.map(film => ({film, foreign: true})),
+        ]
+          .filter(({film}) => !resolved.has(filmKey(film)))
+          .map(({film, foreign}) => [
             filmKey(film),
-            {key: filmKey(film), title: film.title, year: edition.year},
+            {
+              key: filmKey(film),
+              title: film.title,
+              year: edition.year,
+              foreign,
+            },
           ]),
       ),
     );
 
-    console.log(`TMDb fallback for ${pending.size} Japanese films...`);
-    const fallback = await resolveJapaneseFilmsByTmdb(
+    console.log(`TMDb fallback for ${pending.size} films...`);
+    const fallback = await resolveFilmsByTmdb(
       [...pending.values()],
       environment.TMDB_API_KEY,
       throttleMs,

--- a/apps/scrapers/src/kinema-junpo.ts
+++ b/apps/scrapers/src/kinema-junpo.ts
@@ -1,0 +1,434 @@
+import type {Environment} from '@shine/database';
+import {buildUrl, fetchJsonWithRetry} from './common/fetch-utilities';
+import {
+  importImdbEventAward,
+  type ImdbEventAwardConfig,
+  type ImdbEventCollectedData,
+  type ImdbEventImportStats,
+  type ImdbEventNomination,
+} from './imdb-event-award';
+
+const WIKIPEDIA_API = 'https://ja.wikipedia.org/w/api.php';
+const WIKIDATA_API = 'https://www.wikidata.org/w/api.php';
+const WIKIPEDIA_ARTICLE = 'キネマ旬報';
+const SOURCE_URL = 'https://ja.wikipedia.org/wiki/キネマ旬報';
+const USER_AGENT = 'shine-film.com movie database (https://shine-film.com)';
+const BATCH_SIZE = 50;
+
+export const JAPANESE_CATEGORY = 'Best Japanese Film';
+export const FOREIGN_CATEGORY = 'Best Foreign Film';
+
+const JAPANESE_SECTIONS = new Set([
+  '日本映画ベスト・テン',
+  '日本映画',
+  '日本・現代映画',
+  '日本・時代映画',
+]);
+
+const FOREIGN_SECTIONS = new Set([
+  '外国映画ベスト・テン',
+  '外国映画',
+  '外国・発声映画',
+  '外国・無声映画',
+  '芸術的に最も優れた映画',
+  '娯楽的に最も優れた映画',
+  '芸術的優秀映画',
+  '娯楽的優秀映画',
+]);
+
+const EDITION_HEADING = /^====\s*第(\d+)回（(\d{4})年度）\s*====$/m;
+const SECTION_HEADING = /^'''(.+?)'''\s*$/m;
+const HIGHER_HEADING = /^={2,3}[^=]/m;
+const WIKI_LINK = /^\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|([^\]]*))?]]/;
+const LINE_BREAK = /<br\s*\/?>/;
+const EMPTY_RANK = new Set(['-', '－', '―']);
+
+export type KinemaJunpoFilm = {
+  rank: number;
+  page?: string;
+  title: string;
+};
+
+export type KinemaJunpoEdition = {
+  year: number;
+  japanese: KinemaJunpoFilm[];
+  foreign: KinemaJunpoFilm[];
+};
+
+export type ResolvedFilm = {
+  imdbId: string;
+  englishTitle?: string;
+};
+
+// 1924年度から毎年。戦争で1943〜1945年度は中止され、1946年度の第20回で再開した
+export function kinemaJunpoCeremonyNumber(year: number): number | undefined {
+  if (year < 1924 || (year >= 1943 && year <= 1945)) {
+    return undefined;
+  }
+
+  return year <= 1942 ? year - 1923 : year - 1926;
+}
+
+function parseFilmLines(content: string): KinemaJunpoFilm[] {
+  const films: KinemaJunpoFilm[] = [];
+  let rank = 0;
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('#')) {
+      continue;
+    }
+
+    rank++;
+    const entry = trimmed.slice(1).trim();
+    if (EMPTY_RANK.has(entry) || entry === '') {
+      continue;
+    }
+
+    for (const fragment of entry.split(LINE_BREAK)) {
+      const text = fragment.trim();
+      if (text === '') {
+        continue;
+      }
+
+      const link = WIKI_LINK.exec(text);
+      if (link) {
+        const page = link[1].trim();
+        films.push({rank, page, title: (link[2] ?? page).trim()});
+        continue;
+      }
+
+      const title = text.replace(/（.*$/, '').trim();
+      if (title !== '') {
+        films.push({rank, title});
+      }
+    }
+  }
+
+  return films;
+}
+
+export function parseKinemaJunpoWikitext(
+  wikitext: string,
+): KinemaJunpoEdition[] {
+  const parts = wikitext.split(new RegExp(EDITION_HEADING.source, 'gm'));
+  const editions: KinemaJunpoEdition[] = [];
+
+  for (let index = 1; index < parts.length; index += 3) {
+    const year = Number.parseInt(parts[index + 1], 10);
+    const body = parts[index + 2].split(
+      new RegExp(HIGHER_HEADING.source, 'm'),
+    )[0];
+    const blocks = body.split(new RegExp(SECTION_HEADING.source, 'gm'));
+    const edition: KinemaJunpoEdition = {year, japanese: [], foreign: []};
+
+    for (let block = 1; block < blocks.length; block += 2) {
+      const heading = blocks[block];
+      const films = parseFilmLines(blocks[block + 1]);
+
+      if (JAPANESE_SECTIONS.has(heading)) {
+        edition.japanese.push(...films);
+      } else if (FOREIGN_SECTIONS.has(heading)) {
+        edition.foreign.push(...films);
+      }
+    }
+
+    editions.push(edition);
+  }
+
+  return editions;
+}
+
+function buildNominations(
+  films: KinemaJunpoFilm[],
+  resolved: Map<string, ResolvedFilm>,
+): ImdbEventNomination[] {
+  const nominations: ImdbEventNomination[] = [];
+  const seen = new Set<string>();
+
+  for (const film of films) {
+    const match = film.page ? resolved.get(film.page) : undefined;
+    if (!match || seen.has(match.imdbId)) {
+      continue;
+    }
+
+    seen.add(match.imdbId);
+    nominations.push({
+      isWinner: film.rank === 1,
+      notes: `${film.rank}位`,
+      titles: [
+        {
+          imdbId: match.imdbId,
+          title: film.title,
+          originalTitle: match.englishTitle ?? null, // eslint-disable-line unicorn/no-null -- ImdbEventNominationTitleの型に合わせる
+        },
+      ],
+    });
+  }
+
+  return nominations;
+}
+
+export function toImdbEventData(
+  editions: KinemaJunpoEdition[],
+  resolved: Map<string, ResolvedFilm>,
+  collectedAt = new Date().toISOString().slice(0, 10),
+): ImdbEventCollectedData {
+  return {
+    collectedAt,
+    source: SOURCE_URL,
+    editions: editions
+      .map(edition => ({
+        year: edition.year,
+        awardNames: [JAPANESE_CATEGORY, FOREIGN_CATEGORY],
+        targetAward: [
+          {
+            categories: [
+              {
+                category: JAPANESE_CATEGORY,
+                total: null, // eslint-disable-line unicorn/no-null -- ImdbEventCollectedDataの型に合わせる
+                nominations: buildNominations(edition.japanese, resolved),
+              },
+              {
+                category: FOREIGN_CATEGORY,
+                total: null, // eslint-disable-line unicorn/no-null -- ImdbEventCollectedDataの型に合わせる
+                nominations: buildNominations(edition.foreign, resolved),
+              },
+            ],
+          },
+        ],
+      }))
+      .filter(edition =>
+        edition.targetAward[0].categories.some(
+          category => category.nominations.length > 0,
+        ),
+      ),
+  };
+}
+
+export const kinemaJunpoJapaneseConfig: ImdbEventAwardConfig = {
+  organizationName: 'Kinema Junpo',
+  organizationCountry: 'Japan',
+  establishedYear: 1924,
+  categoryName: JAPANESE_CATEGORY,
+  ceremonyNumber: kinemaJunpoCeremonyNumber,
+  isCompetitionCategory: category => category === JAPANESE_CATEGORY,
+  minimumFilmsPerEdition: 1,
+};
+
+export const kinemaJunpoForeignConfig: ImdbEventAwardConfig = {
+  ...kinemaJunpoJapaneseConfig,
+  categoryName: FOREIGN_CATEGORY,
+  isCompetitionCategory: category => category === FOREIGN_CATEGORY,
+};
+
+type WikipediaPagePropertiesResponse = {
+  query?: {
+    normalized?: Array<{from: string; to: string}>;
+    redirects?: Array<{from: string; to: string}>;
+    pages?: Record<
+      string,
+      {title?: string; pageprops?: {wikibase_item?: string}}
+    >;
+  };
+};
+
+type WikidataEntitiesResponse = {
+  entities?: Record<
+    string,
+    {
+      claims?: Record<
+        string,
+        Array<{mainsnak?: {datavalue?: {value?: unknown}}}>
+      >;
+      labels?: Record<string, {value?: string}>;
+    }
+  >;
+};
+
+export async function fetchKinemaJunpoWikitext(): Promise<string> {
+  const url = buildUrl(WIKIPEDIA_API, {
+    action: 'parse',
+    page: WIKIPEDIA_ARTICLE,
+    prop: 'wikitext',
+    format: 'json',
+    formatversion: '2',
+  });
+
+  const response = await fetchJsonWithRetry<{parse?: {wikitext?: string}}>(
+    url,
+    {headers: {'User-Agent': USER_AGENT}},
+  );
+
+  const wikitext = response.parse?.wikitext;
+  if (!wikitext) {
+    throw new Error('Failed to fetch キネマ旬報 wikitext');
+  }
+
+  return wikitext;
+}
+
+async function fetchWikibaseItems(
+  pages: string[],
+): Promise<Map<string, string>> {
+  const url = buildUrl(WIKIPEDIA_API, {
+    action: 'query',
+    prop: 'pageprops',
+    ppprop: 'wikibase_item',
+    redirects: '1',
+    format: 'json',
+    titles: pages.join('|'),
+  });
+
+  const response = await fetchJsonWithRetry<WikipediaPagePropertiesResponse>(
+    url,
+    {
+      headers: {'User-Agent': USER_AGENT},
+    },
+  );
+
+  const normalized = new Map(
+    (response.query?.normalized ?? []).map(entry => [entry.from, entry.to]),
+  );
+  const redirects = new Map(
+    (response.query?.redirects ?? []).map(entry => [entry.from, entry.to]),
+  );
+  const byTitle = new Map(
+    Object.values(response.query?.pages ?? {}).map(page => [page.title, page]),
+  );
+
+  const items = new Map<string, string>();
+  for (const page of pages) {
+    const title = normalized.get(page) ?? page;
+    const resolvedTitle = redirects.get(title) ?? title;
+    const item = byTitle.get(resolvedTitle)?.pageprops?.wikibase_item;
+    if (item) {
+      items.set(page, item);
+    }
+  }
+
+  return items;
+}
+
+async function fetchImdbIds(
+  itemIds: string[],
+): Promise<Map<string, ResolvedFilm>> {
+  const url = buildUrl(WIKIDATA_API, {
+    action: 'wbgetentities',
+    props: 'claims|labels',
+    languages: 'en',
+    format: 'json',
+    ids: itemIds.join('|'),
+  });
+
+  const response = await fetchJsonWithRetry<WikidataEntitiesResponse>(url, {
+    headers: {'User-Agent': USER_AGENT},
+  });
+
+  const films = new Map<string, ResolvedFilm>();
+  for (const [itemId, entity] of Object.entries(response.entities ?? {})) {
+    const imdbId = entity.claims?.P345?.[0]?.mainsnak?.datavalue?.value;
+    if (typeof imdbId !== 'string' || !/^tt\d+$/.test(imdbId)) {
+      continue;
+    }
+
+    films.set(itemId, {imdbId, englishTitle: entity.labels?.en?.value});
+  }
+
+  return films;
+}
+
+export async function resolveFilmsByWikipediaPage(
+  pages: string[],
+): Promise<Map<string, ResolvedFilm>> {
+  const itemsByPage = new Map<string, string>();
+  for (let index = 0; index < pages.length; index += BATCH_SIZE) {
+    const batch = pages.slice(index, index + BATCH_SIZE);
+    for (const [page, item] of await fetchWikibaseItems(batch)) {
+      itemsByPage.set(page, item);
+    }
+
+    console.log(
+      `  Wikipedia: ${Math.min(index + BATCH_SIZE, pages.length)}/${pages.length}`,
+    );
+  }
+
+  const itemIds = [...new Set(itemsByPage.values())];
+  const filmsByItem = new Map<string, ResolvedFilm>();
+  for (let index = 0; index < itemIds.length; index += BATCH_SIZE) {
+    const batch = itemIds.slice(index, index + BATCH_SIZE);
+    for (const [item, film] of await fetchImdbIds(batch)) {
+      filmsByItem.set(item, film);
+    }
+
+    console.log(
+      `  Wikidata: ${Math.min(index + BATCH_SIZE, itemIds.length)}/${itemIds.length}`,
+    );
+  }
+
+  const resolved = new Map<string, ResolvedFilm>();
+  for (const [page, item] of itemsByPage) {
+    const film = filmsByItem.get(item);
+    if (film) {
+      resolved.set(page, film);
+    }
+  }
+
+  return resolved;
+}
+
+export async function importKinemaJunpo({
+  environment,
+  dryRun = false,
+  year,
+  throttleMs = 300,
+}: {
+  environment: Environment;
+  dryRun?: boolean;
+  year?: number;
+  throttleMs?: number;
+}): Promise<{japanese: ImdbEventImportStats; foreign: ImdbEventImportStats}> {
+  const wikitext = await fetchKinemaJunpoWikitext();
+  const allEditions = parseKinemaJunpoWikitext(wikitext);
+  const editions =
+    year === undefined
+      ? allEditions
+      : allEditions.filter(edition => edition.year === year);
+
+  console.log(`Parsed ${editions.length} editions from Wikipedia`);
+
+  const pages = [
+    ...new Set(
+      editions
+        .flatMap(edition => [...edition.japanese, ...edition.foreign])
+        .map(film => film.page)
+        .filter((page): page is string => page !== undefined),
+    ),
+  ];
+
+  console.log(`Resolving IMDb IDs for ${pages.length} articles...`);
+  const resolved = await resolveFilmsByWikipediaPage(pages);
+  console.log(`Resolved ${resolved.size}/${pages.length} articles`);
+
+  const data = toImdbEventData(editions, resolved);
+
+  const japanese = await importImdbEventAward({
+    environment,
+    data,
+    config: kinemaJunpoJapaneseConfig,
+    dryRun,
+    year,
+    throttleMs,
+  });
+
+  const foreign = await importImdbEventAward({
+    environment,
+    data,
+    config: kinemaJunpoForeignConfig,
+    dryRun,
+    year,
+    throttleMs,
+  });
+
+  return {japanese, foreign};
+}

--- a/apps/scrapers/src/kinema-junpo.ts
+++ b/apps/scrapers/src/kinema-junpo.ts
@@ -1,5 +1,7 @@
+import {setTimeout as sleep} from 'node:timers/promises';
 import type {Environment} from '@shine/database';
 import {buildUrl, fetchJsonWithRetry} from './common/fetch-utilities';
+import {fetchTMDBMovieDetails} from './common/tmdb-utilities';
 import {
   importImdbEventAward,
   type ImdbEventAwardConfig,
@@ -8,6 +10,8 @@ import {
   type ImdbEventNomination,
 } from './imdb-event-award';
 
+const TMDB_API = 'https://api.themoviedb.org/3';
+const IMDB_ID_PATTERN = /^tt\d+$/;
 const WIKIPEDIA_API = 'https://ja.wikipedia.org/w/api.php';
 const WIKIDATA_API = 'https://www.wikidata.org/w/api.php';
 const WIKIPEDIA_ARTICLE = 'キネマ旬報';
@@ -139,6 +143,11 @@ export function parseKinemaJunpoWikitext(
   return editions;
 }
 
+/** 記事が無い作品はWikipediaの表示名で引けるようにする */
+export function filmKey(film: KinemaJunpoFilm): string {
+  return film.page ?? `title:${film.title}`;
+}
+
 function buildNominations(
   films: KinemaJunpoFilm[],
   resolved: Map<string, ResolvedFilm>,
@@ -147,7 +156,7 @@ function buildNominations(
   const seen = new Set<string>();
 
   for (const film of films) {
-    const match = film.page ? resolved.get(film.page) : undefined;
+    const match = resolved.get(filmKey(film));
     if (!match || seen.has(match.imdbId)) {
       continue;
     }
@@ -214,6 +223,7 @@ export const kinemaJunpoJapaneseConfig: ImdbEventAwardConfig = {
   ceremonyNumber: kinemaJunpoCeremonyNumber,
   isCompetitionCategory: category => category === JAPANESE_CATEGORY,
   minimumFilmsPerEdition: 1,
+  useNotesAsSpecialMention: true,
 };
 
 export const kinemaJunpoForeignConfig: ImdbEventAwardConfig = {
@@ -377,6 +387,98 @@ export async function resolveFilmsByWikipediaPage(
   return resolved;
 }
 
+export type TmdbSearchResult = {
+  id: number;
+  title?: string;
+  original_title?: string;
+  release_date?: string;
+  original_language?: string;
+};
+
+function normalizeTitle(value: string | undefined): string {
+  return (value ?? '').replaceAll(/[\s\u3000]/g, '').toLowerCase();
+}
+
+/** 同名のリメイクが多いので、絞り込んだ結果が1件のときだけ採用する */
+export function selectTmdbMatch(
+  results: TmdbSearchResult[],
+  title: string,
+  year: number,
+): TmdbSearchResult | undefined {
+  const normalized = normalizeTitle(title);
+  const matches = results.filter(result => {
+    if (result.original_language !== 'ja') {
+      return false;
+    }
+
+    const releaseYear = Number.parseInt(
+      result.release_date?.slice(0, 4) ?? '',
+      10,
+    );
+    if (!Number.isFinite(releaseYear) || Math.abs(releaseYear - year) > 1) {
+      return false;
+    }
+
+    return (
+      normalizeTitle(result.title) === normalized ||
+      normalizeTitle(result.original_title) === normalized
+    );
+  });
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+async function searchTmdbByJapaneseTitle(
+  title: string,
+  tmdbApiKey: string,
+): Promise<TmdbSearchResult[]> {
+  const url = buildUrl(`${TMDB_API}/search/movie`, {
+    api_key: tmdbApiKey,
+    query: title,
+    language: 'ja-JP',
+    include_adult: 'false',
+  });
+
+  const response = await fetchJsonWithRetry<{results?: TmdbSearchResult[]}>(
+    url,
+  );
+
+  return response.results ?? [];
+}
+
+export async function resolveJapaneseFilmsByTmdb(
+  entries: Array<{key: string; title: string; year: number}>,
+  tmdbApiKey: string,
+  throttleMs: number,
+): Promise<Map<string, ResolvedFilm>> {
+  const resolved = new Map<string, ResolvedFilm>();
+
+  for (const entry of entries) {
+    try {
+      const results = await searchTmdbByJapaneseTitle(entry.title, tmdbApiKey);
+      const match = selectTmdbMatch(results, entry.title, entry.year);
+      if (match) {
+        const details = await fetchTMDBMovieDetails(match.id, tmdbApiKey);
+        const imdbId = details?.imdb_id;
+        if (imdbId && IMDB_ID_PATTERN.test(imdbId)) {
+          resolved.set(entry.key, {imdbId, englishTitle: details?.title});
+          console.log(
+            `  TMDb fallback: ${entry.title} (${entry.year}) -> ${imdbId} (TMDb ${match.id})`,
+          );
+        }
+      }
+    } catch (error) {
+      console.error(`  TMDb fallback failed for ${entry.title}:`, error);
+    }
+
+    if (throttleMs > 0) {
+      await sleep(throttleMs);
+    }
+  }
+
+  return resolved;
+}
+
 export async function importKinemaJunpo({
   environment,
   dryRun = false,
@@ -409,6 +511,32 @@ export async function importKinemaJunpo({
   console.log(`Resolving IMDb IDs for ${pages.length} articles...`);
   const resolved = await resolveFilmsByWikipediaPage(pages);
   console.log(`Resolved ${resolved.size}/${pages.length} articles`);
+
+  if (environment.TMDB_API_KEY) {
+    const pending = new Map(
+      editions.flatMap(edition =>
+        edition.japanese
+          .filter(film => !resolved.has(filmKey(film)))
+          .map(film => [
+            filmKey(film),
+            {key: filmKey(film), title: film.title, year: edition.year},
+          ]),
+      ),
+    );
+
+    console.log(`TMDb fallback for ${pending.size} Japanese films...`);
+    const fallback = await resolveJapaneseFilmsByTmdb(
+      [...pending.values()],
+      environment.TMDB_API_KEY,
+      throttleMs,
+    );
+
+    for (const [key, film] of fallback) {
+      resolved.set(key, film);
+    }
+
+    console.log(`TMDb fallback resolved ${fallback.size}/${pending.size}`);
+  }
 
   const data = toImdbEventData(editions, resolved);
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "scrapers:cannes-film-festival": "pnpm --filter @shine/scrapers run cannes-film-festival",
     "scrapers:venice-film-festival": "pnpm --filter @shine/scrapers run venice-film-festival",
     "scrapers:berlin-film-festival": "pnpm --filter @shine/scrapers run berlin-film-festival",
+    "scrapers:kinema-junpo": "pnpm --filter @shine/scrapers run kinema-junpo",
     "scrapers:movie-import": "pnpm --filter @shine/scrapers run movie-import",
     "scrapers:import-imdb-list": "pnpm --filter @shine/scrapers run import-imdb-list",
     "scrapers:availability-check": "pnpm --filter @shine/scrapers run availability-check",

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -72,6 +72,8 @@ export type AwardMovieEntry = {
   movieYear: number | undefined;
   posterUrl: string | undefined;
   isWinner: boolean;
+  /** ランキング形式の賞で「N位」が入る */
+  specialMention?: string;
 };
 
 export type AwardYearGroup = {


### PR DESCRIPTION
日本語版Wikipediaの「キネマ旬報」記事から、第1回（1924年度）〜第99回（2025年度）の日本映画・外国映画ベスト・テンを取り込む。

## 取り込み方

記事名からWikidataのIMDb ID (P345) を引いて映画を同定する。Wikidataに登録が無い作品はTMDbで補うが、既存の `searchTMDBMovie` は照合がゆるく別作品を掴むので使わず、専用の判定を書いた。邦題の完全一致・公開年・作品の言語で絞り、候補が1件のときだけ採用する。外国映画は本国公開から日本公開までのずれがあるので公開年を年度の15年前まで許容する。

取り込み処理そのものは既存の `imdb-event-award` を部門ごとに2回呼んで再利用している。順位は `nominations.specialMention` に「N位」で入れ、賞ページで順位順に並べる。Wikipediaの表記は邦題として信頼できるので、ja翻訳が無い映画とTMDb由来で原題のまま入っている映画に書き込む。

## 本番投入の結果

- 日本映画ベスト・テン 931ノミネーション / 97年、外国映画ベスト・テン 855ノミネーション / 97年
- 映画 6,695 → 7,564件、邦題 5,968 → 6,833件（90.3%）
- 記事の解決率は1,770/1,928（Wikidata 1,541 + TMDb 229）。1位が入っていないのは1927年度日本映画と1935年度外国映画の2つだけ
- 賞ページは `/awards/kinema-junpo-japanese` と `/awards/kinema-junpo-foreign`、年別ページが約200

TMDb照合で採用した作品は6件をTMDbで実地確認した（一本刀土俵入り、日輪、からくり娘、蝕める春、大都会 労働篇、生活線ABC）。ランクインしているのに孤立映画として削除済みだった5件（櫻の園、少年時代、白い手、夜明けのすべて、ラストマイル）は削除を解除してから取り込んでいる。