### PR TITLE
映画詳細ページを読めるページにする

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -1948,6 +1948,9 @@ components:
         name:
           type: string
           description: Category name
+        displayName:
+          type: [string, 'null']
+          description: Japanese name of the award, returned only for `locale=ja`
       required:
         - uid
         - name
@@ -2212,6 +2215,9 @@ components:
         shortName:
           type: [string, 'null']
           description: Organization short name or abbreviation
+        displayName:
+          type: [string, 'null']
+          description: Japanese name of the organization, returned only for `locale=ja`
         slug:
           type: [string, 'null']
           description: Slug of the award page on the frontend (/awards/{slug}), if one exists

--- a/apps/api/src/__tests__/app-e2e.test.ts
+++ b/apps/api/src/__tests__/app-e2e.test.ts
@@ -125,6 +125,24 @@ describe('GET /movies/:id', () => {
   });
 });
 
+async function goldenLionNomination(locale: string) {
+  const response = await app.request(
+    `/movies/movie-a?locale=${locale}`,
+    {},
+    environment,
+  );
+  const body = (await response.json()) as {
+    nominations: Array<{
+      category: {name: string; displayName?: string};
+      organization: {name: string; displayName?: string};
+    }>;
+  };
+
+  return body.nominations.find(
+    nomination => nomination.category.name === 'Golden Lion',
+  );
+}
+
 describe('GET /movies/:id の賞の表示名', () => {
   beforeEach(async () => {
     const database = getDatabase(environment);
@@ -148,36 +166,20 @@ describe('GET /movies/:id の賞の表示名', () => {
     });
   });
 
-  async function nominationOf(locale: string) {
-    const response = await app.request(
-      `/movies/movie-a?locale=${locale}`,
-      {},
-      environment,
-    );
-    const body = (await response.json()) as {
-      nominations: Array<{
-        category: {name: string; displayName?: string};
-        organization: {name: string; displayName?: string};
-      }>;
-    };
-
-    return body.nominations.find(
-      nomination => nomination.category.name === 'Golden Lion',
-    );
-  }
-
   it('日本語ロケールでは組織名を日本語で返す', async () => {
-    expect((await nominationOf('ja'))?.organization.displayName).toBe(
-      'ヴェネツィア国際映画祭',
-    );
+    const nomination = await goldenLionNomination('ja');
+
+    expect(nomination?.organization.displayName).toBe('ヴェネツィア国際映画祭');
   });
 
   it('日本語ロケールでは賞の名前を日本語で返す', async () => {
-    expect((await nominationOf('ja'))?.category.displayName).toBe('金獅子賞');
+    const nomination = await goldenLionNomination('ja');
+
+    expect(nomination?.category.displayName).toBe('金獅子賞');
   });
 
   it('英語ロケールでは日本語の表示名を返さない', async () => {
-    const nomination = await nominationOf('en');
+    const nomination = await goldenLionNomination('en');
 
     expect(nomination?.organization.displayName).toBeUndefined();
     expect(nomination?.category.displayName).toBeUndefined();

--- a/apps/api/src/__tests__/app-e2e.test.ts
+++ b/apps/api/src/__tests__/app-e2e.test.ts
@@ -125,6 +125,65 @@ describe('GET /movies/:id', () => {
   });
 });
 
+describe('GET /movies/:id の賞の表示名', () => {
+  beforeEach(async () => {
+    const database = getDatabase(environment);
+    await database
+      .insert(awardOrganizations)
+      .values({uid: 'org-venice', name: 'Venice Film Festival'});
+    await database.insert(awardCeremonies).values({
+      uid: 'ceremony-venice',
+      organizationUid: 'org-venice',
+      year: 1951,
+    });
+    await database.insert(awardCategories).values({
+      uid: 'category-golden-lion',
+      organizationUid: 'org-venice',
+      name: 'Golden Lion',
+    });
+    await database.insert(nominations).values({
+      movieUid: 'movie-a',
+      ceremonyUid: 'ceremony-venice',
+      categoryUid: 'category-golden-lion',
+    });
+  });
+
+  async function nominationOf(locale: string) {
+    const response = await app.request(
+      `/movies/movie-a?locale=${locale}`,
+      {},
+      environment,
+    );
+    const body = (await response.json()) as {
+      nominations: Array<{
+        category: {name: string; displayName?: string};
+        organization: {name: string; displayName?: string};
+      }>;
+    };
+
+    return body.nominations.find(
+      nomination => nomination.category.name === 'Golden Lion',
+    );
+  }
+
+  it('日本語ロケールでは組織名を日本語で返す', async () => {
+    expect((await nominationOf('ja'))?.organization.displayName).toBe(
+      'ヴェネツィア国際映画祭',
+    );
+  });
+
+  it('日本語ロケールでは賞の名前を日本語で返す', async () => {
+    expect((await nominationOf('ja'))?.category.displayName).toBe('金獅子賞');
+  });
+
+  it('英語ロケールでは日本語の表示名を返さない', async () => {
+    const nomination = await nominationOf('en');
+
+    expect(nomination?.organization.displayName).toBeUndefined();
+    expect(nomination?.category.displayName).toBeUndefined();
+  });
+});
+
 async function postLogin(password: string) {
   return app.request(
     '/auth/login',

--- a/apps/api/src/cache.test.ts
+++ b/apps/api/src/cache.test.ts
@@ -34,8 +34,8 @@ describe('Cache Utilities', () => {
       const fullKey = getCacheKeyForMovie(movieId, true);
       const englishKey = getCacheKeyForMovie(movieId, false, 'en');
 
-      expect(basicKey).toBe(`movie:${movieId}:basic:ja:v3`);
-      expect(fullKey).toBe(`movie:${movieId}:full:ja:v3`);
+      expect(basicKey).toBe(`movie:${movieId}:basic:ja:v4`);
+      expect(fullKey).toBe(`movie:${movieId}:full:ja:v4`);
       expect(basicKey).not.toBe(fullKey);
       expect(englishKey).not.toBe(basicKey);
     });

--- a/apps/api/src/services/__tests__/awards-service.test.ts
+++ b/apps/api/src/services/__tests__/awards-service.test.ts
@@ -15,6 +15,7 @@ import {beforeEach, describe, expect, it} from 'vitest';
 import {
   AwardsService,
   awardPageLinkForOrganizationName,
+  japaneseAwardNames,
   paginateAwardDetail,
 } from '../awards-service';
 
@@ -628,6 +629,26 @@ describe('awardPageLinkForOrganizationName', () => {
       slug: undefined,
       hasYearPages: false,
     });
+  });
+});
+
+describe('japaneseAwardNames', () => {
+  it('組織名の日本語表記を返す', () => {
+    expect(japaneseAwardNames('Venice Film Festival', 'Golden Lion')).toEqual({
+      organization: 'ヴェネツィア国際映画祭',
+      category: '金獅子賞',
+    });
+  });
+
+  it('複数の賞ページを持つ組織はカテゴリで選ぶ', () => {
+    expect(japaneseAwardNames('Kinema Junpo', 'Best Japanese Film')).toEqual({
+      organization: 'キネマ旬報',
+      category: '日本映画ベスト・テン',
+    });
+  });
+
+  it('賞ページの無い組織には何も返さない', () => {
+    expect(japaneseAwardNames('Unknown Org', 'Unknown Category')).toEqual({});
   });
 });
 

--- a/apps/api/src/services/awards-service.ts
+++ b/apps/api/src/services/awards-service.ts
@@ -45,6 +45,17 @@ export function awardPageLinkForOrganizationName(
   };
 }
 
+export function japaneseAwardNames(
+  organizationName: string,
+  categoryName: string,
+): {organization?: string; category?: string} {
+  const definition = findAwardPageDefinition(organizationName, categoryName);
+
+  return definition
+    ? {organization: definition.organization, category: definition.name}
+    : {};
+}
+
 const RANK_PATTERN = /^(\d+)位$/;
 
 function rankOf(entry: AwardMovieEntry): number {

--- a/apps/api/src/services/movies-service.ts
+++ b/apps/api/src/services/movies-service.ts
@@ -14,7 +14,10 @@ import {
   getMovieCacheKeysForAllLocales,
   normalizeCacheLocale,
 } from '../utils/cache';
-import {awardPageLinkForOrganizationName} from './awards-service';
+import {
+  awardPageLinkForOrganizationName,
+  japaneseAwardNames,
+} from './awards-service';
 import {BaseService} from './base-service';
 import type {MovieSelection, SearchOptions} from '@shine/types';
 
@@ -305,29 +308,38 @@ export class MoviesService extends BaseService {
         ? `https://www.imdb.com/title/${movie.imdbId}/`
         : undefined,
       posterUrl: (movie.posterUrl as string) || undefined,
-      nominations: nominationsData.map(nom => ({
-        uid: nom.nominationUid,
-        isWinner: Boolean(nom.isWinner),
-        specialMention: nom.specialMention ?? undefined,
-        category: {
-          uid: nom.categoryUid,
-          name: nom.categoryName,
-        },
-        ceremony: {
-          uid: nom.ceremonyUid,
-          number: nom.ceremonyNumber ?? undefined,
-          year: nom.ceremonyYear,
-        },
-        organization: {
-          uid: nom.organizationUid,
-          name: nom.organizationName,
-          shortName: nom.organizationShortName ?? undefined,
-          ...awardPageLinkForOrganizationName(
-            nom.organizationName,
-            nom.categoryName,
-          ),
-        },
-      })),
+      nominations: nominationsData.map(nom => {
+        const japaneseNames =
+          locale === 'ja'
+            ? japaneseAwardNames(nom.organizationName, nom.categoryName)
+            : {};
+
+        return {
+          uid: nom.nominationUid,
+          isWinner: Boolean(nom.isWinner),
+          specialMention: nom.specialMention ?? undefined,
+          category: {
+            uid: nom.categoryUid,
+            name: nom.categoryName,
+            displayName: japaneseNames.category,
+          },
+          ceremony: {
+            uid: nom.ceremonyUid,
+            number: nom.ceremonyNumber ?? undefined,
+            year: nom.ceremonyYear,
+          },
+          organization: {
+            uid: nom.organizationUid,
+            name: nom.organizationName,
+            shortName: nom.organizationShortName ?? undefined,
+            displayName: japaneseNames.organization,
+            ...awardPageLinkForOrganizationName(
+              nom.organizationName,
+              nom.categoryName,
+            ),
+          },
+        };
+      }),
       articleLinks: topArticles.map(article => ({
         uid: article.uid,
         url: article.url,

--- a/apps/api/src/utils/cache.ts
+++ b/apps/api/src/utils/cache.ts
@@ -197,7 +197,7 @@ export const getCacheKeyForMovie = (
   locale: string = 'ja',
 ): string => {
   const suffix = includeDetails ? 'full' : 'basic';
-  return `movie:${movieId}:${suffix}:${locale}:v3`;
+  return `movie:${movieId}:${suffix}:${locale}:v4`;
 };
 
 export const getMovieCacheKeysForAllLocales = (movieId: string): string[] =>

--- a/apps/front/app/components/editorial/award-tree.test.tsx
+++ b/apps/front/app/components/editorial/award-tree.test.tsx
@@ -32,6 +32,23 @@ const noms: AwardNomination[] = [
   },
 ];
 
+const japaneseNoms: AwardNomination[] = [
+  {
+    uid: 'n5',
+    isWinner: false,
+    specialMention: '5位',
+    category: {name: 'Best Japanese Film', displayName: '日本映画ベスト・テン'},
+    ceremony: {uid: 'c4', year: 1950},
+    organization: {
+      uid: 'o4',
+      name: 'Kinema Junpo',
+      displayName: 'キネマ旬報',
+      slug: 'kinema-junpo-japanese',
+      hasYearPages: true,
+    },
+  },
+];
+
 describe('AwardTree', () => {
   it('組織ヘッダとカテゴリ行を描画する', () => {
     render(<AwardTree nominations={noms} />);
@@ -81,6 +98,23 @@ describe('AwardTree', () => {
       'href',
       '/awards/variety-top-100',
     );
+  });
+
+  it('日本語の表示名があれば組織ヘッダに使う', () => {
+    render(<AwardTree nominations={japaneseNoms} />);
+    expect(
+      screen.getByRole('link', {name: /キネマ旬報 · 1950/}),
+    ).toBeInTheDocument();
+  });
+
+  it('日本語の表示名があればカテゴリ行に使う', () => {
+    render(<AwardTree nominations={japaneseNoms} />);
+    expect(screen.getByText('日本映画ベスト・テン')).toBeInTheDocument();
+  });
+
+  it('順位があれば表示する', () => {
+    render(<AwardTree nominations={japaneseNoms} />);
+    expect(screen.getByText('5位')).toBeInTheDocument();
   });
 
   it('slugがない組織のヘッダはリンクしない', () => {

--- a/apps/front/app/components/editorial/award-tree.tsx
+++ b/apps/front/app/components/editorial/award-tree.tsx
@@ -1,12 +1,14 @@
 export type AwardNomination = {
   uid: string;
   isWinner: boolean;
-  category: {name: string};
+  specialMention?: string;
+  category: {name: string; displayName?: string};
   ceremony: {uid: string; year: number; number?: number};
   organization: {
     uid: string;
     name: string;
     shortName?: string;
+    displayName?: string;
     slug?: string;
     hasYearPages?: boolean;
   };
@@ -50,7 +52,9 @@ export function AwardTree({nominations}: {nominations: AwardNomination[]}) {
           <div key={`${group.organization.uid}-${ceremony.uid}`}>
             {(() => {
               const headerText = `${
-                group.organization.shortName ?? group.organization.name
+                group.organization.displayName ??
+                group.organization.shortName ??
+                group.organization.name
               } · ${ceremony.year}`;
               const slug = group.organization.slug;
               const href =
@@ -73,7 +77,14 @@ export function AwardTree({nominations}: {nominations: AwardNomination[]}) {
               <div
                 key={nomination.uid}
                 className="flex items-center justify-between border-b border-ink/20 px-3 py-1.5 text-sm last:border-b-0">
-                <span>{nomination.category.name}</span>
+                <span>
+                  {nomination.category.displayName ?? nomination.category.name}
+                  {nomination.specialMention && (
+                    <span className="ml-2 font-mono text-xs text-ink-muted">
+                      {nomination.specialMention}
+                    </span>
+                  )}
+                </span>
                 {nomination.isWinner ? (
                   <span className="bg-brand px-1.5 py-0.5 font-mono text-[10px] text-brand-on">
                     ★ WINNER

--- a/apps/front/app/components/editorial/site-footer.test.tsx
+++ b/apps/front/app/components/editorial/site-footer.test.tsx
@@ -24,6 +24,22 @@ describe('SiteFooter', () => {
     expect(screen.getByText(/カンヌ/)).toBeVisible();
   });
 
+  it('三大映画祭をすべて挙げる', () => {
+    render(<SiteFooter locale="ja" />);
+
+    expect(screen.getByText(/ヴェネツィア/)).toBeVisible();
+    expect(screen.getByText(/ベルリン/)).toBeVisible();
+  });
+
+  it('賞の一覧ページへ導線を置く', () => {
+    render(<SiteFooter locale="ja" />);
+
+    expect(screen.getByRole('link', {name: /映画賞/})).toHaveAttribute(
+      'href',
+      '/awards',
+    );
+  });
+
   it('TMDbの利用規約で求められる表記を載せる', () => {
     render(<SiteFooter locale="ja" />);
 

--- a/apps/front/app/components/editorial/site-footer.tsx
+++ b/apps/front/app/components/editorial/site-footer.tsx
@@ -3,8 +3,9 @@ const COPY = {
     heading: 'SHINE について',
     lead: '映画賞の受賞作や名作リストから、毎日・毎週・毎月それぞれ1本ずつ映画を選び出すサイトです。',
     sources:
-      'カンヌ国際映画祭、アカデミー賞、日本アカデミー賞、雑誌の特集リストなど4,000本以上から抽選し、いま配信やレンタルで観られるかも一緒に表示します。',
+      'カンヌ・ヴェネツィア・ベルリンの三大映画祭、アカデミー賞、日本アカデミー賞、キネマ旬報ベスト・テン、雑誌の特集リストなど7,500本以上から抽選し、いま配信やレンタルで観られるかも一緒に表示します。',
     searchLabel: '映画を検索する',
+    awardsLabel: '映画賞から探す',
     dataCredit: '映画データは',
     dataCreditTail: 'と Wikipedia を利用しています。',
   },
@@ -12,8 +13,9 @@ const COPY = {
     heading: 'About SHINE',
     lead: 'SHINE picks one film a day, a week, and a month from award winners and curated lists.',
     sources:
-      'Drawn from over 4,000 films — Cannes, the Academy Awards, the Japan Academy Film Prize, magazine features — with where you can watch each one right now.',
+      'Drawn from over 7,500 films — Cannes, Venice, Berlin, the Academy Awards, the Japan Academy Film Prize, Kinema Junpo best-ten lists, magazine features — with where you can watch each one right now.',
     searchLabel: 'Search films',
+    awardsLabel: 'Browse by award',
     dataCredit: 'Film data from',
     dataCreditTail: 'and Wikipedia.',
   },
@@ -35,11 +37,18 @@ export function SiteFooter({locale = 'ja'}: {locale?: string}) {
         {copy.sources}
       </p>
 
-      <a
-        href="/search"
-        className="inline-block font-mono text-xs font-bold border-2 border-ink px-3 py-1.5 shadow-[3px_3px_0_var(--ink)] no-underline text-ink">
-        {copy.searchLabel}
-      </a>
+      <div className="flex flex-wrap gap-2">
+        <a
+          href="/search"
+          className="inline-block font-mono text-xs font-bold border-2 border-ink px-3 py-1.5 shadow-[3px_3px_0_var(--ink)] no-underline text-ink">
+          {copy.searchLabel}
+        </a>
+        <a
+          href="/awards"
+          className="inline-block font-mono text-xs font-bold border-2 border-ink px-3 py-1.5 shadow-[3px_3px_0_var(--ink)] no-underline text-ink">
+          {copy.awardsLabel}
+        </a>
+      </div>
 
       <p className="mt-6 font-mono text-[10px] leading-relaxed text-ink-muted">
         {copy.dataCredit}{' '}

--- a/apps/front/app/routes/movies.$id.test.tsx
+++ b/apps/front/app/routes/movies.$id.test.tsx
@@ -32,6 +32,7 @@ const mockMovieDetail = {
       category: {
         uid: 'cat-1',
         name: "Palme d'Or",
+        displayName: 'パルム・ドール',
       },
       ceremony: {
         uid: 'cer-1',
@@ -42,6 +43,7 @@ const mockMovieDetail = {
         uid: 'org-1',
         name: 'Cannes Film Festival',
         shortName: 'Cannes',
+        displayName: 'カンヌ国際映画祭',
       },
     },
     {
@@ -50,6 +52,7 @@ const mockMovieDetail = {
       category: {
         uid: 'cat-2',
         name: 'Best Picture',
+        displayName: '作品賞',
       },
       ceremony: {
         uid: 'cer-2',
@@ -60,6 +63,7 @@ const mockMovieDetail = {
         uid: 'org-2',
         name: 'Academy Awards',
         shortName: 'Oscars',
+        displayName: 'アカデミー賞',
       },
     },
   ],
@@ -340,11 +344,11 @@ describe('MovieDetail Component', () => {
       });
     });
 
-    it('説明文に選出元の団体名を含む', () => {
+    it('説明文に選出元の団体名を日本語で含む', () => {
       expect(successMeta()).toContainEqual({
         name: 'description',
         content:
-          '『パルム・ドール受賞作品』(2023年)。Cannes・Oscarsに選出。いま配信・レンタルで観られるかをまとめています。',
+          '『パルム・ドール受賞作品』(2023年)。カンヌ国際映画祭・アカデミー賞に選出。いま配信・レンタルで観られるかをまとめています。',
       });
     });
 
@@ -444,7 +448,7 @@ describe('MovieDetail Component', () => {
       ) as {'script:ld+json': Record<string, unknown>};
 
       expect(jsonLd['script:ld+json'].award).toEqual([
-        "Cannes Film Festival Palme d'Or (2023)",
+        'カンヌ国際映画祭 パルム・ドール (2023)',
       ]);
     });
 

--- a/apps/front/app/routes/movies.$id.test.tsx
+++ b/apps/front/app/routes/movies.$id.test.tsx
@@ -722,6 +722,44 @@ describe('MovieDetail Component', () => {
       expect(screen.getByText('APIへの接続に失敗しました')).toBeInTheDocument();
     });
 
+    it('賞の一覧ページへのナビゲーションを表示する', () => {
+      const loaderData = createLoaderData();
+      const parameters = createParameters('movie-123');
+
+      render(
+        <MovieDetail
+          loaderData={loaderData}
+          actionData={createActionData()}
+          params={parameters}
+          matches={createMatches(loaderData, parameters)}
+        />,
+      );
+
+      expect(screen.getByRole('link', {name: 'Awards'})).toHaveAttribute(
+        'href',
+        '/awards',
+      );
+    });
+
+    it('検索ページへのナビゲーションを表示する', () => {
+      const loaderData = createLoaderData();
+      const parameters = createParameters('movie-123');
+
+      render(
+        <MovieDetail
+          loaderData={loaderData}
+          actionData={createActionData()}
+          params={parameters}
+          matches={createMatches(loaderData, parameters)}
+        />,
+      );
+
+      expect(screen.getByRole('link', {name: 'Search'})).toHaveAttribute(
+        'href',
+        '/search',
+      );
+    });
+
     it('ホームページへの戻るリンクが表示される', () => {
       const loaderData = createLoaderData();
       const parameters = createParameters('movie-123');

--- a/apps/front/app/routes/movies.$id.test.tsx
+++ b/apps/front/app/routes/movies.$id.test.tsx
@@ -514,6 +514,42 @@ describe('MovieDetail Component', () => {
       expect(screen.queryByText('関連映画')).not.toBeInTheDocument();
     });
 
+    it('あらすじを表示する', () => {
+      const loaderData = createLoaderData();
+      const parameters = createParameters('movie-123');
+
+      render(
+        <MovieDetail
+          loaderData={loaderData}
+          actionData={createActionData()}
+          params={parameters}
+          matches={createMatches(loaderData, parameters)}
+        />,
+      );
+
+      expect(
+        screen.getByText('カンヌ国際映画祭でパルム・ドールを受賞した作品'),
+      ).toBeInTheDocument();
+    });
+
+    it('あらすじが無ければセクションを出さない', () => {
+      const loaderData = createLoaderData({
+        movieDetail: {...mockMovieDetail, description: undefined},
+      });
+      const parameters = createParameters('movie-123');
+
+      render(
+        <MovieDetail
+          loaderData={loaderData}
+          actionData={createActionData()}
+          params={parameters}
+          matches={createMatches(loaderData, parameters)}
+        />,
+      );
+
+      expect(screen.queryByText('あらすじ')).not.toBeInTheDocument();
+    });
+
     it('映画詳細データが正常に表示される', () => {
       const loaderData = createLoaderData();
       const parameters = createParameters('movie-123');

--- a/apps/front/app/routes/movies.$id.tsx
+++ b/apps/front/app/routes/movies.$id.tsx
@@ -39,6 +39,7 @@ type MovieDetailData = {
     category: {
       uid: string;
       name: string;
+      displayName?: string;
     };
     ceremony: {
       uid: string;
@@ -49,6 +50,7 @@ type MovieDetailData = {
       uid: string;
       name: string;
       shortName?: string;
+      displayName?: string;
     };
   }>;
   articleLinks: Array<{
@@ -439,7 +441,9 @@ function summarizeOrganizations(
     ...new Set(
       nominations.map(
         nomination =>
-          nomination.organization.shortName || nomination.organization.name,
+          nomination.organization.displayName ||
+          nomination.organization.shortName ||
+          nomination.organization.name,
       ),
     ),
   ];
@@ -452,10 +456,14 @@ function buildMovieJsonLd(
 ): Record<string, unknown> {
   const awards = movieDetail.nominations
     .filter(nomination => nomination.isWinner)
-    .map(
-      nomination =>
-        `${nomination.organization.name} ${nomination.category.name} (${nomination.ceremony.year})`,
-    );
+    .map(nomination => {
+      const organization =
+        nomination.organization.displayName ?? nomination.organization.name;
+      const category =
+        nomination.category.displayName ?? nomination.category.name;
+
+      return `${organization} ${category} (${nomination.ceremony.year})`;
+    });
 
   return {
     '@context': 'https://schema.org',

--- a/apps/front/app/routes/movies.$id.tsx
+++ b/apps/front/app/routes/movies.$id.tsx
@@ -716,6 +716,16 @@ export default function MovieDetail({
           </div>
         </div>
 
+        {/* Synopsis */}
+        {movieDetail.description && (
+          <section className="mb-8">
+            <p className="font-mono text-xs text-ink-muted mb-3">あらすじ</p>
+            <p className="text-sm leading-relaxed text-ink">
+              {movieDetail.description}
+            </p>
+          </section>
+        )}
+
         {/* Awards */}
         {movieDetail.nominations && movieDetail.nominations.length > 0 && (
           <section className="mb-8">

--- a/apps/front/app/routes/movies.$id.tsx
+++ b/apps/front/app/routes/movies.$id.tsx
@@ -4,6 +4,7 @@ import {Form, redirect} from 'react-router';
 import type {Route} from './+types/movies.$id';
 import {resolveApiUrl} from '@/lib/api';
 import {AwardTree} from '@/components/editorial/award-tree';
+import {Masthead} from '@/components/editorial/masthead';
 import {BigYear} from '@/components/editorial/big-year';
 import {MetaLine} from '@/components/editorial/meta-line';
 import {PosterFrame} from '@/components/editorial/poster-frame';
@@ -682,7 +683,7 @@ export default function MovieDetail({
     return <MovieDetailErrorView error="映画情報が取得できませんでした" />;
   }
 
-  const {movieDetail, turnstileSiteKey} = data;
+  const {movieDetail, turnstileSiteKey, locale} = data;
   const relatedMovies = data.relatedMovies ?? [];
   const title = movieDetail.title || 'タイトル不明';
 
@@ -698,13 +699,7 @@ export default function MovieDetail({
   return (
     <div className="min-h-screen bg-paper">
       <div className="max-w-3xl mx-auto px-4 py-8">
-        <nav className="mb-8">
-          <a
-            href="/"
-            className="font-mono text-xs text-ink-muted hover:text-ink transition-colors">
-            ← SHINE
-          </a>
-        </nav>
+        <Masthead locale={locale} />
 
         {/* Hero */}
         <div className="flex gap-5 mb-8 pb-8 border-b-2 border-ink">
@@ -757,7 +752,7 @@ export default function MovieDetail({
             year={movieDetail.year}
             tmdbId={movieDetail.tmdbId}
             imdbUrl={movieDetail.imdbUrl}
-            locale="ja"
+            locale={locale}
           />
         </section>
 
@@ -803,7 +798,7 @@ export default function MovieDetail({
           submissionResult={submissionResult}
           turnstileSiteKey={turnstileSiteKey}
         />
-        <SiteFooter locale="ja" />
+        <SiteFooter locale={locale} />
       </div>
     </div>
   );

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -39,6 +39,7 @@ export type MovieSelection = {
     category: {
       uid: string;
       name: string;
+      displayName?: string | undefined;
     };
     ceremony: {
       uid: string;
@@ -49,6 +50,7 @@ export type MovieSelection = {
       uid: string;
       name: string;
       shortName: string | undefined;
+      displayName?: string | undefined;
       slug: string | undefined;
       hasYearPages: boolean;
     };


### PR DESCRIPTION
検索から映画詳細ページに来た人が、その映画がどんな作品かを読めず、他のページにも移動できない状態だったので直した。

- APIが返していたあらすじを詳細ページに表示（データはあるのに表示していなかった）
- 賞と組織の名前を日本語で表示。API側で `awardPageDefinitions` から引いた `displayName` を返し、フロントはそれを優先する。キネマ旬報の順位（「5位」）も出す
- 詳細ページにヘッダを出して検索・賞一覧・クイズへ移動できるようにした。`← SHINE` は Masthead のロゴが担う
- フッターの説明を現状に合わせた（4,000本→7,500本以上、ヴェネツィア・ベルリン・キネマ旬報が抜けていた）。賞一覧への導線も追加
- 映画詳細のキャッシュキーを v4 に上げた（上げないと既存キャッシュが英語のまま1時間返る）

375px で全ページ `scrollWidth == clientWidth` を確認済み。