### PR TITLE
クイズのOG画像を出題と同じ焦点で切り出す

### DIFF
--- a/apps/front/app/lib/og/template.test.ts
+++ b/apps/front/app/lib/og/template.test.ts
@@ -144,6 +144,26 @@ describe('buildQuizCardHtml', () => {
     expect(buildQuizCardHtml(baseProperties)).toContain('overflow:hidden');
   });
 
+  it('渡された焦点で切り出す(出題ページと同じ範囲にするため)', () => {
+    const html = buildQuizCardHtml({
+      ...baseProperties,
+      focalX: 0,
+      focalY: 0,
+    });
+
+    expect(html).toContain('left:0px;top:0px');
+  });
+
+  it('焦点が右下なら右下を切り出す', () => {
+    const html = buildQuizCardHtml({
+      ...baseProperties,
+      focalX: 1,
+      focalY: 1,
+    });
+
+    expect(html).not.toContain('left:0px;top:0px');
+  });
+
   it('ポスターが無ければimgタグを出さない', () => {
     const html = buildQuizCardHtml({
       ...baseProperties,

--- a/apps/front/app/lib/og/template.ts
+++ b/apps/front/app/lib/og/template.ts
@@ -128,19 +128,23 @@ type QuizCardProperties = {
   date: string;
   poolSize: number;
   posterDataUri?: string;
+  focalX?: number;
+  focalY?: number;
 };
 
 export function buildQuizCardHtml({
   date,
   poolSize,
   posterDataUri,
+  focalX = 0.5,
+  focalY = 0.5,
 }: QuizCardProperties): string {
   const cropHtml = posterDataUri
     ? buildQuizPosterHtml({
         posterDataUri,
         stage: 0,
-        focalX: 0.5,
-        focalY: 0.5,
+        focalX,
+        focalY,
         frameWidth: QUIZ_CARD_FRAME_WIDTH,
         frameHeight: QUIZ_CARD_FRAME_HEIGHT,
       })

--- a/apps/front/app/routes/og-quiz.tsx
+++ b/apps/front/app/routes/og-quiz.tsx
@@ -13,13 +13,15 @@ type QuizAnswer = {
   focalY: number;
 };
 
+type PosterCrop = {posterDataUri?: string; focalX?: number; focalY?: number};
+
 async function fetchTodaysPoster(
   context: unknown,
   signal: AbortSignal,
-): Promise<string | undefined> {
+): Promise<PosterCrop> {
   const quizKey = resolveQuizKey(context);
   if (!quizKey) {
-    return undefined;
+    return {};
   }
 
   const response = await fetch(`${resolveApiUrl(context)}/quiz/answer`, {
@@ -27,11 +29,17 @@ async function fetchTodaysPoster(
     signal,
   });
   if (!response.ok) {
-    return undefined;
+    return {};
   }
 
   const answer = (await response.json()) as QuizAnswer;
-  return fetchPosterAsDataUri(upgradePosterForSharing(answer.posterUrl));
+  return {
+    posterDataUri: await fetchPosterAsDataUri(
+      upgradePosterForSharing(answer.posterUrl),
+    ),
+    focalX: answer.focalX,
+    focalY: answer.focalY,
+  };
 }
 
 // クエリの date はキャッシュ回避用で、描画は必ずAPIが返す当日分を使う
@@ -48,8 +56,8 @@ export async function loader({context, request}: Route.LoaderArgs) {
     poolSize: number;
   };
 
-  const posterDataUri = await fetchTodaysPoster(context, request.signal);
-  const html = buildQuizCardHtml({date, poolSize, posterDataUri});
+  const crop = await fetchTodaysPoster(context, request.signal);
+  const html = buildQuizCardHtml({date, poolSize, ...crop});
   const notoSans = await loadGoogleFont('Noto Sans JP', 700, html);
 
   if (!notoSans) {


### PR DESCRIPTION
PR #287 のOGカードが焦点を0.5固定で切り出していて、出題ページ（日付シードの焦点）とは違う範囲が見えていた。2枚を並べると見える面積が実質2倍になるうえ、ポスターの中央はタイトルや主演の顔が入りやすく、原題から答えが割れうる。

`/quiz/answer` が返す focalX/focalY をカードにも渡し、出題ページの stage 0 と同一の範囲にした。ローカルで両方を出力して同じ範囲であることを確認済み。