### PR TITLE
クイズのポスターに邦題版を使わない

### DIFF
--- a/apps/api/src/__tests__/quiz-api.test.ts
+++ b/apps/api/src/__tests__/quiz-api.test.ts
@@ -13,6 +13,7 @@ import {translations} from '@shine/database/schema/translations';
 import {migrate} from 'drizzle-orm/libsql/migrator';
 import {beforeEach, describe, expect, it} from 'vitest';
 import {quizRoutes} from '../routes/quiz';
+import {QuizService} from '../services/quiz-service';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(
@@ -22,17 +23,27 @@ const migrationsFolder = path.resolve(
 
 const QUIZ_KEY = 'test-quiz-key';
 
+type SeedPoster = {url: string; languageCode?: string; isPrimary?: number};
+
 type SeedOptions = {
   uid: string;
   title?: string;
   poster?: boolean;
+  posters?: SeedPoster[];
   organizations: Array<'cannes' | 'kinema'>;
   deleted?: boolean;
 };
 
 async function seedMovie(
   database: ReturnType<typeof getDatabase>,
-  {uid, title, poster = true, organizations, deleted = false}: SeedOptions,
+  {
+    uid,
+    title,
+    poster = true,
+    posters,
+    organizations,
+    deleted = false,
+  }: SeedOptions,
 ) {
   await database.insert(movies).values({
     uid,
@@ -51,7 +62,16 @@ async function seedMovie(
     });
   }
 
-  if (poster) {
+  if (posters) {
+    await database.insert(posterUrls).values(
+      posters.map(entry => ({
+        movieUid: uid,
+        url: entry.url,
+        languageCode: entry.languageCode,
+        isPrimary: entry.isPrimary ?? 0,
+      })),
+    );
+  } else if (poster) {
     await database.insert(posterUrls).values({
       movieUid: uid,
       url: `https://image.tmdb.org/t/p/original/${uid}.jpg`,
@@ -126,6 +146,19 @@ async function createTestEnvironment(): Promise<Environment> {
     title: '削除済み',
     organizations: ['cannes', 'kinema'],
     deleted: true,
+  });
+  await seedMovie(database, {
+    uid: 'movie-with-japanese-poster',
+    title: '羅生門',
+    organizations: ['cannes', 'kinema'],
+    posters: [
+      {
+        url: 'https://image.tmdb.org/t/p/original/ja.jpg',
+        languageCode: 'ja',
+        isPrimary: 1,
+      },
+      {url: 'https://image.tmdb.org/t/p/original/intl.jpg'},
+    ],
   });
 
   return environment;
@@ -223,7 +256,11 @@ describe('GET /quiz/answer', () => {
   it('picks a movie from the pool', async () => {
     const answer = await fetchAnswer(environment);
 
-    expect(['movie-in-pool', 'movie-also-in-pool']).toContain(answer.uid);
+    expect([
+      'movie-in-pool',
+      'movie-also-in-pool',
+      'movie-with-japanese-poster',
+    ]).toContain(answer.uid);
   });
 
   it('returns the same movie for the same date', async () => {
@@ -238,6 +275,23 @@ describe('GET /quiz/answer', () => {
 
     expect(answer.focalX).toBeGreaterThanOrEqual(0);
     expect(answer.focalX).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('出題ポスター', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+  });
+
+  it('邦題が刷られたポスターを避ける', async () => {
+    const pool = await new QuizService(environment).getPool();
+    const entry = pool.find(item => item.uid === 'movie-with-japanese-poster');
+
+    expect(entry?.posterUrl).toBe(
+      'https://image.tmdb.org/t/p/original/intl.jpg',
+    );
   });
 });
 
@@ -262,6 +316,7 @@ describe('GET /quiz/candidates', () => {
     expect(candidates.map(candidate => candidate.uid).toSorted()).toEqual([
       'movie-also-in-pool',
       'movie-in-pool',
+      'movie-with-japanese-poster',
     ]);
   });
 
@@ -270,6 +325,7 @@ describe('GET /quiz/candidates', () => {
 
     expect(candidates.map(candidate => candidate.title).toSorted()).toEqual([
       '東京物語',
+      '羅生門',
       '赤ひげ',
     ]);
   });

--- a/apps/api/src/services/quiz-service.ts
+++ b/apps/api/src/services/quiz-service.ts
@@ -13,7 +13,7 @@ import {BaseService} from './base-service';
 export const QUIZ_MAX_ATTEMPTS = 6;
 
 const MINIMUM_ORGANIZATIONS = 2;
-const POOL_CACHE_KEY = 'quiz:pool:v1';
+const POOL_CACHE_KEY = 'quiz:pool:v2';
 const POOL_CACHE_TTL = 604_800;
 
 export type QuizPoolEntry = {
@@ -167,10 +167,14 @@ export class QuizService extends BaseService {
             AND translations.language_code = 'ja'
           LIMIT 1
         )`.as('title'),
+        // 邦題ポスターには答えが刷られているので最後に回す
         posterUrl: sql<string>`(
           SELECT url FROM poster_urls
           WHERE poster_urls.movie_uid = movies.uid
-          ORDER BY poster_urls.is_primary DESC
+          ORDER BY
+            CASE WHEN poster_urls.language_code = 'ja' THEN 1 ELSE 0 END ASC,
+            poster_urls.is_primary DESC,
+            poster_urls.url ASC
           LIMIT 1
         )`.as('posterUrl'),
       })


### PR DESCRIPTION
クイズのポスター選択が `is_primary DESC` だけで言語を見ておらず、出題プール1,396本のうち99本は邦題ポスターがprimaryだった。邦題ポスターには答えが刷られているので、ズームアウトの途中で読めるとゲームが終わる。

言語なし・外国語のポスターを先に取るようにした。同順は url で決めて選択を安定させている。プールのキャッシュキーを v2 に上げたのでデプロイ後に作り直される。

サイトの他の場所（`selectBestPoster`）は今まで通り ja を優先する。クイズだけ意図的に外している。