### PR TITLE
クイズのシェアURLを出題日ごとに分ける

### DIFF
--- a/apps/front/app/lib/quiz-state.test.ts
+++ b/apps/front/app/lib/quiz-state.test.ts
@@ -135,6 +135,14 @@ describe('shareText', () => {
 
     expect(shareText(state, MAX_ATTEMPTS)).not.toContain('赤ひげ');
   });
+
+  it('links to the URL carrying the puzzle date', () => {
+    const state = play([{title: '赤ひげ', correct: true}]);
+
+    expect(shareText(state, MAX_ATTEMPTS)).toContain(
+      'https://shine-film.com/quiz?d=2026-08-16',
+    );
+  });
 });
 
 describe('streakOf', () => {

--- a/apps/front/app/lib/quiz-state.ts
+++ b/apps/front/app/lib/quiz-state.ts
@@ -93,7 +93,7 @@ export function shareText(state: QuizGameState, maxAttempts: number): string {
   return [
     `SHINE QUIZ ${state.date} ${score}`,
     marks.join('') + padding,
-    'https://shine-film.com/quiz',
+    `https://shine-film.com/quiz?d=${state.date}`,
   ].join('\n');
 }
 

--- a/apps/front/app/routes/quiz.test.tsx
+++ b/apps/front/app/routes/quiz.test.tsx
@@ -87,6 +87,26 @@ describe('Quiz page', () => {
         content: 'https://shine-film.com/og/quiz.png?date=2026-08-16',
       });
     });
+
+    it('og:urlに出題日を付けてSNSのカードキャッシュを分ける', () => {
+      const descriptors = meta(
+        cast<Route.MetaArgs>({data: {puzzle: PUZZLE, locale: 'ja'}}),
+      );
+
+      expect(descriptors).toContainEqual({
+        property: 'og:url',
+        content: 'https://shine-film.com/quiz?d=2026-08-16',
+      });
+    });
+
+    it('出題が取れないときのog:urlは日付を付けない', () => {
+      const descriptors = meta(cast<Route.MetaArgs>({data: {locale: 'ja'}}));
+
+      expect(descriptors).toContainEqual({
+        property: 'og:url',
+        content: 'https://shine-film.com/quiz',
+      });
+    });
   });
 
   describe('プレイ', () => {

--- a/apps/front/app/routes/quiz.tsx
+++ b/apps/front/app/routes/quiz.tsx
@@ -28,12 +28,14 @@ export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
   const imageUrl = puzzle
     ? `${SITE_URL}/og/quiz.png?date=${puzzle.date}`
     : `${SITE_URL}/og/quiz.png`;
+  // SNSのカードはページURL単位でキャッシュされるので、出題日で別URLにする
+  const path = puzzle ? `/quiz?d=${puzzle.date}` : '/quiz';
 
   return buildSocialMeta({
     title: '今日の映画クイズ | SHINE',
     description:
       'ポスターの一部と5つのヒントから、今日の1本を当てる。カンヌ・アカデミー賞・キネマ旬報などに選ばれた映画から毎日1問。',
-    path: '/quiz',
+    path,
     locale: locale ?? DEFAULT_LOCALE,
     imageUrl,
     largeImage: true,

--- a/apps/scrapers/src/sns-post-cli.ts
+++ b/apps/scrapers/src/sns-post-cli.ts
@@ -28,6 +28,7 @@ import {
 import {
   buildDailyPostText,
   buildQuizPostText,
+  buildQuizShareUrl,
   buildQuizXPostText,
   buildXPostText,
 } from './sns/post-text';
@@ -183,7 +184,7 @@ async function buildDailyPlan(): Promise<PostPlan> {
 async function buildQuizPlan(): Promise<PostPlan> {
   // 出題日はAPIに従う(ジョブの起動が遅れても昨日の問題を告知しない)
   const puzzle = await fetchQuizPuzzle();
-  const url = `${SITE_URL}/quiz`;
+  const url = buildQuizShareUrl({siteUrl: SITE_URL, date: puzzle.date});
 
   return {
     text: buildQuizPostText(puzzle),

--- a/apps/scrapers/src/sns/post-text.test.ts
+++ b/apps/scrapers/src/sns/post-text.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest';
 import {
   buildDailyPostText,
   buildQuizPostText,
+  buildQuizShareUrl,
   buildQuizXPostText,
   buildXPostText,
   xWeightedLength,
@@ -126,6 +127,30 @@ describe('buildQuizXPostText', () => {
     expect(xWeightedLength(buildQuizXPostText(quizBase))).toBeLessThanOrEqual(
       280,
     );
+  });
+});
+
+describe('buildQuizShareUrl', () => {
+  it('出題日をクエリに付けて日ごとに別URLにする', () => {
+    expect(
+      buildQuizShareUrl({
+        siteUrl: 'https://shine-film.com',
+        date: '2026-08-16',
+      }),
+    ).toBe('https://shine-film.com/quiz?d=2026-08-16');
+  });
+
+  it('日付が変われば別のURLを返す', () => {
+    const first = buildQuizShareUrl({
+      siteUrl: 'https://shine-film.com',
+      date: '2026-08-16',
+    });
+    const second = buildQuizShareUrl({
+      siteUrl: 'https://shine-film.com',
+      date: '2026-08-17',
+    });
+
+    expect(first).not.toBe(second);
   });
 });
 

--- a/apps/scrapers/src/sns/post-text.ts
+++ b/apps/scrapers/src/sns/post-text.ts
@@ -61,6 +61,16 @@ export function buildQuizPostText(input: QuizPostInput): string {
   return `${buildQuizBody(input)}\n${HASHTAG}`;
 }
 
+export function buildQuizShareUrl({
+  siteUrl,
+  date,
+}: {
+  siteUrl: string;
+  date: string;
+}): string {
+  return `${siteUrl}/quiz?d=${date}`;
+}
+
 export function buildQuizXPostText(
   input: QuizPostInput & {url: string},
 ): string {


### PR DESCRIPTION
X などのSNSはリンクカードをページURL単位でキャッシュするため、`og:image` のクエリだけ日替わりにしても `/quiz` は再クロールされず、初回に取得したカードが出続けていた。

- `/quiz` の `og:url`、SNS告知の投稿URL、プレイ後のシェアテキストのURLに `?d=<出題日>` を付けて日ごとに別URLにした
- canonical は root の loader がクエリを落として `/quiz` を返すので変更なし