### PR TITLE
クイズの告知（OG画像とSNS投稿）

### DIFF
--- a/.github/workflows/sns-quiz-post.yml
+++ b/.github/workflows/sns-quiz-post.yml
@@ -1,0 +1,57 @@
+name: SNS Quiz Post
+
+on:
+  schedule:
+    # デイリー投稿(09:20 JST)と離して昼に告知する
+    # 実際の起動はGitHub Actionsの都合で数時間遅れることがある
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: '本文の確認のみ(投稿しない)'
+        type: boolean
+        default: false
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Post today's quiz
+        working-directory: apps/scrapers
+        run: pnpm run sns-post --quiz ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          BLUESKY_IDENTIFIER: ${{ secrets.BLUESKY_IDENTIFIER }}
+          BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_KEY_SECRET: ${{ secrets.X_API_KEY_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}

--- a/apps/front/app/lib/og/quiz-poster.test.ts
+++ b/apps/front/app/lib/og/quiz-poster.test.ts
@@ -52,6 +52,30 @@ describe('cropLayout', () => {
 
     expect(layout.left + layout.width).toBe(QUIZ_POSTER_WIDTH);
   });
+
+  it('scales the enlarged poster to the given frame', () => {
+    const layout = cropLayout({
+      zoom: 3,
+      focalX: 0.5,
+      focalY: 0.5,
+      frameWidth: 200,
+      frameHeight: 300,
+    });
+
+    expect(layout).toMatchObject({width: 600, height: 900});
+  });
+
+  it('keeps the right edge inside the given frame', () => {
+    const layout = cropLayout({
+      zoom: 3,
+      focalX: 1,
+      focalY: 0.5,
+      frameWidth: 200,
+      frameHeight: 300,
+    });
+
+    expect(layout.left + layout.width).toBe(200);
+  });
 });
 
 describe('buildQuizPosterHtml', () => {
@@ -75,5 +99,18 @@ describe('buildQuizPosterHtml', () => {
     });
 
     expect(html).toContain(`width="${QUIZ_POSTER_WIDTH * zoomForStage(0)}"`);
+  });
+
+  it('renders at the given frame size', () => {
+    const html = buildQuizPosterHtml({
+      posterDataUri: 'data:image/jpeg;base64,AAA',
+      stage: 0,
+      focalX: 0.5,
+      focalY: 0.5,
+      frameWidth: 336,
+      frameHeight: 504,
+    });
+
+    expect(html).toContain('width:336px;height:504px');
   });
 });

--- a/apps/front/app/lib/og/quiz-poster.ts
+++ b/apps/front/app/lib/og/quiz-poster.ts
@@ -36,30 +36,26 @@ export function cropLayout({
   zoom,
   focalX,
   focalY,
+  frameWidth = QUIZ_POSTER_WIDTH,
+  frameHeight = QUIZ_POSTER_HEIGHT,
 }: {
   zoom: number;
   focalX: number;
   focalY: number;
+  frameWidth?: number;
+  frameHeight?: number;
 }): CropLayout {
-  const width = Math.round(QUIZ_POSTER_WIDTH * zoom);
-  const height = Math.round(QUIZ_POSTER_HEIGHT * zoom);
+  const width = Math.round(frameWidth * zoom);
+  const height = Math.round(frameHeight * zoom);
 
   return {
     width,
     height,
     left: Math.round(
-      clamp(
-        QUIZ_POSTER_WIDTH / 2 - focalX * width,
-        QUIZ_POSTER_WIDTH - width,
-        0,
-      ),
+      clamp(frameWidth / 2 - focalX * width, frameWidth - width, 0),
     ),
     top: Math.round(
-      clamp(
-        QUIZ_POSTER_HEIGHT / 2 - focalY * height,
-        QUIZ_POSTER_HEIGHT - height,
-        0,
-      ),
+      clamp(frameHeight / 2 - focalY * height, frameHeight - height, 0),
     ),
   };
 }
@@ -69,15 +65,25 @@ export function buildQuizPosterHtml({
   stage,
   focalX,
   focalY,
+  frameWidth = QUIZ_POSTER_WIDTH,
+  frameHeight = QUIZ_POSTER_HEIGHT,
 }: {
   posterDataUri: string;
   stage: number;
   focalX: number;
   focalY: number;
+  frameWidth?: number;
+  frameHeight?: number;
 }): string {
-  const layout = cropLayout({zoom: zoomForStage(stage), focalX, focalY});
+  const layout = cropLayout({
+    zoom: zoomForStage(stage),
+    focalX,
+    focalY,
+    frameWidth,
+    frameHeight,
+  });
 
-  return `<div style="display:flex;position:relative;width:${QUIZ_POSTER_WIDTH}px;height:${QUIZ_POSTER_HEIGHT}px;overflow:hidden;background:${COLORS.paper};border:8px solid ${COLORS.ink};">
+  return `<div style="display:flex;position:relative;width:${frameWidth}px;height:${frameHeight}px;overflow:hidden;background:${COLORS.paper};border:8px solid ${COLORS.ink};">
   <img src="${posterDataUri}" width="${layout.width}" height="${layout.height}" style="position:absolute;left:${layout.left}px;top:${layout.top}px;" />
 </div>`;
 }

--- a/apps/front/app/lib/og/template.test.ts
+++ b/apps/front/app/lib/og/template.test.ts
@@ -3,6 +3,7 @@ import {
   buildBannerHtml,
   buildHomeCardHtml,
   buildMovieCardHtml,
+  buildQuizCardHtml,
   escapeHtml,
   splitYear,
   titleFontSize,
@@ -111,6 +112,54 @@ describe('buildHomeCardHtml', () => {
 
   it('日本語のタグラインを含む', () => {
     expect(buildHomeCardHtml()).toContain('毎日1本、埋もれた映画に光を当てる');
+  });
+});
+
+describe('buildQuizCardHtml', () => {
+  const baseProperties = {
+    date: '2026-08-16',
+    poolSize: 1396,
+    posterDataUri: 'data:image/jpeg;base64,abc',
+  };
+
+  it('クイズの見出しを含む', () => {
+    expect(buildQuizCardHtml(baseProperties)).toContain('今日の映画クイズ');
+  });
+
+  it('出題日を含む', () => {
+    expect(buildQuizCardHtml(baseProperties)).toContain('2026-08-16');
+  });
+
+  it('出題プールの本数を含む', () => {
+    expect(buildQuizCardHtml(baseProperties)).toContain('1,396');
+  });
+
+  it('ポスターをdata URIで埋め込む', () => {
+    expect(buildQuizCardHtml(baseProperties)).toContain(
+      'data:image/jpeg;base64,abc',
+    );
+  });
+
+  it('ポスターを切り出して表示する', () => {
+    expect(buildQuizCardHtml(baseProperties)).toContain('overflow:hidden');
+  });
+
+  it('ポスターが無ければimgタグを出さない', () => {
+    const html = buildQuizCardHtml({
+      ...baseProperties,
+      posterDataUri: undefined,
+    });
+
+    expect(html).not.toContain('<img');
+  });
+
+  it('ポスターが無くても見出しは出す', () => {
+    const html = buildQuizCardHtml({
+      ...baseProperties,
+      posterDataUri: undefined,
+    });
+
+    expect(html).toContain('今日の映画クイズ');
   });
 });
 

--- a/apps/front/app/lib/og/template.ts
+++ b/apps/front/app/lib/og/template.ts
@@ -4,6 +4,8 @@
  * (子がテキスト1つでも省略するとレンダリングが失敗する)
  * 配色はサイトのライトテーマ(tokens.css)に固定する。
  */
+import {buildQuizPosterHtml} from './quiz-poster';
+
 const COLORS = {
   paper: '#ece8df',
   surface: '#ffffff',
@@ -116,6 +118,49 @@ export function buildMovieCardHtml({
     <div style="display:flex;gap:14px;flex-wrap:wrap;">${chips}</div>
   </div>
   ${posterHtml}
+</div>`;
+}
+
+const QUIZ_CARD_FRAME_WIDTH = 324;
+const QUIZ_CARD_FRAME_HEIGHT = 486;
+
+type QuizCardProperties = {
+  date: string;
+  poolSize: number;
+  posterDataUri?: string;
+};
+
+export function buildQuizCardHtml({
+  date,
+  poolSize,
+  posterDataUri,
+}: QuizCardProperties): string {
+  const cropHtml = posterDataUri
+    ? buildQuizPosterHtml({
+        posterDataUri,
+        stage: 0,
+        focalX: 0.5,
+        focalY: 0.5,
+        frameWidth: QUIZ_CARD_FRAME_WIDTH,
+        frameHeight: QUIZ_CARD_FRAME_HEIGHT,
+      })
+    : '';
+
+  return `<div style="display:flex;width:${OG_WIDTH}px;height:${OG_HEIGHT}px;background:${COLORS.paper};border:16px solid ${COLORS.ink};padding:40px 48px;justify-content:space-between;align-items:center;">
+  <div style="display:flex;flex-direction:column;justify-content:space-between;height:100%;flex:1;padding-right:40px;">
+    <div style="display:flex;align-items:flex-end;justify-content:space-between;border-bottom:5px solid ${COLORS.ink};padding-bottom:12px;">
+      <div style="display:flex;font-size:54px;font-weight:700;letter-spacing:-3px;color:${COLORS.ink};">SHINE</div>
+      <div style="display:flex;font-size:22px;color:${COLORS.inkMuted};">${TAGLINE}</div>
+    </div>
+    <div style="display:flex;flex-direction:column;">
+      <div style="display:flex;font-size:28px;font-weight:700;letter-spacing:6px;color:${COLORS.brand};">TODAY’S QUIZ</div>
+      <div style="display:flex;font-size:76px;font-weight:700;letter-spacing:-4px;color:${COLORS.ink};margin-top:10px;">今日の映画クイズ</div>
+      <div style="display:flex;font-size:30px;color:${COLORS.inkMuted};margin-top:20px;">ポスターの一部と5つのヒントで当てる</div>
+      <div style="display:flex;font-size:26px;color:${COLORS.inkMuted};margin-top:12px;">受賞作${poolSize.toLocaleString('ja-JP')}本から毎日1問 — ${escapeHtml(date)}</div>
+    </div>
+    <div style="display:flex;background:${COLORS.brand};color:${COLORS.brandOn};border:3px solid ${COLORS.ink};padding:8px 22px;font-size:28px;font-weight:700;">shine-film.com/quiz</div>
+  </div>
+  ${cropHtml}
 </div>`;
 }
 

--- a/apps/front/app/routes.ts
+++ b/apps/front/app/routes.ts
@@ -20,6 +20,7 @@ export default [
   route('og/movie.png', 'routes/og-movie.tsx'),
   route('og/home.png', 'routes/og-home.tsx'),
   route('og/banner.png', 'routes/og-banner.tsx'),
+  route('og/quiz.png', 'routes/og-quiz.tsx'),
   route('admin/login', 'routes/admin.login.tsx'),
   route('admin/movies', 'routes/admin.movies.tsx'),
   route('admin/movies/:id', 'routes/admin.movies.$id.tsx'),

--- a/apps/front/app/routes/og-quiz.tsx
+++ b/apps/front/app/routes/og-quiz.tsx
@@ -1,0 +1,77 @@
+import {ImageResponse} from 'workers-og';
+import type {Route} from './+types/og-quiz';
+import {resolveApiUrl, resolveQuizKey} from '@/lib/api';
+import {fetchPosterAsDataUri, loadGoogleFont} from '@/lib/og/assets';
+import {OG_HEIGHT, OG_WIDTH, buildQuizCardHtml} from '@/lib/og/template';
+import {upgradePosterForSharing} from '@/lib/meta';
+
+const CACHE_CONTROL = 'public, max-age=3600';
+
+type QuizAnswer = {
+  posterUrl: string;
+  focalX: number;
+  focalY: number;
+};
+
+async function fetchTodaysPoster(
+  context: unknown,
+  signal: AbortSignal,
+): Promise<string | undefined> {
+  const quizKey = resolveQuizKey(context);
+  if (!quizKey) {
+    return undefined;
+  }
+
+  const response = await fetch(`${resolveApiUrl(context)}/quiz/answer`, {
+    headers: {'X-Quiz-Key': quizKey},
+    signal,
+  });
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const answer = (await response.json()) as QuizAnswer;
+  return fetchPosterAsDataUri(upgradePosterForSharing(answer.posterUrl));
+}
+
+// クエリの date はキャッシュ回避用で、描画は必ずAPIが返す当日分を使う
+export async function loader({context, request}: Route.LoaderArgs) {
+  const dailyResponse = await fetch(`${resolveApiUrl(context)}/quiz/daily`, {
+    signal: request.signal,
+  });
+  if (!dailyResponse.ok) {
+    return new Response('Quiz unavailable', {status: 503});
+  }
+
+  const {date, poolSize} = (await dailyResponse.json()) as {
+    date: string;
+    poolSize: number;
+  };
+
+  const posterDataUri = await fetchTodaysPoster(context, request.signal);
+  const html = buildQuizCardHtml({date, poolSize, posterDataUri});
+  const notoSans = await loadGoogleFont('Noto Sans JP', 700, html);
+
+  if (!notoSans) {
+    return new Response('Font unavailable', {status: 503});
+  }
+
+  const image = new ImageResponse(html, {
+    width: OG_WIDTH,
+    height: OG_HEIGHT,
+    fonts: [
+      {name: 'Noto Sans JP', data: notoSans, weight: 700, style: 'normal'},
+    ],
+  });
+
+  // ストリームのままだとレンダリング失敗が空レスポンスに化けるため、先に全量を読む
+  const body = await image.arrayBuffer();
+
+  return new Response(body, {
+    status: image.status,
+    headers: {
+      'Content-Type': 'image/png',
+      'Cache-Control': CACHE_CONTROL,
+    },
+  });
+}

--- a/apps/front/app/routes/quiz.test.tsx
+++ b/apps/front/app/routes/quiz.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import QuizPage, {loader} from './quiz';
+import QuizPage, {loader, meta} from './quiz';
 import type {Route} from './+types/quiz';
 import {QUIZ_STATE_KEY} from '@/lib/quiz-state';
 
@@ -73,6 +73,19 @@ describe('Quiz page', () => {
           }),
         ),
       ).rejects.toMatchObject({status: 502});
+    });
+  });
+
+  describe('meta', () => {
+    it('クイズ専用のOG画像を出題日付きで指す', () => {
+      const descriptors = meta(
+        cast<Route.MetaArgs>({data: {puzzle: PUZZLE, locale: 'ja'}}),
+      );
+
+      expect(descriptors).toContainEqual({
+        property: 'og:image',
+        content: 'https://shine-film.com/og/quiz.png?date=2026-08-16',
+      });
     });
   });
 

--- a/apps/front/app/routes/quiz.tsx
+++ b/apps/front/app/routes/quiz.tsx
@@ -24,7 +24,10 @@ import {
 const SUGGESTION_LIMIT = 8;
 
 export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
-  const {locale} = data as {locale?: Locale};
+  const {locale, puzzle} = data as {locale?: Locale; puzzle?: {date: string}};
+  const imageUrl = puzzle
+    ? `${SITE_URL}/og/quiz.png?date=${puzzle.date}`
+    : `${SITE_URL}/og/quiz.png`;
 
   return buildSocialMeta({
     title: '今日の映画クイズ | SHINE',
@@ -32,7 +35,7 @@ export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
       'ポスターの一部と5つのヒントから、今日の1本を当てる。カンヌ・アカデミー賞・キネマ旬報などに選ばれた映画から毎日1問。',
     path: '/quiz',
     locale: locale ?? DEFAULT_LOCALE,
-    imageUrl: `${SITE_URL}/og/home.png`,
+    imageUrl,
     largeImage: true,
   });
 }

--- a/apps/scrapers/src/sns-post-cli.ts
+++ b/apps/scrapers/src/sns-post-cli.ts
@@ -6,6 +6,7 @@
  * 使い方:
  *   pnpm run sns-post --dry-run   投稿せず本文とカード情報を表示
  *   pnpm run sns-post             実際に投稿する
+ *   pnpm run sns-post --quiz      デイリーセレクションではなく今日のクイズを告知する
  *
  * 必要な環境変数(実投稿時、設定があるサービスにだけ投稿する):
  *   BLUESKY_IDENTIFIER   例: shine-film.com
@@ -24,7 +25,12 @@ import {
   publishPost,
   uploadBlob,
 } from './sns/bluesky';
-import {buildDailyPostText, buildXPostText} from './sns/post-text';
+import {
+  buildDailyPostText,
+  buildQuizPostText,
+  buildQuizXPostText,
+  buildXPostText,
+} from './sns/post-text';
 import {postTweet, type XCredentials} from './sns/x';
 
 loadEnvironmentFiles();
@@ -60,10 +66,20 @@ async function fetchDailyMovie(): Promise<SelectionMovie> {
   return data.daily;
 }
 
-async function fetchOgImage(
-  movieUid: string,
-): Promise<ArrayBuffer | undefined> {
-  const response = await fetch(`${SITE_URL}/og/movie.png?id=${movieUid}`);
+async function fetchQuizPuzzle(): Promise<{date: string; poolSize: number}> {
+  const response = await fetch(`${API_URL}/quiz/daily`, {
+    headers: {Origin: SITE_URL},
+  });
+
+  if (!response.ok) {
+    throw new Error(`Quiz API failed: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as {date: string; poolSize: number};
+}
+
+async function fetchOgImage(url: string): Promise<ArrayBuffer | undefined> {
+  const response = await fetch(url);
   return response.ok ? response.arrayBuffer() : undefined;
 }
 
@@ -80,7 +96,7 @@ function getXCredentials(): XCredentials | undefined {
 
 async function postToBluesky(
   text: string,
-  movieUid: string,
+  imageUrl: string,
   link: {uri: string; title: string; description: string},
 ): Promise<void> {
   const identifier = process.env.BLUESKY_IDENTIFIER;
@@ -91,7 +107,7 @@ async function postToBluesky(
   }
 
   const session = await createSession(identifier, password);
-  const ogImage = await fetchOgImage(movieUid);
+  const ogImage = await fetchOgImage(imageUrl);
   const thumb = ogImage
     ? await uploadBlob(session, ogImage, 'image/png')
     : undefined;
@@ -120,9 +136,14 @@ async function postToX(text: string): Promise<void> {
   console.log(`X: 投稿しました https://x.com/i/status/${result.id}`);
 }
 
-async function main() {
-  const isDryRun = process.argv.includes('--dry-run');
+type PostPlan = {
+  text: string;
+  xText: string;
+  link: {uri: string; title: string; description: string};
+  imageUrl: string;
+};
 
+async function buildDailyPlan(): Promise<PostPlan> {
   const movie = await fetchDailyMovie();
   const title = movie.title!;
   const organizations = [
@@ -147,20 +168,50 @@ async function main() {
     url: `${SITE_URL}/movies/${movie.uid}`,
   });
 
-  const link = {
-    uri: `${SITE_URL}/movies/${movie.uid}`,
-    title: `${title}${movie.year ? ` (${movie.year})` : ''} | SHINE`,
-    description: `『${title}』をいま観られるかをまとめています。`,
+  return {
+    text,
+    xText,
+    link: {
+      uri: `${SITE_URL}/movies/${movie.uid}`,
+      title: `${title}${movie.year ? ` (${movie.year})` : ''} | SHINE`,
+      description: `『${title}』をいま観られるかをまとめています。`,
+    },
+    imageUrl: `${SITE_URL}/og/movie.png?id=${movie.uid}`,
   };
+}
+
+async function buildQuizPlan(): Promise<PostPlan> {
+  // 出題日はAPIに従う(ジョブの起動が遅れても昨日の問題を告知しない)
+  const puzzle = await fetchQuizPuzzle();
+  const url = `${SITE_URL}/quiz`;
+
+  return {
+    text: buildQuizPostText(puzzle),
+    xText: buildQuizXPostText({...puzzle, url}),
+    link: {
+      uri: url,
+      title: '今日の映画クイズ | SHINE',
+      description:
+        'ポスターの一部と5つのヒントから、今日の1本を当てる。毎日1問。',
+    },
+    imageUrl: `${SITE_URL}/og/quiz.png?date=${puzzle.date}`,
+  };
+}
+
+async function main() {
+  const isDryRun = process.argv.includes('--dry-run');
+  const plan = process.argv.includes('--quiz')
+    ? await buildQuizPlan()
+    : await buildDailyPlan();
 
   console.log('--- Bluesky投稿内容 ---');
-  console.log(text);
+  console.log(plan.text);
   console.log('--- リンクカード ---');
-  console.log(`uri:   ${link.uri}`);
-  console.log(`title: ${link.title}`);
-  console.log(`thumb: ${SITE_URL}/og/movie.png?id=${movie.uid}`);
+  console.log(`uri:   ${plan.link.uri}`);
+  console.log(`title: ${plan.link.title}`);
+  console.log(`thumb: ${plan.imageUrl}`);
   console.log('--- X投稿内容 ---');
-  console.log(xText);
+  console.log(plan.xText);
 
   if (isDryRun) {
     console.log('\n(dry-run: 投稿していません)');
@@ -169,14 +220,14 @@ async function main() {
 
   const errors: Error[] = [];
   try {
-    await postToBluesky(text, movie.uid, link);
+    await postToBluesky(plan.text, plan.imageUrl, plan.link);
   } catch (error) {
     errors.push(error as Error);
     console.error('Bluesky: 投稿に失敗しました:', error);
   }
 
   try {
-    await postToX(xText);
+    await postToX(plan.xText);
   } catch (error) {
     errors.push(error as Error);
     console.error('X: 投稿に失敗しました:', error);

--- a/apps/scrapers/src/sns/post-text.test.ts
+++ b/apps/scrapers/src/sns/post-text.test.ts
@@ -1,5 +1,11 @@
 import {describe, expect, it} from 'vitest';
-import {buildDailyPostText, buildXPostText, xWeightedLength} from './post-text';
+import {
+  buildDailyPostText,
+  buildQuizPostText,
+  buildQuizXPostText,
+  buildXPostText,
+  xWeightedLength,
+} from './post-text';
 
 const base = {
   title: 'ハウスメイド',
@@ -71,6 +77,55 @@ describe('buildDailyPostText', () => {
 
     expect([...text].length).toBeLessThanOrEqual(300);
     expect(text).toMatch(/#青空映画部$/);
+  });
+});
+
+describe('buildQuizPostText', () => {
+  const quizBase = {date: '2026-08-16', poolSize: 1396};
+
+  it('出題日を月日で入れる', () => {
+    expect(buildQuizPostText(quizBase)).toContain('8/16');
+  });
+
+  it('遊び方を説明する', () => {
+    expect(buildQuizPostText(quizBase)).toContain('ヒント');
+  });
+
+  it('出題プールの本数を含む', () => {
+    expect(buildQuizPostText(quizBase)).toContain('1,396本');
+  });
+
+  it('末尾に #青空映画部 タグを付ける', () => {
+    expect(buildQuizPostText(quizBase)).toMatch(/#青空映画部$/);
+  });
+
+  it('300字(Blueskyの上限)を超えない', () => {
+    expect([...buildQuizPostText(quizBase)].length).toBeLessThanOrEqual(300);
+  });
+});
+
+describe('buildQuizXPostText', () => {
+  const quizBase = {
+    date: '2026-08-16',
+    poolSize: 1396,
+    url: 'https://shine-film.com/quiz',
+  };
+
+  it('本文の末尾にスキームを外したURLを含む', () => {
+    const text = buildQuizXPostText(quizBase);
+
+    expect(text).toMatch(/\nshine-film\.com\/quiz$/);
+    expect(text).not.toContain('https://');
+  });
+
+  it('ハッシュタグは付けない', () => {
+    expect(buildQuizXPostText(quizBase)).not.toContain('#');
+  });
+
+  it('weighted長が280以内に収まる', () => {
+    expect(xWeightedLength(buildQuizXPostText(quizBase))).toBeLessThanOrEqual(
+      280,
+    );
   });
 });
 

--- a/apps/scrapers/src/sns/post-text.ts
+++ b/apps/scrapers/src/sns/post-text.ts
@@ -42,6 +42,31 @@ export function buildDailyPostText(input: DailyPostInput): string {
   return `${truncatedBody}\n${HASHTAG}`;
 }
 
+type QuizPostInput = {
+  date: string;
+  poolSize: number;
+};
+
+function buildQuizBody({date, poolSize}: QuizPostInput): string {
+  const [, month, day] = date.split('-');
+
+  return [
+    `今日の映画クイズ（${Number(month)}/${Number(day)}）`,
+    'ポスターの一部と5つのヒントから、今日の1本を当てる。',
+    `受賞作${poolSize.toLocaleString('en-US')}本から毎日1問。`,
+  ].join('\n');
+}
+
+export function buildQuizPostText(input: QuizPostInput): string {
+  return `${buildQuizBody(input)}\n${HASHTAG}`;
+}
+
+export function buildQuizXPostText(
+  input: QuizPostInput & {url: string},
+): string {
+  return `${buildQuizBody(input)}\n${input.url.replace(/^https?:\/\//, '')}`;
+}
+
 export function xWeightedLength(text: string): number {
   let length = 0;
   for (const character of text) {


### PR DESCRIPTION
/quiz を人に見せるための2点。

- `/og/quiz.png` を追加。今日のポスターの一部（プレイ開始時と同じ切り出し）と出題日を載せた1200x630のカードを返す。/quiz の og:image をこれに差し替え、URLに出題日を付けてSNS側のキャッシュを日ごとに切り替える。答えを漏らさないよう、ポスターはこれまで通り `/quiz/answer` 経由で取り、リンクカードのタイトルや説明には作品名を入れない。
- `sns-post --quiz` を追加。Bluesky はリンクカード付き、X は裸URLで `shine-film.com/quiz` を告知する。出題日はローカルで計算せずAPIの `/quiz/daily` に従う（ジョブの起動が遅れても昨日の問題を告知しないため）。
- デイリー投稿(09:20 JST)と連投にならないよう、告知は別ワークフローで12:00 JSTに出す。

Xの費用は裸URLなので $0.015/日（年 $5.5）。