### PR TITLE
日替わり映画クイズ /quiz を追加

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -371,6 +371,129 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /quiz/daily:
+    get:
+      summary: Get today's quiz
+      description: Returns the puzzle date and the number of attempts. Never contains anything that identifies the answer
+      operationId: getQuizDaily
+      tags:
+        - Quiz
+      security: []
+      parameters:
+        - name: date
+          in: query
+          description: Puzzle date (YYYY-MM-DD). Defaults to today; future dates are rejected
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Successfully retrieved the puzzle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizPuzzle'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /quiz/candidates:
+    get:
+      summary: List every movie that can be guessed
+      description: Returns the whole quiz pool so the client can filter guesses locally
+      operationId: getQuizCandidates
+      tags:
+        - Quiz
+      security: []
+      responses:
+        '200':
+          description: Successfully retrieved the candidates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  candidates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/QuizCandidate'
+                required:
+                  - candidates
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /quiz/guess:
+    post:
+      summary: Submit a guess
+      description: Checks a guess server-side. Returns the next hint while attempts remain, and the answer once solved or after the last attempt
+      operationId: submitQuizGuess
+      tags:
+        - Quiz
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                date:
+                  type: string
+                  format: date
+                movieUid:
+                  type: string
+                  description: Omit to pass on this attempt
+                attempt:
+                  type: integer
+                  minimum: 1
+              required:
+                - attempt
+      responses:
+        '200':
+          description: Guess processed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizGuessResult'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /quiz/answer:
+    get:
+      summary: Get the answer (internal)
+      description: Returns the answer including the poster URL. Used by the frontend worker to render the cropped poster; requires the shared key
+      operationId: getQuizAnswer
+      tags:
+        - Quiz
+      security: []
+      parameters:
+        - name: X-Quiz-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Successfully retrieved the answer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizAnswer'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /movies/{id}/article-links:
     get:
       summary: Get movie article links
@@ -1908,6 +2031,83 @@ components:
         - totalCount
         - totalPages
 
+    QuizPuzzle:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+        maxAttempts:
+          type: integer
+        poolSize:
+          type: integer
+      required:
+        - date
+        - maxAttempts
+        - poolSize
+
+    QuizCandidate:
+      type: object
+      properties:
+        uid:
+          type: string
+        title:
+          type: string
+        year:
+          type: [integer, 'null']
+      required:
+        - uid
+        - title
+
+    QuizHint:
+      type: object
+      properties:
+        label:
+          type: string
+        value:
+          type: string
+      required:
+        - label
+        - value
+
+    QuizAnswer:
+      type: object
+      properties:
+        uid:
+          type: string
+        title:
+          type: string
+        year:
+          type: [integer, 'null']
+        posterUrl:
+          type: string
+        focalX:
+          type: number
+        focalY:
+          type: number
+      required:
+        - uid
+        - title
+        - posterUrl
+        - focalX
+        - focalY
+
+    QuizGuessResult:
+      type: object
+      properties:
+        correct:
+          type: boolean
+        hint:
+          allOf:
+            - $ref: '#/components/schemas/QuizHint'
+          description: Returned while attempts remain
+        answer:
+          allOf:
+            - $ref: '#/components/schemas/QuizAnswer'
+          description: Returned once solved or after the last attempt
+      required:
+        - correct
+
     AwardSummary:
       type: object
       properties:
@@ -3095,6 +3295,8 @@ components:
 tags:
   - name: Awards
     description: Award and editorial list pages
+  - name: Quiz
+    description: Daily movie guessing game
   - name: Movies
     description: Movie information and search operations
   - name: Articles

--- a/apps/api/src/__tests__/quiz-api.test.ts
+++ b/apps/api/src/__tests__/quiz-api.test.ts
@@ -1,0 +1,352 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {quizRoutes} from '../routes/quiz';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+const QUIZ_KEY = 'test-quiz-key';
+
+type SeedOptions = {
+  uid: string;
+  title?: string;
+  poster?: boolean;
+  organizations: Array<'cannes' | 'kinema'>;
+  deleted?: boolean;
+};
+
+async function seedMovie(
+  database: ReturnType<typeof getDatabase>,
+  {uid, title, poster = true, organizations, deleted = false}: SeedOptions,
+) {
+  await database.insert(movies).values({
+    uid,
+    year: 1965,
+    originalLanguage: 'ja',
+    deletedAt: deleted ? 1 : undefined,
+  });
+
+  if (title) {
+    await database.insert(translations).values({
+      resourceType: 'movie_title',
+      resourceUid: uid,
+      languageCode: 'ja',
+      content: title,
+      isDefault: 1,
+    });
+  }
+
+  if (poster) {
+    await database.insert(posterUrls).values({
+      movieUid: uid,
+      url: `https://image.tmdb.org/t/p/original/${uid}.jpg`,
+      isPrimary: 1,
+    });
+  }
+
+  for (const organization of organizations) {
+    await database.insert(nominations).values({
+      movieUid: uid,
+      ceremonyUid: `ceremony-${organization}`,
+      categoryUid: `cat-${organization}`,
+      isWinner: 1,
+    });
+  }
+}
+
+async function createTestEnvironment(): Promise<Environment> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-quiz-'));
+  const environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+    QUIZ_ANSWER_KEY: QUIZ_KEY,
+  } as Environment;
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+
+  await database.insert(awardOrganizations).values([
+    {uid: 'org-cannes', name: 'Cannes Film Festival'},
+    {uid: 'org-kinema', name: 'Kinema Junpo'},
+  ]);
+  await database.insert(awardCategories).values([
+    {uid: 'cat-cannes', organizationUid: 'org-cannes', name: "Palme d'Or"},
+    {
+      uid: 'cat-kinema',
+      organizationUid: 'org-kinema',
+      name: 'Best Japanese Film',
+    },
+  ]);
+  await database.insert(awardCeremonies).values([
+    {uid: 'ceremony-cannes', organizationUid: 'org-cannes', year: 1965},
+    {uid: 'ceremony-kinema', organizationUid: 'org-kinema', year: 1965},
+  ]);
+
+  await seedMovie(database, {
+    uid: 'movie-in-pool',
+    title: '赤ひげ',
+    organizations: ['cannes', 'kinema'],
+  });
+  await seedMovie(database, {
+    uid: 'movie-also-in-pool',
+    title: '東京物語',
+    organizations: ['cannes', 'kinema'],
+  });
+  await seedMovie(database, {
+    uid: 'movie-single-org',
+    title: '無常',
+    organizations: ['cannes'],
+  });
+  await seedMovie(database, {
+    uid: 'movie-no-japanese-title',
+    organizations: ['cannes', 'kinema'],
+  });
+  await seedMovie(database, {
+    uid: 'movie-no-poster',
+    title: 'ポスターなし',
+    poster: false,
+    organizations: ['cannes', 'kinema'],
+  });
+  await seedMovie(database, {
+    uid: 'movie-deleted',
+    title: '削除済み',
+    organizations: ['cannes', 'kinema'],
+    deleted: true,
+  });
+
+  return environment;
+}
+
+const DATE = '2026-01-15';
+
+async function fetchAnswer(environment: Environment) {
+  const response = await quizRoutes.request(
+    `/answer?date=${DATE}`,
+    {headers: {'X-Quiz-Key': QUIZ_KEY}},
+    environment,
+  );
+  return response.json() as Promise<{
+    uid: string;
+    title: string;
+    posterUrl: string;
+    focalX: number;
+    focalY: number;
+  }>;
+}
+
+describe('GET /quiz/daily', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  it('returns the puzzle date', async () => {
+    const response = await quizRoutes.request(
+      `/daily?date=${DATE}`,
+      {},
+      environment,
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {date: string};
+    expect(body.date).toBe(DATE);
+  });
+
+  it('returns the number of attempts', async () => {
+    const response = await quizRoutes.request(
+      `/daily?date=${DATE}`,
+      {},
+      environment,
+    );
+
+    const body = (await response.json()) as {maxAttempts: number};
+    expect(body.maxAttempts).toBe(6);
+  });
+
+  it('never exposes the answer', async () => {
+    const answer = await fetchAnswer(environment);
+    const response = await quizRoutes.request(
+      `/daily?date=${DATE}`,
+      {},
+      environment,
+    );
+
+    const raw = await response.text();
+    expect(raw).not.toContain(answer.title);
+    expect(raw).not.toContain(answer.uid);
+    expect(raw).not.toContain('image.tmdb.org');
+  });
+
+  it('rejects a future date', async () => {
+    const response = await quizRoutes.request(
+      '/daily?date=2999-01-01',
+      {},
+      environment,
+    );
+
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('GET /quiz/answer', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  it('requires the internal key', async () => {
+    const response = await quizRoutes.request(
+      `/answer?date=${DATE}`,
+      {},
+      environment,
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('picks a movie from the pool', async () => {
+    const answer = await fetchAnswer(environment);
+
+    expect(['movie-in-pool', 'movie-also-in-pool']).toContain(answer.uid);
+  });
+
+  it('returns the same movie for the same date', async () => {
+    const first = await fetchAnswer(environment);
+    const second = await fetchAnswer(environment);
+
+    expect(second.uid).toBe(first.uid);
+  });
+
+  it('keeps the focal point inside the poster', async () => {
+    const answer = await fetchAnswer(environment);
+
+    expect(answer.focalX).toBeGreaterThanOrEqual(0);
+    expect(answer.focalX).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('GET /quiz/candidates', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  async function fetchCandidates() {
+    const response = await quizRoutes.request('/candidates', {}, environment);
+    const body = (await response.json()) as {
+      candidates: Array<{uid: string; title: string}>;
+    };
+    return body.candidates;
+  }
+
+  it('lists every movie in the pool', async () => {
+    const candidates = await fetchCandidates();
+
+    expect(candidates.map(candidate => candidate.uid).toSorted()).toEqual([
+      'movie-also-in-pool',
+      'movie-in-pool',
+    ]);
+  });
+
+  it('carries the title of each candidate', async () => {
+    const candidates = await fetchCandidates();
+
+    expect(candidates.map(candidate => candidate.title).toSorted()).toEqual([
+      '東京物語',
+      '赤ひげ',
+    ]);
+  });
+});
+
+describe('POST /quiz/guess', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  async function guess(body: Record<string, unknown>) {
+    const response = await quizRoutes.request(
+      '/guess',
+      {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({date: DATE, ...body}),
+      },
+      environment,
+    );
+    return response.json() as Promise<{
+      correct: boolean;
+      hint?: {label: string; value: string};
+      answer?: {uid: string; title: string};
+    }>;
+  }
+
+  it('accepts the right movie', async () => {
+    const answer = await fetchAnswer(environment);
+    const result = await guess({movieUid: answer.uid, attempt: 1});
+
+    expect(result.correct).toBe(true);
+  });
+
+  it('reveals the answer once solved', async () => {
+    const answer = await fetchAnswer(environment);
+    const result = await guess({movieUid: answer.uid, attempt: 1});
+
+    expect(result.answer?.title).toBe(answer.title);
+  });
+
+  it('rejects a wrong movie', async () => {
+    const answer = await fetchAnswer(environment);
+    const wrong =
+      answer.uid === 'movie-in-pool' ? 'movie-also-in-pool' : 'movie-in-pool';
+    const result = await guess({movieUid: wrong, attempt: 1});
+
+    expect(result.correct).toBe(false);
+  });
+
+  it('hides the answer while attempts remain', async () => {
+    const answer = await fetchAnswer(environment);
+    const wrong =
+      answer.uid === 'movie-in-pool' ? 'movie-also-in-pool' : 'movie-in-pool';
+    const result = await guess({movieUid: wrong, attempt: 1});
+
+    expect(result.answer).toBeUndefined();
+  });
+
+  it('opens one hint per wrong guess', async () => {
+    const result = await guess({movieUid: undefined, attempt: 1});
+
+    expect(result.hint?.label).toBe('製作年');
+  });
+
+  it('opens a later hint on a later attempt', async () => {
+    const result = await guess({movieUid: undefined, attempt: 3});
+
+    expect(result.hint?.label).toBe('選出した映画賞');
+  });
+
+  it('reveals the answer after the last attempt', async () => {
+    const answer = await fetchAnswer(environment);
+    const result = await guess({movieUid: undefined, attempt: 6});
+
+    expect(result.answer?.title).toBe(answer.title);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import {authRoutes} from './routes/auth';
 import {awardsRoutes} from './routes/awards';
 import {documentationRoutes} from './routes/documentation';
 import {moviesRoutes} from './routes/movies';
+import {quizRoutes} from './routes/quiz';
 import {selectionsRoutes} from './routes/selections';
 import {utilitiesRoutes} from './routes/utilities';
 
@@ -47,6 +48,7 @@ app.route('/docs', documentationRoutes); // API documentation
 app.route('/', selectionsRoutes); // Main endpoint for movie selections
 app.route('/movies', moviesRoutes);
 app.route('/awards', awardsRoutes);
+app.route('/quiz', quizRoutes);
 app.route('/admin', adminRoutes);
 app.route('/', utilitiesRoutes); // Utility endpoints like fetch-url-title
 

--- a/apps/api/src/routes/quiz.ts
+++ b/apps/api/src/routes/quiz.ts
@@ -1,0 +1,110 @@
+import type {Environment} from '@shine/database';
+import type {QuizGuessResult} from '@shine/types';
+import {Hono} from 'hono';
+import {
+  buildQuizHints,
+  QUIZ_MAX_ATTEMPTS,
+  QuizService,
+  toQuizAnswer,
+  type QuizPoolEntry,
+} from '../services/quiz-service';
+import {createCachedResponse} from '../utils/cache';
+
+export const quizRoutes = new Hono<{Bindings: Environment}>();
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const CANDIDATES_TTL = 86_400;
+const DAILY_TTL = 600;
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function resolveDate(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return today();
+  }
+
+  return DATE_PATTERN.test(value) && value <= today() ? value : undefined;
+}
+
+quizRoutes.get('/daily', async c => {
+  const date = resolveDate(c.req.query('date'));
+  if (!date) {
+    return c.json({error: 'Invalid date'}, 400);
+  }
+
+  const pool = await new QuizService(c.env).getPool();
+  if (pool.length === 0) {
+    return c.json({error: 'Quiz unavailable'}, 503);
+  }
+
+  return createCachedResponse(
+    {date, maxAttempts: QUIZ_MAX_ATTEMPTS, poolSize: pool.length},
+    DAILY_TTL,
+  );
+});
+
+quizRoutes.get('/candidates', async c => {
+  const candidates = await new QuizService(c.env).getCandidates();
+
+  return createCachedResponse({candidates}, CANDIDATES_TTL);
+});
+
+quizRoutes.get('/answer', async c => {
+  const key = c.env.QUIZ_ANSWER_KEY;
+  if (!key || c.req.header('X-Quiz-Key') !== key) {
+    return c.json({error: 'Unauthorized'}, 401);
+  }
+
+  const date = resolveDate(c.req.query('date'));
+  if (!date) {
+    return c.json({error: 'Invalid date'}, 400);
+  }
+
+  const entry = await new QuizService(c.env).getEntry(date);
+  if (!entry) {
+    return c.json({error: 'Quiz unavailable'}, 503);
+  }
+
+  return c.json(toQuizAnswer(entry, date), 200, {'Cache-Control': 'no-store'});
+});
+
+type GuessBody = {
+  date?: string;
+  movieUid?: string;
+  attempt?: number;
+};
+
+function guessResult(
+  entry: QuizPoolEntry,
+  date: string,
+  {movieUid, attempt}: {movieUid?: string; attempt: number},
+): QuizGuessResult {
+  const correct = movieUid === entry.uid;
+  if (correct || attempt >= QUIZ_MAX_ATTEMPTS) {
+    return {correct, answer: toQuizAnswer(entry, date)};
+  }
+
+  return {correct, hint: buildQuizHints(entry)[attempt - 1]};
+}
+
+quizRoutes.post('/guess', async c => {
+  const body = await c.req.json<GuessBody>().catch(() => ({}) as GuessBody);
+  const date = resolveDate(body.date);
+  const attempt = Number(body.attempt);
+  if (!date || !Number.isInteger(attempt) || attempt < 1) {
+    return c.json({error: 'Invalid request'}, 400);
+  }
+
+  const entry = await new QuizService(c.env).getEntry(date);
+  if (!entry) {
+    return c.json({error: 'Quiz unavailable'}, 503);
+  }
+
+  return c.json(
+    guessResult(entry, date, {movieUid: body.movieUid, attempt}),
+    200,
+    {'Cache-Control': 'no-store'},
+  );
+});

--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -13,6 +13,23 @@ import type {
   AwardYearGroup,
 } from '@shine/types';
 
+export function findAwardPageDefinition(
+  organizationName: string,
+  categoryName?: string,
+): AwardPageDefinition | undefined {
+  const candidates = awardPageDefinitions.filter(
+    entry => entry.organizationName === organizationName,
+  );
+
+  return candidates.length > 1
+    ? candidates.find(
+        entry =>
+          categoryName !== undefined &&
+          entry.categoryNames.includes(categoryName),
+      )
+    : candidates[0];
+}
+
 export function awardPageLinkForOrganizationName(
   organizationName: string,
   categoryName?: string,
@@ -20,18 +37,7 @@ export function awardPageLinkForOrganizationName(
   slug: string | undefined;
   hasYearPages: boolean;
 } {
-  const candidates = awardPageDefinitions.filter(
-    entry => entry.organizationName === organizationName,
-  );
-
-  const definition =
-    candidates.length > 1
-      ? candidates.find(
-          entry =>
-            categoryName !== undefined &&
-            entry.categoryNames.includes(categoryName),
-        )
-      : candidates[0];
+  const definition = findAwardPageDefinition(organizationName, categoryName);
 
   return {
     slug: definition?.slug,
@@ -55,7 +61,7 @@ function compareAwardMovies(a: AwardMovieEntry, b: AwardMovieEntry): number {
     : rankA - rankB;
 }
 
-type AwardPageDefinition = {
+export type AwardPageDefinition = {
   slug: string;
   organizationName: string;
   categoryNames: string[];

--- a/apps/api/src/services/quiz-service.ts
+++ b/apps/api/src/services/quiz-service.ts
@@ -1,0 +1,243 @@
+import {and, eq, isNull, sql} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import type {QuizAnswer, QuizCandidate, QuizHint} from '@shine/types';
+import {EdgeCache} from '../utils/cache';
+import {simpleHash} from '../utils/hash';
+import {findAwardPageDefinition} from './awards-service';
+import {BaseService} from './base-service';
+
+export const QUIZ_MAX_ATTEMPTS = 6;
+
+const MINIMUM_ORGANIZATIONS = 2;
+const POOL_CACHE_KEY = 'quiz:pool:v1';
+const POOL_CACHE_TTL = 604_800;
+
+export type QuizPoolEntry = {
+  uid: string;
+  title: string;
+  year: number | undefined;
+  posterUrl: string;
+  originalLanguage: string;
+  organizations: string[];
+  achievements: string[];
+};
+
+/** 賞ページ定義のorganizationが英語のままのもの */
+const organizationLabelOverrides: Record<string, string> = {
+  '1001 Movies You Must See Before You Die': '死ぬまでに観たい映画1001本',
+};
+
+const languageDisplayNames = new Intl.DisplayNames(['ja'], {type: 'language'});
+
+function languageLabel(code: string): string {
+  try {
+    return languageDisplayNames.of(code) ?? code;
+  } catch {
+    return code;
+  }
+}
+
+export function buildQuizHints(entry: QuizPoolEntry): QuizHint[] {
+  const characters = [...entry.title];
+
+  return [
+    {label: '製作年', value: entry.year ? `${entry.year}年` : '不明'},
+    {label: '原語', value: languageLabel(entry.originalLanguage)},
+    {label: '選出した映画賞', value: entry.achievements.join(' / ')},
+    {label: '邦題の長さ', value: `${characters.length}文字`},
+    {label: '邦題の頭文字', value: characters[0] ?? '?'},
+  ];
+}
+
+/** ポスターを拡大表示するときに中心へ置く点。日付ごとに変えて絵面を変化させる */
+export function quizFocalPoint(date: string): {focalX: number; focalY: number} {
+  const seed = simpleHash(`quiz-focal-${date}`);
+
+  return {
+    focalX: 0.3 + ((seed % 1000) / 1000) * 0.4,
+    focalY: 0.25 + (((seed >>> 10) % 1000) / 1000) * 0.35,
+  };
+}
+
+export function pickQuizEntry(
+  pool: QuizPoolEntry[],
+  date: string,
+): QuizPoolEntry | undefined {
+  if (pool.length === 0) {
+    return undefined;
+  }
+
+  return pool[simpleHash(`quiz-${date}`) % pool.length];
+}
+
+export function toQuizAnswer(
+  entry: QuizPoolEntry,
+  date: string,
+): QuizAnswer & {hints: QuizHint[]} {
+  return {
+    uid: entry.uid,
+    title: entry.title,
+    year: entry.year,
+    posterUrl: entry.posterUrl,
+    ...quizFocalPoint(date),
+    hints: buildQuizHints(entry),
+  };
+}
+
+type NominationFacts = {
+  organizationName: string;
+  categoryName: string;
+  ceremonyYear: number;
+  isWinner: boolean;
+  specialMention: string | undefined;
+};
+
+function describeNomination(facts: NominationFacts): {
+  organization: string;
+  achievement: string;
+} {
+  const definition = findAwardPageDefinition(
+    facts.organizationName,
+    facts.categoryName,
+  );
+  const organization =
+    organizationLabelOverrides[facts.organizationName] ??
+    definition?.organization ??
+    facts.organizationName;
+
+  if (definition?.grouping === 'list') {
+    return {organization, achievement: `${organization}に選出`};
+  }
+
+  const outcome =
+    facts.specialMention ?? (facts.isWinner ? '受賞' : 'ノミネート');
+
+  return {
+    organization,
+    achievement: `${organization} ${facts.ceremonyYear}年 ${outcome}`,
+  };
+}
+
+export class QuizService extends BaseService {
+  async getPool(): Promise<QuizPoolEntry[]> {
+    const cache = new EdgeCache(undefined, this.env.CACHE_KV);
+    const cached = await cache.get(POOL_CACHE_KEY);
+    if (cached) {
+      return cached.data as QuizPoolEntry[];
+    }
+
+    const pool = await this.buildPool();
+    await cache.set(POOL_CACHE_KEY, pool, POOL_CACHE_TTL);
+    return pool;
+  }
+
+  async getCandidates(): Promise<QuizCandidate[]> {
+    const pool = await this.getPool();
+
+    return pool.map(entry => ({
+      uid: entry.uid,
+      title: entry.title,
+      year: entry.year,
+    }));
+  }
+
+  async getEntry(date: string): Promise<QuizPoolEntry | undefined> {
+    return pickQuizEntry(await this.getPool(), date);
+  }
+
+  private async buildPool(): Promise<QuizPoolEntry[]> {
+    const rows = await this.database
+      .select({
+        uid: movies.uid,
+        year: movies.year,
+        originalLanguage: movies.originalLanguage,
+        isWinner: nominations.isWinner,
+        specialMention: nominations.specialMention,
+        ceremonyYear: awardCeremonies.year,
+        organizationName: awardOrganizations.name,
+        categoryName: awardCategories.name,
+        title: sql<string>`(
+          SELECT content FROM translations
+          WHERE translations.resource_uid = movies.uid
+            AND translations.resource_type = 'movie_title'
+            AND translations.language_code = 'ja'
+          LIMIT 1
+        )`.as('title'),
+        posterUrl: sql<string>`(
+          SELECT url FROM poster_urls
+          WHERE poster_urls.movie_uid = movies.uid
+          ORDER BY poster_urls.is_primary DESC
+          LIMIT 1
+        )`.as('posterUrl'),
+      })
+      .from(nominations)
+      .innerJoin(
+        awardCeremonies,
+        eq(nominations.ceremonyUid, awardCeremonies.uid),
+      )
+      .innerJoin(
+        awardOrganizations,
+        eq(awardCeremonies.organizationUid, awardOrganizations.uid),
+      )
+      .innerJoin(
+        awardCategories,
+        eq(nominations.categoryUid, awardCategories.uid),
+      )
+      .innerJoin(movies, eq(nominations.movieUid, movies.uid))
+      .where(
+        and(
+          isNull(movies.deletedAt),
+          sql`EXISTS (
+            SELECT 1 FROM translations
+            WHERE translations.resource_uid = movies.uid
+              AND translations.resource_type = 'movie_title'
+              AND translations.language_code = 'ja'
+          )`,
+          sql`EXISTS (
+            SELECT 1 FROM poster_urls WHERE poster_urls.movie_uid = movies.uid
+          )`,
+        ),
+      );
+
+    const entries = new Map<string, QuizPoolEntry>();
+    for (const row of rows) {
+      const {organization, achievement} = describeNomination({
+        organizationName: row.organizationName,
+        categoryName: row.categoryName,
+        ceremonyYear: row.ceremonyYear,
+        isWinner: row.isWinner === 1,
+        specialMention: row.specialMention ?? undefined,
+      });
+
+      let entry = entries.get(row.uid);
+      if (!entry) {
+        entry = {
+          uid: row.uid,
+          title: row.title,
+          year: row.year ?? undefined,
+          posterUrl: row.posterUrl,
+          originalLanguage: row.originalLanguage,
+          organizations: [],
+          achievements: [],
+        };
+        entries.set(row.uid, entry);
+      }
+
+      if (!entry.organizations.includes(organization)) {
+        entry.organizations.push(organization);
+      }
+
+      if (!entry.achievements.includes(achievement)) {
+        entry.achievements.push(achievement);
+      }
+    }
+
+    return [...entries.values()]
+      .filter(entry => entry.organizations.length >= MINIMUM_ORGANIZATIONS)
+      .toSorted((a, b) => (a.uid < b.uid ? -1 : 1));
+  }
+}

--- a/apps/front/app/components/editorial/masthead.test.tsx
+++ b/apps/front/app/components/editorial/masthead.test.tsx
@@ -32,6 +32,14 @@ describe('Masthead', () => {
     );
   });
 
+  it('QUIZ リンクを描画する', () => {
+    render(<Masthead locale="ja" />);
+    expect(screen.getByRole('link', {name: /quiz/i})).toHaveAttribute(
+      'href',
+      '/quiz',
+    );
+  });
+
   it('日本語ロケールでは日本語のタグラインを描画する', () => {
     render(<Masthead locale="ja" />);
 

--- a/apps/front/app/components/editorial/masthead.tsx
+++ b/apps/front/app/components/editorial/masthead.tsx
@@ -32,6 +32,12 @@ export function Masthead({locale = 'en'}: {locale?: string}) {
         </p>
         <LanguageSelector locale={locale} />
         <a
+          href="/quiz"
+          aria-label="Quiz"
+          className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">
+          QUIZ
+        </a>
+        <a
           href="/daily"
           aria-label="Daily picks"
           className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">

--- a/apps/front/app/lib/api.ts
+++ b/apps/front/app/lib/api.ts
@@ -1,5 +1,5 @@
 type CloudflareContext = {
-  cloudflare?: {env?: {PUBLIC_API_URL?: string}};
+  cloudflare?: {env?: {PUBLIC_API_URL?: string; QUIZ_ANSWER_KEY?: string}};
 };
 
 export function resolveApiUrl(context: unknown): string {
@@ -7,4 +7,8 @@ export function resolveApiUrl(context: unknown): string {
     (context as CloudflareContext)?.cloudflare?.env?.PUBLIC_API_URL ??
     'http://localhost:8787'
   );
+}
+
+export function resolveQuizKey(context: unknown): string | undefined {
+  return (context as CloudflareContext)?.cloudflare?.env?.QUIZ_ANSWER_KEY;
 }

--- a/apps/front/app/lib/og/quiz-poster.test.ts
+++ b/apps/front/app/lib/og/quiz-poster.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from 'vitest';
+import {
+  buildQuizPosterHtml,
+  cropLayout,
+  QUIZ_POSTER_WIDTH,
+  zoomForStage,
+} from './quiz-poster';
+
+describe('zoomForStage', () => {
+  it('starts zoomed in', () => {
+    expect(zoomForStage(0)).toBeGreaterThan(5);
+  });
+
+  it('zooms out as stages advance', () => {
+    expect(zoomForStage(1)).toBeLessThan(zoomForStage(0));
+  });
+
+  it('still hides part of the poster on the last playable stage', () => {
+    expect(zoomForStage(5)).toBeGreaterThan(1);
+  });
+
+  it('shows the whole poster once the game is over', () => {
+    expect(zoomForStage(6)).toBe(1);
+  });
+
+  it('clamps stages beyond the last one', () => {
+    expect(zoomForStage(99)).toBe(1);
+  });
+});
+
+describe('cropLayout', () => {
+  it('shows the whole poster at zoom 1', () => {
+    const layout = cropLayout({zoom: 1, focalX: 0.5, focalY: 0.5});
+
+    expect(layout).toMatchObject({left: 0, top: 0});
+  });
+
+  it('centers the focal point', () => {
+    const layout = cropLayout({zoom: 2, focalX: 0.5, focalY: 0.5});
+
+    expect(layout.left + layout.width * 0.5).toBe(QUIZ_POSTER_WIDTH / 2);
+  });
+
+  it('keeps the left edge inside the poster', () => {
+    const layout = cropLayout({zoom: 4, focalX: 0, focalY: 0.5});
+
+    expect(layout.left).toBe(0);
+  });
+
+  it('keeps the right edge inside the poster', () => {
+    const layout = cropLayout({zoom: 4, focalX: 1, focalY: 0.5});
+
+    expect(layout.left + layout.width).toBe(QUIZ_POSTER_WIDTH);
+  });
+});
+
+describe('buildQuizPosterHtml', () => {
+  it('clips the enlarged poster to the frame', () => {
+    const html = buildQuizPosterHtml({
+      posterDataUri: 'data:image/jpeg;base64,AAA',
+      stage: 0,
+      focalX: 0.5,
+      focalY: 0.5,
+    });
+
+    expect(html).toContain('overflow:hidden');
+  });
+
+  it('enlarges the poster beyond the frame', () => {
+    const html = buildQuizPosterHtml({
+      posterDataUri: 'data:image/jpeg;base64,AAA',
+      stage: 0,
+      focalX: 0.5,
+      focalY: 0.5,
+    });
+
+    expect(html).toContain(`width="${QUIZ_POSTER_WIDTH * zoomForStage(0)}"`);
+  });
+});

--- a/apps/front/app/lib/og/quiz-poster.ts
+++ b/apps/front/app/lib/og/quiz-poster.ts
@@ -1,0 +1,83 @@
+/**
+ * クイズ用のポスター切り出し。
+ * Satoriはfilterを解さないため、拡大した画像をoverflow:hiddenの枠に絶対配置してクロップする。
+ */
+export const QUIZ_POSTER_WIDTH = 480;
+export const QUIZ_POSTER_HEIGHT = 720;
+
+/** 手数ぶんの6段階と、決着後に全体を見せる最終段階 */
+const ZOOM_STAGES = [6, 4.5, 3.2, 2.4, 1.8, 1.4, 1];
+
+const COLORS = {
+  paper: '#ece8df',
+  ink: '#15140f',
+};
+
+export function zoomForStage(stage: number): number {
+  const index = Math.min(
+    Math.max(Math.trunc(stage), 0),
+    ZOOM_STAGES.length - 1,
+  );
+  return ZOOM_STAGES[index];
+}
+
+export type CropLayout = {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+};
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+export function cropLayout({
+  zoom,
+  focalX,
+  focalY,
+}: {
+  zoom: number;
+  focalX: number;
+  focalY: number;
+}): CropLayout {
+  const width = Math.round(QUIZ_POSTER_WIDTH * zoom);
+  const height = Math.round(QUIZ_POSTER_HEIGHT * zoom);
+
+  return {
+    width,
+    height,
+    left: Math.round(
+      clamp(
+        QUIZ_POSTER_WIDTH / 2 - focalX * width,
+        QUIZ_POSTER_WIDTH - width,
+        0,
+      ),
+    ),
+    top: Math.round(
+      clamp(
+        QUIZ_POSTER_HEIGHT / 2 - focalY * height,
+        QUIZ_POSTER_HEIGHT - height,
+        0,
+      ),
+    ),
+  };
+}
+
+export function buildQuizPosterHtml({
+  posterDataUri,
+  stage,
+  focalX,
+  focalY,
+}: {
+  posterDataUri: string;
+  stage: number;
+  focalX: number;
+  focalY: number;
+}): string {
+  const layout = cropLayout({zoom: zoomForStage(stage), focalX, focalY});
+
+  return `<div style="display:flex;position:relative;width:${QUIZ_POSTER_WIDTH}px;height:${QUIZ_POSTER_HEIGHT}px;overflow:hidden;background:${COLORS.paper};border:8px solid ${COLORS.ink};">
+  <img src="${posterDataUri}" width="${layout.width}" height="${layout.height}" style="position:absolute;left:${layout.left}px;top:${layout.top}px;" />
+</div>`;
+}

--- a/apps/front/app/lib/quiz-state.test.ts
+++ b/apps/front/app/lib/quiz-state.test.ts
@@ -1,0 +1,186 @@
+import {describe, expect, it} from 'vitest';
+import {
+  applyGuess,
+  createGame,
+  filterCandidates,
+  recordResult,
+  shareText,
+  streakOf,
+  type QuizGameState,
+} from './quiz-state';
+
+const MAX_ATTEMPTS = 6;
+const ANSWER = {uid: 'movie-a', title: '赤ひげ', year: 1965};
+
+function play(
+  outcomes: Array<{title?: string; correct: boolean}>,
+): QuizGameState {
+  let state = createGame('2026-08-16');
+  for (const [index, outcome] of outcomes.entries()) {
+    const settled = outcome.correct || index + 1 >= MAX_ATTEMPTS;
+    state = applyGuess(
+      state,
+      outcome,
+      settled ? {answer: ANSWER} : {hint: {label: '製作年', value: '1965年'}},
+      MAX_ATTEMPTS,
+    );
+  }
+
+  return state;
+}
+
+describe('applyGuess', () => {
+  it('keeps playing after a wrong guess', () => {
+    const state = play([{title: '東京物語', correct: false}]);
+
+    expect(state.status).toBe('playing');
+  });
+
+  it('collects the hint from a wrong guess', () => {
+    const state = play([{title: '東京物語', correct: false}]);
+
+    expect(state.hints).toHaveLength(1);
+  });
+
+  it('wins on a correct guess', () => {
+    const state = play([{title: '赤ひげ', correct: true}]);
+
+    expect(state.status).toBe('won');
+  });
+
+  it('keeps the answer once won', () => {
+    const state = play([{title: '赤ひげ', correct: true}]);
+
+    expect(state.answer).toEqual(ANSWER);
+  });
+
+  it('loses after the last attempt', () => {
+    const state = play(
+      Array.from({length: MAX_ATTEMPTS}, () => ({
+        title: '東京物語',
+        correct: false,
+      })),
+    );
+
+    expect(state.status).toBe('lost');
+  });
+});
+
+describe('filterCandidates', () => {
+  const candidates = [
+    {uid: 'a', title: '赤ひげ'},
+    {uid: 'b', title: '東京物語'},
+    {uid: 'c', title: '007／ゴールドフィンガー'},
+  ];
+
+  it('matches by substring', () => {
+    expect(filterCandidates(candidates, '東京', 8)).toHaveLength(1);
+  });
+
+  it('ignores separators in the title', () => {
+    expect(filterCandidates(candidates, '007ゴールド', 8)).toHaveLength(1);
+  });
+
+  it('returns nothing for an empty query', () => {
+    expect(filterCandidates(candidates, '  ', 8)).toEqual([]);
+  });
+
+  it('caps the number of matches', () => {
+    expect(filterCandidates(candidates, '', 8)).toEqual([]);
+  });
+});
+
+describe('shareText', () => {
+  it('marks the winning guess', () => {
+    const state = play([
+      {title: '東京物語', correct: false},
+      {title: '赤ひげ', correct: true},
+    ]);
+
+    expect(shareText(state, MAX_ATTEMPTS)).toContain('🟥🟩⬜⬜⬜⬜');
+  });
+
+  it('shows the score', () => {
+    const state = play([
+      {title: '東京物語', correct: false},
+      {title: '赤ひげ', correct: true},
+    ]);
+
+    expect(shareText(state, MAX_ATTEMPTS)).toContain('2/6');
+  });
+
+  it('marks a pass differently from a wrong guess', () => {
+    const state = play([
+      {correct: false},
+      {title: '東京物語', correct: false},
+      {title: '赤ひげ', correct: true},
+    ]);
+
+    expect(shareText(state, MAX_ATTEMPTS)).toContain('⬛🟥🟩');
+  });
+
+  it('scores a loss as X', () => {
+    const state = play(
+      Array.from({length: MAX_ATTEMPTS}, () => ({
+        title: '東京物語',
+        correct: false,
+      })),
+    );
+
+    expect(shareText(state, MAX_ATTEMPTS)).toContain('X');
+  });
+
+  it('never leaks the answer', () => {
+    const state = play([{title: '赤ひげ', correct: true}]);
+
+    expect(shareText(state, MAX_ATTEMPTS)).not.toContain('赤ひげ');
+  });
+});
+
+describe('streakOf', () => {
+  it('counts consecutive wins', () => {
+    const history = {
+      '2026-08-14': {attempts: 2, won: true},
+      '2026-08-15': {attempts: 3, won: true},
+      '2026-08-16': {attempts: 1, won: true},
+    };
+
+    expect(streakOf(history, '2026-08-16')).toBe(3);
+  });
+
+  it('stops at a loss', () => {
+    const history = {
+      '2026-08-14': {attempts: 6, won: false},
+      '2026-08-15': {attempts: 3, won: true},
+      '2026-08-16': {attempts: 1, won: true},
+    };
+
+    expect(streakOf(history, '2026-08-16')).toBe(2);
+  });
+
+  it('stops at a missed day', () => {
+    const history = {
+      '2026-08-14': {attempts: 2, won: true},
+      '2026-08-16': {attempts: 1, won: true},
+    };
+
+    expect(streakOf(history, '2026-08-16')).toBe(1);
+  });
+});
+
+describe('recordResult', () => {
+  it('stores a finished game', () => {
+    const state = play([{title: '赤ひげ', correct: true}]);
+
+    expect(recordResult({}, state)['2026-08-16']).toEqual({
+      attempts: 1,
+      won: true,
+    });
+  });
+
+  it('ignores a game in progress', () => {
+    const state = play([{title: '東京物語', correct: false}]);
+
+    expect(recordResult({}, state)).toEqual({});
+  });
+});

--- a/apps/front/app/lib/quiz-state.ts
+++ b/apps/front/app/lib/quiz-state.ts
@@ -1,0 +1,132 @@
+export type QuizHint = {label: string; value: string};
+
+export type QuizCandidate = {uid: string; title: string; year?: number};
+
+export type QuizAnswer = {
+  uid: string;
+  title: string;
+  year?: number;
+};
+
+export type QuizGuess = {
+  title?: string;
+  correct: boolean;
+};
+
+export type QuizGameState = {
+  date: string;
+  guesses: QuizGuess[];
+  hints: QuizHint[];
+  answer?: QuizAnswer;
+  status: 'playing' | 'won' | 'lost';
+};
+
+export type QuizHistory = Record<string, {attempts: number; won: boolean}>;
+
+export const QUIZ_STATE_KEY = 'shine-quiz-v1';
+export const QUIZ_HISTORY_KEY = 'shine-quiz-history-v1';
+
+export function createGame(date: string): QuizGameState {
+  return {date, guesses: [], hints: [], status: 'playing'};
+}
+
+export function applyGuess(
+  state: QuizGameState,
+  guess: QuizGuess,
+  result: {hint?: QuizHint; answer?: QuizAnswer},
+  maxAttempts: number,
+): QuizGameState {
+  const guesses = [...state.guesses, guess];
+  const hints = result.hint ? [...state.hints, result.hint] : state.hints;
+
+  if (guess.correct) {
+    return {...state, guesses, hints, answer: result.answer, status: 'won'};
+  }
+
+  if (guesses.length >= maxAttempts) {
+    return {...state, guesses, hints, answer: result.answer, status: 'lost'};
+  }
+
+  return {...state, guesses, hints};
+}
+
+const NOISE_PATTERN = /[\s・：:,、。！!?？'"’”/／]/g;
+
+function normalize(value: string): string {
+  return value.toLowerCase().replaceAll(NOISE_PATTERN, '');
+}
+
+export function filterCandidates(
+  candidates: QuizCandidate[],
+  query: string,
+  limit: number,
+): QuizCandidate[] {
+  const needle = normalize(query);
+  if (needle.length === 0) {
+    return [];
+  }
+
+  return candidates
+    .filter(candidate => normalize(candidate.title).includes(needle))
+    .slice(0, limit);
+}
+
+const MARKS = {
+  correct: '🟩',
+  wrong: '🟥',
+  passed: '⬛',
+  unused: '⬜',
+};
+
+export function shareText(state: QuizGameState, maxAttempts: number): string {
+  const marks = state.guesses.map(guess => {
+    if (guess.correct) {
+      return MARKS.correct;
+    }
+
+    return guess.title ? MARKS.wrong : MARKS.passed;
+  });
+  const padding = MARKS.unused.repeat(Math.max(maxAttempts - marks.length, 0));
+  const score =
+    state.status === 'won' ? `${state.guesses.length}/${maxAttempts}` : 'X';
+
+  return [
+    `SHINE QUIZ ${state.date} ${score}`,
+    marks.join('') + padding,
+    'https://shine-film.com/quiz',
+  ].join('\n');
+}
+
+export function recordResult(
+  history: QuizHistory,
+  state: QuizGameState,
+): QuizHistory {
+  if (state.status === 'playing') {
+    return history;
+  }
+
+  return {
+    ...history,
+    [state.date]: {
+      attempts: state.guesses.length,
+      won: state.status === 'won',
+    },
+  };
+}
+
+function previousDate(date: string): string {
+  const time = Date.parse(`${date}T00:00:00Z`);
+  return new Date(time - 86_400_000).toISOString().slice(0, 10);
+}
+
+export function streakOf(history: QuizHistory, date: string): number {
+  let streak = 0;
+  let cursor = date;
+
+  while (history[cursor]?.won) {
+    streak++;
+    cursor = previousDate(cursor);
+  }
+
+  return streak;
+}

--- a/apps/front/app/routes.ts
+++ b/apps/front/app/routes.ts
@@ -15,6 +15,7 @@ export default [
   route('sitemap.xml', 'routes/sitemap-index.tsx'),
   route('sitemap/movies.xml', 'routes/sitemap-movies.tsx'),
   route('sitemap/awards.xml', 'routes/sitemap-awards.tsx'),
+  route('quiz', 'routes/quiz.tsx'),
   route('quiz/poster.png', 'routes/quiz-poster.tsx'),
   route('og/movie.png', 'routes/og-movie.tsx'),
   route('og/home.png', 'routes/og-home.tsx'),

--- a/apps/front/app/routes.ts
+++ b/apps/front/app/routes.ts
@@ -15,6 +15,7 @@ export default [
   route('sitemap.xml', 'routes/sitemap-index.tsx'),
   route('sitemap/movies.xml', 'routes/sitemap-movies.tsx'),
   route('sitemap/awards.xml', 'routes/sitemap-awards.tsx'),
+  route('quiz/poster.png', 'routes/quiz-poster.tsx'),
   route('og/movie.png', 'routes/og-movie.tsx'),
   route('og/home.png', 'routes/og-home.tsx'),
   route('og/banner.png', 'routes/og-banner.tsx'),

--- a/apps/front/app/routes/quiz-poster.tsx
+++ b/apps/front/app/routes/quiz-poster.tsx
@@ -1,0 +1,68 @@
+import {ImageResponse} from 'workers-og';
+import type {Route} from './+types/quiz-poster';
+import {resolveApiUrl, resolveQuizKey} from '@/lib/api';
+import {fetchPosterAsDataUri} from '@/lib/og/assets';
+import {
+  buildQuizPosterHtml,
+  QUIZ_POSTER_HEIGHT,
+  QUIZ_POSTER_WIDTH,
+} from '@/lib/og/quiz-poster';
+import {upgradePosterForSharing} from '@/lib/meta';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const CACHE_CONTROL = 'public, max-age=3600';
+
+type QuizAnswer = {
+  posterUrl: string;
+  focalX: number;
+  focalY: number;
+};
+
+export async function loader({context, request}: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const date = url.searchParams.get('date') ?? '';
+  const stage = Number.parseInt(url.searchParams.get('stage') ?? '0', 10);
+
+  if (!DATE_PATTERN.test(date) || !Number.isInteger(stage) || stage < 0) {
+    return new Response('Not Found', {status: 404});
+  }
+
+  const quizKey = resolveQuizKey(context);
+  if (!quizKey) {
+    return new Response('Quiz unavailable', {status: 503});
+  }
+
+  const response = await fetch(
+    `${resolveApiUrl(context)}/quiz/answer?date=${date}`,
+    {headers: {'X-Quiz-Key': quizKey}, signal: request.signal},
+  );
+  if (!response.ok) {
+    return new Response('Not Found', {status: 404});
+  }
+
+  const answer = (await response.json()) as QuizAnswer;
+  const posterDataUri = await fetchPosterAsDataUri(
+    upgradePosterForSharing(answer.posterUrl),
+  );
+  if (!posterDataUri) {
+    return new Response('Poster unavailable', {status: 503});
+  }
+
+  const image = new ImageResponse(
+    buildQuizPosterHtml({
+      posterDataUri,
+      stage,
+      focalX: answer.focalX,
+      focalY: answer.focalY,
+    }),
+    {width: QUIZ_POSTER_WIDTH, height: QUIZ_POSTER_HEIGHT},
+  );
+
+  // ストリームのままだとレンダリング失敗が空レスポンスに化けるため、先に全量を読む
+  const body = await image.arrayBuffer();
+
+  return new Response(body, {
+    status: image.status,
+    headers: {'Content-Type': 'image/png', 'Cache-Control': CACHE_CONTROL},
+  });
+}

--- a/apps/front/app/routes/quiz.test.tsx
+++ b/apps/front/app/routes/quiz.test.tsx
@@ -1,0 +1,171 @@
+import '@testing-library/jest-dom';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import QuizPage, {loader} from './quiz';
+import type {Route} from './+types/quiz';
+import {QUIZ_STATE_KEY} from '@/lib/quiz-state';
+
+globalThis.fetch = vi.fn();
+
+const cast = <T,>(value?: unknown): T => value as T;
+
+const PUZZLE = {date: '2026-08-16', maxAttempts: 6, poolSize: 1396};
+const CANDIDATES = [
+  {uid: 'movie-a', title: '赤ひげ', year: 1965},
+  {uid: 'movie-b', title: '東京物語', year: 1953},
+];
+
+const createComponentProperties = (): Route.ComponentProps =>
+  cast<Route.ComponentProps>({
+    loaderData: {
+      puzzle: PUZZLE,
+      candidates: CANDIDATES,
+      apiUrl: 'http://localhost:8787',
+      locale: 'ja',
+    },
+    params: {},
+    matches: [],
+  });
+
+describe('Quiz page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    globalThis.localStorage.clear();
+  });
+
+  describe('loader', () => {
+    it('出題と回答候補をまとめて取得する', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch
+        .mockResolvedValueOnce({ok: true, json: async () => PUZZLE} as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({candidates: CANDIDATES}),
+        } as Response);
+
+      const request = new Request('http://localhost:3000/quiz');
+      const result = await loader(
+        cast<Route.LoaderArgs>({
+          context: {
+            cloudflare: {env: {PUBLIC_API_URL: 'http://localhost:8787'}},
+          },
+          request,
+          params: {},
+          matches: [],
+        }),
+      );
+
+      expect(result.candidates).toEqual(CANDIDATES);
+    });
+
+    it('APIが失敗したら502を投げる', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({ok: false} as Response);
+
+      await expect(
+        loader(
+          cast<Route.LoaderArgs>({
+            context: {cloudflare: {env: {}}},
+            request: new Request('http://localhost:3000/quiz'),
+            params: {},
+            matches: [],
+          }),
+        ),
+      ).rejects.toMatchObject({status: 502});
+    });
+  });
+
+  describe('プレイ', () => {
+    it('最初はズームしたポスターを出す', () => {
+      render(<QuizPage {...createComponentProperties()} />);
+
+      expect(screen.getByAltText('ポスターの一部')).toHaveAttribute(
+        'src',
+        '/quiz/poster.png?date=2026-08-16&stage=0',
+      );
+    });
+
+    it('入力に一致する候補を出す', async () => {
+      render(<QuizPage {...createComponentProperties()} />);
+
+      await userEvent.type(screen.getByLabelText(/邦題で回答/), '東京');
+
+      expect(
+        await screen.findByRole('button', {name: /東京物語/}),
+      ).toBeInTheDocument();
+    });
+
+    it('外すとヒントが開く', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          correct: false,
+          hint: {label: '製作年', value: '1965年'},
+        }),
+      } as Response);
+
+      render(<QuizPage {...createComponentProperties()} />);
+      await userEvent.type(screen.getByLabelText(/邦題で回答/), '東京');
+      await userEvent.click(
+        await screen.findByRole('button', {name: /東京物語/}),
+      );
+
+      expect(await screen.findByText('1965年')).toBeInTheDocument();
+    });
+
+    it('当たると答えを見せる', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          correct: true,
+          answer: {uid: 'movie-a', title: '赤ひげ', year: 1965},
+        }),
+      } as Response);
+
+      render(<QuizPage {...createComponentProperties()} />);
+      await userEvent.type(screen.getByLabelText(/邦題で回答/), '赤ひげ');
+      await userEvent.click(
+        await screen.findByRole('button', {name: /赤ひげ/}),
+      );
+
+      expect(await screen.findByText('正解！')).toBeInTheDocument();
+    });
+
+    it('リロードしても進行を引き継ぐ', async () => {
+      globalThis.localStorage.setItem(
+        QUIZ_STATE_KEY,
+        JSON.stringify({
+          date: PUZZLE.date,
+          guesses: [{title: '東京物語', correct: false}],
+          hints: [{label: '製作年', value: '1965年'}],
+          status: 'playing',
+        }),
+      );
+
+      render(<QuizPage {...createComponentProperties()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('1965年')).toBeInTheDocument();
+      });
+    });
+
+    it('日付が変わったら前日の進行は捨てる', async () => {
+      globalThis.localStorage.setItem(
+        QUIZ_STATE_KEY,
+        JSON.stringify({
+          date: '2026-08-15',
+          guesses: [{title: '東京物語', correct: false}],
+          hints: [{label: '製作年', value: '1965年'}],
+          status: 'playing',
+        }),
+      );
+
+      render(<QuizPage {...createComponentProperties()} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('1965年')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/front/app/routes/quiz.tsx
+++ b/apps/front/app/routes/quiz.tsx
@@ -1,0 +1,331 @@
+import {useEffect, useMemo, useState} from 'react';
+import type {Route} from './+types/quiz';
+import {Masthead} from '@/components/editorial/masthead';
+import {SiteFooter} from '@/components/editorial/site-footer';
+import {resolveApiUrl} from '@/lib/api';
+import {DEFAULT_LOCALE, getLocaleFromRequest, type Locale} from '@/lib/locale';
+import {SITE_URL, buildSocialMeta} from '@/lib/meta';
+import {
+  applyGuess,
+  createGame,
+  filterCandidates,
+  QUIZ_HISTORY_KEY,
+  QUIZ_STATE_KEY,
+  recordResult,
+  shareText,
+  streakOf,
+  type QuizAnswer,
+  type QuizCandidate,
+  type QuizGameState,
+  type QuizHint,
+  type QuizHistory,
+} from '@/lib/quiz-state';
+
+const SUGGESTION_LIMIT = 8;
+
+export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
+  const {locale} = data as {locale?: Locale};
+
+  return buildSocialMeta({
+    title: '今日の映画クイズ | SHINE',
+    description:
+      'ポスターの一部と5つのヒントから、今日の1本を当てる。カンヌ・アカデミー賞・キネマ旬報などに選ばれた映画から毎日1問。',
+    path: '/quiz',
+    locale: locale ?? DEFAULT_LOCALE,
+    imageUrl: `${SITE_URL}/og/home.png`,
+    largeImage: true,
+  });
+}
+
+export async function loader({context, request}: Route.LoaderArgs) {
+  const locale = getLocaleFromRequest(request);
+  const apiUrl = resolveApiUrl(context);
+
+  const [dailyResponse, candidatesResponse] = await Promise.all([
+    fetch(`${apiUrl}/quiz/daily`, {signal: request.signal}),
+    fetch(`${apiUrl}/quiz/candidates`, {signal: request.signal}),
+  ]);
+
+  if (!dailyResponse.ok || !candidatesResponse.ok) {
+    throw new Response('Failed to load quiz', {status: 502});
+  }
+
+  const puzzle = (await dailyResponse.json()) as {
+    date: string;
+    maxAttempts: number;
+    poolSize: number;
+  };
+  const {candidates} = (await candidatesResponse.json()) as {
+    candidates: QuizCandidate[];
+  };
+
+  return {puzzle, candidates, apiUrl, locale};
+}
+
+function readStorage<T>(key: string): T | undefined {
+  try {
+    const raw = globalThis.localStorage?.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeStorage(key: string, value: unknown): void {
+  try {
+    globalThis.localStorage?.setItem(key, JSON.stringify(value));
+  } catch {
+    // プライベートモードなどでは保存できないが、その日のプレイは続けられる
+  }
+}
+
+export default function QuizPage({loaderData}: Route.ComponentProps) {
+  const {puzzle, candidates, apiUrl} = loaderData as {
+    puzzle: {date: string; maxAttempts: number; poolSize: number};
+    candidates: QuizCandidate[];
+    apiUrl: string;
+  };
+  const locale = 'ja';
+
+  const [game, setGame] = useState<QuizGameState>(() =>
+    createGame(puzzle.date),
+  );
+  const [history, setHistory] = useState<QuizHistory>({});
+  const [restored, setRestored] = useState(false);
+  const [query, setQuery] = useState('');
+  const [pending, setPending] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const saved = readStorage<QuizGameState>(QUIZ_STATE_KEY);
+    if (saved?.date === puzzle.date) {
+      setGame(saved);
+    }
+
+    setHistory(readStorage<QuizHistory>(QUIZ_HISTORY_KEY) ?? {});
+    setRestored(true);
+  }, [puzzle.date]);
+
+  useEffect(() => {
+    if (restored) {
+      writeStorage(QUIZ_STATE_KEY, game);
+    }
+  }, [game, restored]);
+
+  const suggestions = useMemo(
+    () => filterCandidates(candidates, query, SUGGESTION_LIMIT),
+    [candidates, query],
+  );
+
+  const finished = game.status !== 'playing';
+  const stage = finished ? puzzle.maxAttempts : game.guesses.length;
+  const remaining = puzzle.maxAttempts - game.guesses.length;
+
+  async function submit(candidate?: QuizCandidate) {
+    if (pending || finished) {
+      return;
+    }
+
+    setPending(true);
+    try {
+      const response = await fetch(`${apiUrl}/quiz/guess`, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          date: puzzle.date,
+          movieUid: candidate?.uid,
+          attempt: game.guesses.length + 1,
+        }),
+      });
+      if (!response.ok) {
+        return;
+      }
+
+      const result = (await response.json()) as {
+        correct: boolean;
+        hint?: QuizHint;
+        answer?: QuizAnswer;
+      };
+      const next = applyGuess(
+        game,
+        {title: candidate?.title, correct: result.correct},
+        result,
+        puzzle.maxAttempts,
+      );
+
+      setGame(next);
+      setQuery('');
+      if (next.status !== 'playing') {
+        const updated = recordResult(history, next);
+        setHistory(updated);
+        writeStorage(QUIZ_HISTORY_KEY, updated);
+      }
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function copyShareText() {
+    try {
+      await navigator.clipboard.writeText(shareText(game, puzzle.maxAttempts));
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  const streak = streakOf(history, puzzle.date);
+
+  return (
+    <div className="min-h-screen bg-paper text-ink">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <Masthead locale={locale} />
+
+        <div className="flex items-baseline justify-between gap-3 mb-2">
+          <h1 className="font-display font-black text-2xl md:text-3xl tracking-tight">
+            TODAY&apos;S QUIZ
+          </h1>
+          <span className="font-mono text-xs text-ink-muted">
+            {puzzle.date}
+          </span>
+        </div>
+        <p className="font-mono text-xs text-ink-muted mb-6">
+          ポスターの一部と5つのヒントから、今日の1本を当てる（全
+          {puzzle.poolSize.toLocaleString('ja-JP')}本）
+          {streak >= 2 ? ` — ${streak}日連続正解中` : ''}
+        </p>
+
+        <div className="grid gap-6 md:grid-cols-[minmax(0,320px)_1fr] md:items-start">
+          <div className="border-2 border-ink bg-surface">
+            <img
+              src={`/quiz/poster.png?date=${puzzle.date}&stage=${stage}`}
+              alt={finished ? game.answer?.title : 'ポスターの一部'}
+              width={480}
+              height={720}
+              className="block w-full h-auto"
+            />
+          </div>
+
+          <div>
+            <div className="flex gap-1.5 mb-4" aria-label="残りの手数">
+              {Array.from({length: puzzle.maxAttempts}, (_, index) => {
+                const guess = game.guesses[index];
+                const filled = guess
+                  ? guess.correct
+                    ? 'bg-brand'
+                    : 'bg-ink'
+                  : 'bg-transparent';
+                return (
+                  <span
+                    key={index}
+                    className={`w-4 h-4 border-2 border-ink ${filled}`}
+                  />
+                );
+              })}
+            </div>
+
+            {game.hints.length > 0 && (
+              <dl className="mb-5">
+                {game.hints.map(hint => (
+                  <div
+                    key={hint.label}
+                    className="flex gap-3 py-2 border-t-2 border-ink">
+                    <dt className="font-mono text-[10px] text-ink-muted w-24 shrink-0 pt-0.5">
+                      {hint.label}
+                    </dt>
+                    <dd className="font-display font-bold text-sm leading-snug">
+                      {hint.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+
+            {finished ? (
+              <div className="border-2 border-ink p-4">
+                <p className="font-display font-black text-lg mb-1">
+                  {game.status === 'won' ? '正解！' : '残念！'}
+                </p>
+                <p className="font-display font-bold text-base leading-snug">
+                  {game.answer ? (
+                    <a
+                      href={`/movies/${game.answer.uid}`}
+                      className="text-ink underline">
+                      {game.answer.title}
+                    </a>
+                  ) : (
+                    '—'
+                  )}
+                  {game.answer?.year ? (
+                    <span className="font-mono text-xs text-ink-muted ml-2">
+                      {game.answer.year}
+                    </span>
+                  ) : undefined}
+                </p>
+                <button
+                  type="button"
+                  onClick={copyShareText}
+                  className="mt-4 font-mono text-xs font-bold bg-brand text-brand-on px-3 py-1.5 border-2 border-ink shadow-[3px_3px_0_var(--ink)]">
+                  {copied ? 'コピーしました' : '結果をコピー'}
+                </button>
+                <p className="font-mono text-[10px] text-ink-muted mt-3">
+                  次の問題は明日9時に出ます
+                </p>
+              </div>
+            ) : (
+              <div>
+                <label
+                  htmlFor="quiz-guess"
+                  className="block font-mono text-[10px] text-ink-muted mb-1">
+                  邦題で回答（残り{remaining}回）
+                </label>
+                <input
+                  id="quiz-guess"
+                  type="text"
+                  value={query}
+                  autoComplete="off"
+                  placeholder="タイトルを入力"
+                  onChange={event => {
+                    setQuery(event.target.value);
+                  }}
+                  className="w-full border-2 border-ink bg-surface px-3 py-2 font-display text-base"
+                />
+
+                {suggestions.length > 0 && (
+                  <ul className="mt-2 border-2 border-ink divide-y-2 divide-ink">
+                    {suggestions.map(candidate => (
+                      <li key={candidate.uid}>
+                        <button
+                          type="button"
+                          disabled={pending}
+                          onClick={async () => submit(candidate)}
+                          className="w-full text-left px-3 py-2 font-display font-bold text-sm bg-surface">
+                          {candidate.title}
+                          {candidate.year ? (
+                            <span className="font-mono text-[10px] text-ink-muted ml-2">
+                              {candidate.year}
+                            </span>
+                          ) : undefined}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                <button
+                  type="button"
+                  disabled={pending}
+                  onClick={async () => submit()}
+                  className="mt-3 font-mono text-xs font-bold px-3 py-1.5 border-2 border-ink text-ink">
+                  パスしてヒントを見る
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <SiteFooter locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/apps/front/app/routes/sitemap-awards.tsx
+++ b/apps/front/app/routes/sitemap-awards.tsx
@@ -77,6 +77,7 @@ export async function loader({context, request}: Route.LoaderArgs) {
 
   const entries: SitemapEntry[] = [
     {path: '/awards', changefreq: 'weekly'},
+    {path: '/quiz', changefreq: 'daily'},
     {path: '/daily', changefreq: 'daily'},
     {path: '/weekly', changefreq: 'weekly'},
     {path: '/monthly', changefreq: 'monthly'},

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -24,6 +24,7 @@ export type Environment = {
   ADMIN_PASSWORD?: string;
   JWT_SECRET?: string;
   TURNSTILE_SECRET_KEY?: string;
+  QUIZ_ANSWER_KEY?: string;
   BROWSER?: Fetcher;
   CACHE_KV?: KVNamespace;
 };

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -125,6 +125,39 @@ export type AwardSummary = {
   lastYear: number;
 };
 
+export type QuizHint = {
+  label: string;
+  value: string;
+};
+
+export type QuizCandidate = {
+  uid: string;
+  title: string;
+  year: number | undefined;
+};
+
+export type QuizPuzzle = {
+  date: string;
+  maxAttempts: number;
+  poolSize: number;
+};
+
+export type QuizAnswer = {
+  uid: string;
+  title: string;
+  year: number | undefined;
+  posterUrl: string;
+  /** ポスターの拡大表示で中心に置く点。0〜1の相対座標 */
+  focalX: number;
+  focalY: number;
+};
+
+export type QuizGuessResult = {
+  correct: boolean;
+  hint?: QuizHint;
+  answer?: QuizAnswer;
+};
+
 export type DateSeedOptions = {
   locale: string;
   date?: Date;


### PR DESCRIPTION
ポスターのズームと5つのヒントから、その日の1本を当てるデイリーパズルを追加した。

出題プールは「2組織以上に選ばれ、邦題とポスターが揃っている」1,396本。日付シードで全ユーザー同じ1本を選ぶ。答えとポスターURLはクライアントに一切渡さず、ポスターは front の `/quiz/poster.png` がサーバー側で段階的にズームアウトしたPNGを生成して返す。正誤判定とヒントの開示もAPI側で行う。答えを返す `/quiz/answer` は `X-Quiz-Key` 必須で、front worker だけが呼ぶ。

回答候補は出題プール全件をページに載せてクライアント側で絞り込む。進行と成績は localStorage。

デプロイ前に両workerへ `QUIZ_ANSWER_KEY` の設定が必要。