### PR TITLE
ヘッダのナビがスマホではみ出るのを直す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ Cloudflare Workers: non-secret vars go in `wrangler.jsonc`/`wrangler.toml` `vars
 - Admin pages authenticate with a JWT held in localStorage
 - API URL resolution: always `resolveApiUrl(context)` from `@/lib/api` — never hand-cast `context.cloudflare`
 - Tests: Vitest + React Testing Library, co-located `*.test.tsx`
+- **Masthead のナビ**: 項目は `NAV_LINKS` に足す。ボタンの行は `flex-wrap` 前提で、横並び固定にすると狭い画面で必ずはみ出す（過去2回のデグレ原因）
+- **横幅のはみ出し確認**: 共通レイアウトやヘッダを触ったら `agent-browser set viewport 375 812` の後、各ページで `document.documentElement.scrollWidth <= clientWidth` を確認する（jsdomはレイアウトを持たないのでvitestでは検出できない）
 
 ## Code Style and Conventions
 

--- a/apps/front/app/components/editorial/masthead.test.tsx
+++ b/apps/front/app/components/editorial/masthead.test.tsx
@@ -51,4 +51,14 @@ describe('Masthead', () => {
 
     expect(screen.getByText(/A FORGOTTEN FILM/i)).toBeInTheDocument();
   });
+
+  it('ナビゲーションは折り返す(項目を増やしても横幅からはみ出さないため)', () => {
+    render(<Masthead locale="ja" />);
+
+    const navigation = screen.getByRole('link', {
+      name: /search/i,
+    }).parentElement;
+
+    expect(navigation).toHaveClass('flex-wrap');
+  });
 });

--- a/apps/front/app/components/editorial/masthead.tsx
+++ b/apps/front/app/components/editorial/masthead.tsx
@@ -13,6 +13,12 @@ const TAGLINES = {
   en: ['A FORGOTTEN FILM,', 'EVERY DAY'],
 } as const;
 
+const NAV_LINKS = [
+  {href: '/quiz', label: 'QUIZ', ariaLabel: 'Quiz'},
+  {href: '/daily', label: 'DAILY', ariaLabel: 'Daily picks'},
+  {href: '/awards', label: 'AWARDS', ariaLabel: 'Awards'},
+] as const;
+
 export function Masthead({locale = 'en'}: {locale?: string}) {
   const [taglineTop, taglineBottom] =
     TAGLINES[locale as keyof typeof TAGLINES] ?? TAGLINES.en;
@@ -24,31 +30,22 @@ export function Masthead({locale = 'en'}: {locale?: string}) {
           SHINE
         </a>
       </h1>
-      <div className="ml-auto flex items-center gap-2 md:gap-3">
+      <div className="ml-auto flex flex-wrap items-center justify-end gap-2 md:gap-3">
         <p className="hidden md:block text-right font-mono text-[10px] leading-tight text-ink-muted">
           {taglineTop}
           <br />
           {taglineBottom} — {today()}
         </p>
         <LanguageSelector locale={locale} />
-        <a
-          href="/quiz"
-          aria-label="Quiz"
-          className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">
-          QUIZ
-        </a>
-        <a
-          href="/daily"
-          aria-label="Daily picks"
-          className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">
-          DAILY
-        </a>
-        <a
-          href="/awards"
-          aria-label="Awards"
-          className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">
-          AWARDS
-        </a>
+        {NAV_LINKS.map(link => (
+          <a
+            key={link.href}
+            href={link.href}
+            aria-label={link.ariaLabel}
+            className="font-mono text-xs font-bold px-2.5 py-1 border-2 border-ink text-ink">
+            {link.label}
+          </a>
+        ))}
         <a
           href="/search"
           aria-label="Search"


### PR DESCRIPTION
QUIZ ボタンを足した分でヘッダのボタン列が 375px 幅を超え、ページ全体が横スクロールしていた（375px で scrollWidth 432）。

- ボタン列を `flex-wrap` にして、項目が増えても折り返して収まるようにした。リンクは `NAV_LINKS` 配列にまとめ、追加は1行で済むようにした
- 320 / 375 / 414px の各幅でトップ・/quiz・/awards・/daily・/search・映画詳細に横はみ出しが無いことを確認。デスクトップの見た目は変更なし

再発防止として、`flex-wrap` が外れたら落ちるテストを masthead.test.tsx に追加し、確認手順を CLAUDE.md に書いた。jsdom はレイアウトを持たないので実寸の検証は vitest では不可能で、ブラウザでの `scrollWidth <= clientWidth` チェックが要る。