### PR TITLE
無冠の映画ページを追加

### DIFF
--- a/apps/api/openapi.yml
+++ b/apps/api/openapi.yml
@@ -324,6 +324,28 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /uncrowned:
+    get:
+      summary: Get the most-nominated films that never won
+      description: |
+        Returns the films with the most nominations in the year-grouped award
+        pages that never won any of them, with the awards and ceremony years
+        they lost, plus how many nominated films exist and how many of them
+        never won. Editorial lists are not counted.
+      operationId: getUncrowned
+      tags:
+        - Awards
+      security: []
+      responses:
+        '200':
+          description: Successfully retrieved uncrowned films
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Uncrowned'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /awards/{slug}:
     get:
       summary: Get an award page
@@ -2294,6 +2316,64 @@ components:
         - awards
         - pairs
         - distribution
+        - topMovies
+
+    Uncrowned:
+      type: object
+      properties:
+        nominatedFilmCount:
+          type: integer
+          description: Films nominated in the year-grouped award pages
+        uncrownedFilmCount:
+          type: integer
+          description: Nominated films that never won any of those awards
+        awards:
+          type: array
+          description: Year-grouped awards that appear among the losses
+          items:
+            type: object
+            properties:
+              slug:
+                type: string
+              name:
+                type: string
+              shortLabel:
+                type: string
+              organization:
+                type: string
+            required: [slug, name, shortLabel, organization]
+        topMovies:
+          type: array
+          description: Films with the most losses and no wins, at most 24
+          items:
+            type: object
+            properties:
+              uid:
+                type: string
+                format: uuid
+              title:
+                type: [string, 'null']
+              year:
+                type: [integer, 'null']
+              posterUrl:
+                type: [string, 'null']
+              losses:
+                type: array
+                description: Lost nominations, oldest ceremony first
+                items:
+                  type: object
+                  properties:
+                    slug:
+                      type: string
+                    year:
+                      type: integer
+                      description: Ceremony year of the lost nomination
+                  required: [slug, year]
+            required: [uid, losses]
+      required:
+        - nominatedFilmCount
+        - uncrownedFilmCount
+        - awards
         - topMovies
 
     AwardOrganization:

--- a/apps/api/src/__tests__/uncrowned-api.test.ts
+++ b/apps/api/src/__tests__/uncrowned-api.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import app from '../index';
+import type {Uncrowned} from '@shine/types';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+let environment: Environment;
+
+beforeEach(async () => {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'shine-uncrowned-'),
+  );
+  environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+
+  await database.insert(awardOrganizations).values([
+    {uid: 'org-cannes', name: 'Cannes Film Festival'},
+    {uid: 'org-academy', name: 'Academy Awards'},
+  ]);
+  await database.insert(awardCategories).values([
+    {uid: 'cat-palme', organizationUid: 'org-cannes', name: "Palme d'Or"},
+    {
+      uid: 'cat-best-picture',
+      organizationUid: 'org-academy',
+      name: 'Academy Award for Best Picture',
+    },
+  ]);
+  await database.insert(awardCeremonies).values([
+    {uid: 'ceremony-cannes', organizationUid: 'org-cannes', year: 2020},
+    {uid: 'ceremony-academy', organizationUid: 'org-academy', year: 2020},
+  ]);
+  await database.insert(movies).values([
+    {uid: 'movie-loser', year: 2019},
+    {uid: 'movie-winner', year: 2019},
+  ]);
+  await database.insert(translations).values({
+    resourceType: 'movie_title',
+    resourceUid: 'movie-loser',
+    languageCode: 'ja',
+    content: '無冠の映画',
+  });
+  await database.insert(nominations).values([
+    {
+      movieUid: 'movie-loser',
+      ceremonyUid: 'ceremony-cannes',
+      categoryUid: 'cat-palme',
+    },
+    {
+      movieUid: 'movie-loser',
+      ceremonyUid: 'ceremony-academy',
+      categoryUid: 'cat-best-picture',
+    },
+    {
+      movieUid: 'movie-winner',
+      ceremonyUid: 'ceremony-cannes',
+      categoryUid: 'cat-palme',
+      isWinner: 1,
+    },
+  ]);
+});
+
+async function fetchUncrowned() {
+  const response = await app.request('/uncrowned', {}, environment);
+  const body = (await response.json()) as Uncrowned;
+
+  return {response, body};
+}
+
+describe('GET /uncrowned', () => {
+  it('無冠の映画を返す', async () => {
+    const {body} = await fetchUncrowned();
+
+    expect(body.topMovies).toHaveLength(1);
+    expect(body.topMovies[0]).toMatchObject({
+      uid: 'movie-loser',
+      title: '無冠の映画',
+    });
+  });
+
+  it('母数を返す', async () => {
+    const {body} = await fetchUncrowned();
+
+    expect(body.nominatedFilmCount).toBe(2);
+    expect(body.uncrownedFilmCount).toBe(1);
+  });
+
+  it('キャッシュヘッダーを付けて返す', async () => {
+    const {response} = await fetchUncrowned();
+
+    expect(response.headers.get('Cache-Control')).toContain('max-age=');
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import {documentationRoutes} from './routes/documentation';
 import {moviesRoutes} from './routes/movies';
 import {quizRoutes} from './routes/quiz';
 import {selectionsRoutes} from './routes/selections';
+import {uncrownedRoutes} from './routes/uncrowned';
 import {utilitiesRoutes} from './routes/utilities';
 
 const app = new Hono<{Bindings: Environment}>();
@@ -50,6 +51,7 @@ app.route('/', selectionsRoutes); // Main endpoint for movie selections
 app.route('/movies', moviesRoutes);
 app.route('/awards', awardsRoutes);
 app.route('/crossings', crossingsRoutes);
+app.route('/uncrowned', uncrownedRoutes);
 app.route('/quiz', quizRoutes);
 app.route('/admin', adminRoutes);
 app.route('/', utilitiesRoutes); // Utility endpoints like fetch-url-title

--- a/apps/api/src/routes/uncrowned.ts
+++ b/apps/api/src/routes/uncrowned.ts
@@ -1,0 +1,32 @@
+import type {Environment} from '@shine/database';
+import {Hono} from 'hono';
+import {UncrownedService} from '../services/uncrowned-service';
+import {
+  checkETag,
+  createCachedResponse,
+  createETag,
+  EdgeCache,
+} from '../utils/cache';
+
+export const uncrownedRoutes = new Hono<{Bindings: Environment}>();
+
+const UNCROWNED_CACHE_TTL = 604_800;
+const UNCROWNED_CACHE_KEY = 'uncrowned:v1';
+
+uncrownedRoutes.get('/', async c => {
+  const cache = new EdgeCache(undefined, c.env.CACHE_KV);
+  const cached = await cache.get(UNCROWNED_CACHE_KEY);
+  const result =
+    cached?.data ?? (await new UncrownedService(c.env).getUncrowned());
+
+  if (!cached) {
+    await cache.set(UNCROWNED_CACHE_KEY, result, UNCROWNED_CACHE_TTL);
+  }
+
+  const etag = createETag(result);
+  if (checkETag(c.req, etag)) {
+    return new Response(undefined, {status: 304, headers: {ETag: etag}});
+  }
+
+  return createCachedResponse(result, UNCROWNED_CACHE_TTL, {ETag: etag});
+});

--- a/apps/api/src/services/__tests__/uncrowned-service.test.ts
+++ b/apps/api/src/services/__tests__/uncrowned-service.test.ts
@@ -1,0 +1,328 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {posterUrls} from '@shine/database/schema/poster-urls';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {UncrownedService} from '../uncrowned-service';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../../packages/database/migrations',
+);
+
+type TestDatabase = ReturnType<typeof getDatabase>;
+
+async function createTestEnvironment(): Promise<{
+  environment: Environment;
+  database: TestDatabase;
+}> {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'shine-uncrowned-'),
+  );
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+  return {environment, database};
+}
+
+const AWARDS = [
+  {
+    orgUid: 'org-cannes',
+    orgName: 'Cannes Film Festival',
+    categoryUid: 'cat-palme',
+    categoryName: "Palme d'Or",
+    ceremonyUid: 'ceremony-cannes',
+    ceremonyYear: 2019,
+  },
+  {
+    orgUid: 'org-academy',
+    orgName: 'Academy Awards',
+    categoryUid: 'cat-best-picture',
+    categoryName: 'Academy Award for Best Picture',
+    ceremonyUid: 'ceremony-academy',
+    ceremonyYear: 2020,
+  },
+  {
+    orgUid: 'org-kinejun',
+    orgName: 'Kinema Junpo',
+    categoryUid: 'cat-kj-foreign',
+    categoryName: 'Best Foreign Film',
+    ceremonyUid: 'ceremony-kinejun',
+    ceremonyYear: 2021,
+  },
+  {
+    orgUid: 'org-1001',
+    orgName: '1001 Movies You Must See Before You Die',
+    categoryUid: 'cat-1001',
+    categoryName: 'Selected Films',
+    ceremonyUid: 'ceremony-1001',
+    ceremonyYear: 2020,
+  },
+];
+
+async function seedAwards(database: TestDatabase): Promise<void> {
+  for (const award of AWARDS) {
+    await database
+      .insert(awardOrganizations)
+      .values({uid: award.orgUid, name: award.orgName});
+    await database.insert(awardCategories).values({
+      uid: award.categoryUid,
+      organizationUid: award.orgUid,
+      name: award.categoryName,
+    });
+    await database.insert(awardCeremonies).values({
+      uid: award.ceremonyUid,
+      organizationUid: award.orgUid,
+      year: award.ceremonyYear,
+    });
+  }
+}
+
+async function seedMovie(
+  database: TestDatabase,
+  uid: string,
+  options: {
+    jaTitle?: string;
+    defaultTitle?: string;
+    year?: number;
+    posterUrl?: string;
+    deleted?: boolean;
+  } = {},
+): Promise<void> {
+  await database.insert(movies).values({
+    uid,
+    year: options.year ?? 2020,
+    deletedAt: options.deleted ? 1_700_000_000 : undefined,
+  });
+  await database.insert(translations).values({
+    resourceType: 'movie_title',
+    resourceUid: uid,
+    languageCode: 'en',
+    content: options.defaultTitle ?? `${uid} title`,
+    isDefault: 1,
+  });
+  if (options.jaTitle) {
+    await database.insert(translations).values({
+      resourceType: 'movie_title',
+      resourceUid: uid,
+      languageCode: 'ja',
+      content: options.jaTitle,
+    });
+  }
+
+  if (options.posterUrl) {
+    await database.insert(posterUrls).values({
+      movieUid: uid,
+      url: options.posterUrl,
+      isPrimary: 1,
+    });
+  }
+}
+
+async function nominate(
+  database: TestDatabase,
+  movieUid: string,
+  entries: Array<{award: number; isWinner?: boolean}>,
+): Promise<void> {
+  await database.insert(nominations).values(
+    entries.map(entry => ({
+      movieUid,
+      ceremonyUid: AWARDS[entry.award].ceremonyUid,
+      categoryUid: AWARDS[entry.award].categoryUid,
+      isWinner: entry.isWinner ? 1 : 0,
+    })),
+  );
+}
+
+describe('UncrownedService.getUncrowned', () => {
+  let service: UncrownedService;
+  let database: TestDatabase;
+
+  beforeEach(async () => {
+    const created = await createTestEnvironment();
+    database = created.database;
+    service = new UncrownedService(created.environment);
+    await seedAwards(database);
+    await seedMovie(database, 'movie-3losses', {
+      jaTitle: '三連敗の映画',
+      year: 2018,
+      posterUrl: 'https://example.com/3losses.jpg',
+    });
+    await seedMovie(database, 'movie-2losses', {
+      defaultTitle: 'Two Losses',
+      year: 2019,
+    });
+    await seedMovie(database, 'movie-1loss', {
+      defaultTitle: 'One Loss',
+      year: 2020,
+    });
+    await seedMovie(database, 'movie-winner', {defaultTitle: 'The Winner'});
+    await nominate(database, 'movie-3losses', [
+      {award: 0},
+      {award: 1},
+      {award: 2},
+    ]);
+    await nominate(database, 'movie-2losses', [{award: 0}, {award: 1}]);
+    await nominate(database, 'movie-1loss', [{award: 0}]);
+    await nominate(database, 'movie-winner', [
+      {award: 0},
+      {award: 1, isWinner: true},
+      {award: 2},
+    ]);
+  });
+
+  it('一度も勝っていない映画を敗北数の多い順に返す', async () => {
+    const {topMovies} = await service.getUncrowned();
+
+    expect(topMovies.map(movie => movie.uid)).toEqual([
+      'movie-3losses',
+      'movie-2losses',
+      'movie-1loss',
+    ]);
+  });
+
+  it('勝ったことのある映画は含めない', async () => {
+    const {topMovies} = await service.getUncrowned();
+
+    expect(topMovies.map(movie => movie.uid)).not.toContain('movie-winner');
+  });
+
+  it('敗北した賞のslugとセレモニーの年を返す', async () => {
+    const {topMovies} = await service.getUncrowned();
+
+    expect(topMovies[0].losses).toEqual([
+      {slug: 'palme-dor', year: 2019},
+      {slug: 'academy-best-picture', year: 2020},
+      {slug: 'kinema-junpo-foreign', year: 2021},
+    ]);
+  });
+
+  it('リスト型の賞への選出は敗北に数えない', async () => {
+    await nominate(database, 'movie-1loss', [{award: 3}]);
+
+    const {topMovies} = await service.getUncrowned();
+
+    expect(
+      topMovies.find(movie => movie.uid === 'movie-1loss')?.losses,
+    ).toEqual([{slug: 'palme-dor', year: 2019}]);
+  });
+
+  it('リスト型の賞で選ばれていても無冠のままにする', async () => {
+    await nominate(database, 'movie-2losses', [{award: 3, isWinner: true}]);
+
+    const {topMovies} = await service.getUncrowned();
+
+    expect(topMovies.map(movie => movie.uid)).toContain('movie-2losses');
+  });
+
+  it('ノミネートされた映画の総数を返す', async () => {
+    const {nominatedFilmCount} = await service.getUncrowned();
+
+    expect(nominatedFilmCount).toBe(4);
+  });
+
+  it('無冠の映画の総数を返す', async () => {
+    const {uncrownedFilmCount} = await service.getUncrowned();
+
+    expect(uncrownedFilmCount).toBe(3);
+  });
+
+  it('論理削除された映画は数えない', async () => {
+    await seedMovie(database, 'movie-deleted', {deleted: true});
+    await nominate(database, 'movie-deleted', [{award: 0}, {award: 1}]);
+
+    const {topMovies, nominatedFilmCount, uncrownedFilmCount} =
+      await service.getUncrowned();
+
+    expect(topMovies.map(movie => movie.uid)).not.toContain('movie-deleted');
+    expect(nominatedFilmCount).toBe(4);
+    expect(uncrownedFilmCount).toBe(3);
+  });
+
+  it('上限を超える映画は返さない', async () => {
+    const {topMovies} = await service.getUncrowned({limit: 1});
+
+    expect(topMovies.map(movie => movie.uid)).toEqual(['movie-3losses']);
+  });
+
+  it('敗北数が同じ場合は古い映画から順に返す', async () => {
+    await seedMovie(database, 'movie-old', {
+      defaultTitle: 'Old One Loss',
+      year: 1953,
+    });
+    await nominate(database, 'movie-old', [{award: 1}]);
+
+    const {topMovies} = await service.getUncrowned();
+
+    expect(topMovies.map(movie => movie.uid)).toEqual([
+      'movie-3losses',
+      'movie-2losses',
+      'movie-old',
+      'movie-1loss',
+    ]);
+  });
+
+  it('邦題があれば邦題を返す', async () => {
+    const {topMovies} = await service.getUncrowned();
+
+    expect(topMovies[0].title).toBe('三連敗の映画');
+  });
+
+  it('ポスターを返す', async () => {
+    const {topMovies} = await service.getUncrowned();
+
+    expect(topMovies[0].posterUrl).toBe('https://example.com/3losses.jpg');
+  });
+
+  it('賞ページを持たない団体のノミネーションは無視する', async () => {
+    await database
+      .insert(awardOrganizations)
+      .values({uid: 'org-unknown', name: 'Unknown Award'});
+    await database.insert(awardCategories).values({
+      uid: 'cat-unknown',
+      organizationUid: 'org-unknown',
+      name: 'Unknown Category',
+    });
+    await database.insert(awardCeremonies).values({
+      uid: 'ceremony-unknown',
+      organizationUid: 'org-unknown',
+      year: 2020,
+    });
+    await database.insert(nominations).values({
+      movieUid: 'movie-1loss',
+      ceremonyUid: 'ceremony-unknown',
+      categoryUid: 'cat-unknown',
+      isWinner: 1,
+    });
+
+    const {topMovies} = await service.getUncrowned();
+
+    expect(
+      topMovies.find(movie => movie.uid === 'movie-1loss')?.losses,
+    ).toEqual([{slug: 'palme-dor', year: 2019}]);
+  });
+
+  it('タグ表示用に敗北のあった賞を返す', async () => {
+    const {awards} = await service.getUncrowned();
+
+    expect(awards.map(award => award.slug)).toEqual([
+      'palme-dor',
+      'academy-best-picture',
+      'kinema-junpo-foreign',
+    ]);
+    expect(awards[0].shortLabel).toBe('カンヌ');
+  });
+});

--- a/apps/api/src/services/uncrowned-service.ts
+++ b/apps/api/src/services/uncrowned-service.ts
@@ -1,0 +1,160 @@
+import {inArray, isNull, sql} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {awardPageDefinitions, findAwardPageDefinition} from './awards-service';
+import {BaseService} from './base-service';
+import type {Uncrowned, UncrownedLoss, UncrownedMovie} from '@shine/types';
+
+const DEFAULT_MOVIE_LIMIT = 24;
+
+function compareLosses(a: UncrownedLoss, b: UncrownedLoss): number {
+  return a.year - b.year || a.slug.localeCompare(b.slug);
+}
+
+function compareTopMovies(a: UncrownedMovie, b: UncrownedMovie): number {
+  return (
+    b.losses.length - a.losses.length ||
+    (a.year ?? 0) - (b.year ?? 0) ||
+    a.uid.localeCompare(b.uid)
+  );
+}
+
+export class UncrownedService extends BaseService {
+  async getUncrowned(options: {limit?: number} = {}): Promise<Uncrowned> {
+    const limit = options.limit ?? DEFAULT_MOVIE_LIMIT;
+    const rows = await this.database
+      .select({
+        movieUid: nominations.movieUid,
+        isWinner: nominations.isWinner,
+        ceremonyYear: awardCeremonies.year,
+        organizationName: awardOrganizations.name,
+        categoryName: awardCategories.name,
+      })
+      .from(nominations)
+      .innerJoin(
+        awardCeremonies,
+        sql`${awardCeremonies.uid} = ${nominations.ceremonyUid}`,
+      )
+      .innerJoin(
+        awardOrganizations,
+        sql`${awardOrganizations.uid} = ${awardCeremonies.organizationUid}`,
+      )
+      .innerJoin(
+        awardCategories,
+        sql`${awardCategories.uid} = ${nominations.categoryUid}`,
+      )
+      .innerJoin(movies, sql`${movies.uid} = ${nominations.movieUid}`)
+      .where(isNull(movies.deletedAt));
+
+    const nominatedMovies = new Set<string>();
+    const crownedMovies = new Set<string>();
+    const lossSlugs = new Set<string>();
+    const lossesByMovie = new Map<string, Map<string, UncrownedLoss>>();
+    for (const row of rows) {
+      const definition = findAwardPageDefinition(
+        row.organizationName,
+        row.categoryName,
+      );
+      if (definition?.grouping !== 'year') {
+        continue;
+      }
+
+      nominatedMovies.add(row.movieUid);
+      if (row.isWinner) {
+        crownedMovies.add(row.movieUid);
+        continue;
+      }
+
+      lossSlugs.add(definition.slug);
+      const losses =
+        lossesByMovie.get(row.movieUid) ?? new Map<string, UncrownedLoss>();
+      losses.set(`${definition.slug}:${row.ceremonyYear}`, {
+        slug: definition.slug,
+        year: row.ceremonyYear,
+      });
+      lossesByMovie.set(row.movieUid, losses);
+    }
+
+    const uncrowned = new Map(
+      [...lossesByMovie].filter(([uid]) => !crownedMovies.has(uid)),
+    );
+
+    const awards = awardPageDefinitions
+      .filter(
+        definition =>
+          definition.grouping === 'year' && lossSlugs.has(definition.slug),
+      )
+      .map(definition => ({
+        slug: definition.slug,
+        name: definition.name,
+        shortLabel: definition.shortLabel,
+        organization: definition.organization,
+      }));
+
+    return {
+      nominatedFilmCount: nominatedMovies.size,
+      uncrownedFilmCount: uncrowned.size,
+      awards,
+      topMovies: await this.loadTopMovies(uncrowned, limit),
+    };
+  }
+
+  private async loadTopMovies(
+    lossesByMovie: Map<string, Map<string, UncrownedLoss>>,
+    limit: number,
+  ): Promise<UncrownedMovie[]> {
+    const movieUids = [...lossesByMovie.entries()]
+      .toSorted(
+        ([uidA, a], [uidB, b]) => b.size - a.size || uidA.localeCompare(uidB),
+      )
+      .slice(0, limit)
+      .map(([uid]) => uid);
+
+    if (movieUids.length === 0) {
+      return [];
+    }
+
+    const rows = await this.database
+      .select({
+        uid: movies.uid,
+        year: movies.year,
+        jaTitle: sql<string | null>`(
+          SELECT content FROM translations
+          WHERE translations.resource_uid = movies.uid
+            AND translations.resource_type = 'movie_title'
+            AND translations.language_code = 'ja'
+          LIMIT 1
+        )`.as('jaTitle'),
+        defaultTitle: sql<string | null>`(
+          SELECT content FROM translations
+          WHERE translations.resource_uid = movies.uid
+            AND translations.resource_type = 'movie_title'
+          ORDER BY translations.is_default DESC
+          LIMIT 1
+        )`.as('defaultTitle'),
+        posterUrl: sql<string | null>`(
+          SELECT url FROM poster_urls
+          WHERE poster_urls.movie_uid = movies.uid
+          ORDER BY poster_urls.is_primary DESC
+          LIMIT 1
+        )`.as('posterUrl'),
+      })
+      .from(movies)
+      .where(inArray(movies.uid, movieUids));
+
+    return rows
+      .map(row => ({
+        uid: row.uid,
+        title: row.jaTitle ?? row.defaultTitle ?? undefined,
+        year: row.year ?? undefined,
+        posterUrl: row.posterUrl ?? undefined,
+        losses: [...(lossesByMovie.get(row.uid)?.values() ?? [])].toSorted(
+          compareLosses,
+        ),
+      }))
+      .toSorted(compareTopMovies);
+  }
+}

--- a/apps/front/app/routes.ts
+++ b/apps/front/app/routes.ts
@@ -9,6 +9,7 @@ export default [
   route('monthly', 'routes/monthly.tsx'),
   route('awards', 'routes/awards.tsx'),
   route('crossings', 'routes/crossings.tsx'),
+  route('uncrowned', 'routes/uncrowned.tsx'),
   route('awards/:slug', 'routes/awards.$slug.tsx'),
   route('awards/:slug/:year', 'routes/awards.$slug.$year.tsx'),
   route('robots.txt', 'routes/robots.tsx'),

--- a/apps/front/app/routes/awards.test.tsx
+++ b/apps/front/app/routes/awards.test.tsx
@@ -72,6 +72,22 @@ describe('Awards crossings link', () => {
       '/crossings',
     );
   });
+
+  it('無冠の映画ページへの導線を置く', () => {
+    render(
+      <AwardsIndexPage
+        loaderData={cast<LoaderData>({...mockAwards, locale: 'ja'})}
+        actionData={undefined}
+        params={cast<ComponentProperties['params']>({})}
+        matches={cast<ComponentProperties['matches']>([])}
+      />,
+    );
+
+    expect(screen.getByRole('link', {name: /無冠の映画/})).toHaveAttribute(
+      'href',
+      '/uncrowned',
+    );
+  });
 });
 
 describe('Awards index page', () => {

--- a/apps/front/app/routes/awards.tsx
+++ b/apps/front/app/routes/awards.tsx
@@ -69,11 +69,18 @@ export default function AwardsIndex({loaderData}: Route.ComponentProps) {
           映画賞・映画リストから作品を探す
         </p>
 
-        <a
-          href="/crossings"
-          className="mb-8 inline-block border-2 border-ink px-3 py-1.5 font-mono text-xs font-bold no-underline text-ink shadow-[3px_3px_0_var(--brand)]">
-          賞の交差を見る →
-        </a>
+        <div className="mb-8 flex flex-wrap gap-3">
+          <a
+            href="/crossings"
+            className="inline-block border-2 border-ink px-3 py-1.5 font-mono text-xs font-bold no-underline text-ink shadow-[3px_3px_0_var(--brand)]">
+            賞の交差を見る →
+          </a>
+          <a
+            href="/uncrowned"
+            className="inline-block border-2 border-ink px-3 py-1.5 font-mono text-xs font-bold no-underline text-ink shadow-[3px_3px_0_var(--brand)]">
+            無冠の映画を見る →
+          </a>
+        </div>
 
         <div>
           {awards.map(award => (

--- a/apps/front/app/routes/sitemap-awards.tsx
+++ b/apps/front/app/routes/sitemap-awards.tsx
@@ -78,6 +78,7 @@ export async function loader({context, request}: Route.LoaderArgs) {
   const entries: SitemapEntry[] = [
     {path: '/awards', changefreq: 'weekly'},
     {path: '/crossings', changefreq: 'weekly'},
+    {path: '/uncrowned', changefreq: 'weekly'},
     {path: '/quiz', changefreq: 'daily'},
     {path: '/daily', changefreq: 'daily'},
     {path: '/weekly', changefreq: 'weekly'},

--- a/apps/front/app/routes/uncrowned.test.tsx
+++ b/apps/front/app/routes/uncrowned.test.tsx
@@ -1,0 +1,207 @@
+import '@testing-library/jest-dom';
+import {render, screen, within} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import UncrownedPage, {loader, meta} from './uncrowned';
+import type {Route} from './+types/uncrowned';
+
+globalThis.fetch = vi.fn();
+
+const createMockContext = (apiUrl = 'http://localhost:8787') => ({
+  cloudflare: {
+    env: {
+      PUBLIC_API_URL: apiUrl,
+    },
+  },
+});
+
+const mockUncrowned = {
+  nominatedFilmCount: 6506,
+  uncrownedFilmCount: 6008,
+  awards: [
+    {
+      slug: 'palme-dor',
+      name: 'パルム・ドール',
+      shortLabel: 'カンヌ',
+      organization: 'カンヌ国際映画祭',
+    },
+    {
+      slug: 'academy-best-picture',
+      name: '作品賞',
+      shortLabel: 'アカデミー',
+      organization: 'アカデミー賞',
+    },
+  ],
+  topMovies: [
+    {
+      uid: 'movie-1',
+      title: '十五才 学校IV',
+      year: 2000,
+      posterUrl: 'https://example.com/1.jpg',
+      losses: [
+        {slug: 'palme-dor', year: 2019},
+        {slug: 'academy-best-picture', year: 2020},
+      ],
+    },
+    {
+      uid: 'movie-2',
+      title: 'ローマの休日',
+      year: 1953,
+      posterUrl: 'https://example.com/2.jpg',
+      losses: [{slug: 'academy-best-picture', year: 1954}],
+    },
+  ],
+};
+
+const cast = <T,>(value?: unknown): T => value as T;
+
+type LoaderArguments = Route.LoaderArgs;
+type ComponentProperties = Route.ComponentProps;
+type LoaderData = ComponentProperties['loaderData'];
+
+const createLoaderArguments = (
+  context: unknown,
+  request: Request,
+): LoaderArguments =>
+  cast<LoaderArguments>({
+    context,
+    request,
+    params: {},
+    matches: [],
+  });
+
+const loaderData = () =>
+  cast<LoaderData>({...mockUncrowned, locale: 'ja' as const});
+
+function renderPage() {
+  render(
+    <UncrownedPage
+      loaderData={loaderData()}
+      actionData={undefined}
+      params={cast<ComponentProperties['params']>({})}
+      matches={cast<ComponentProperties['matches']>([])}
+    />,
+  );
+}
+
+describe('Uncrowned page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('loader', () => {
+    it('APIから無冠の映画を取得して返す', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        cast<Response>({
+          ok: true,
+          async json() {
+            return mockUncrowned;
+          },
+        }),
+      );
+
+      const result = await loader(
+        createLoaderArguments(
+          createMockContext(),
+          new Request('https://shine-film.com/uncrowned'),
+        ),
+      );
+
+      expect(result.topMovies).toHaveLength(2);
+      expect(fetch).toHaveBeenCalledWith(
+        'http://localhost:8787/uncrowned',
+        expect.anything(),
+      );
+    });
+
+    it('APIが失敗したら502を投げる', async () => {
+      vi.mocked(fetch).mockResolvedValue(cast<Response>({ok: false}));
+
+      await expect(
+        loader(
+          createLoaderArguments(
+            createMockContext(),
+            new Request('https://shine-film.com/uncrowned'),
+          ),
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('meta', () => {
+    it('タイトルを返す', () => {
+      const descriptors = meta(
+        cast<Route.MetaArgs>({
+          data: loaderData(),
+          params: {},
+          location: {pathname: '/uncrowned', search: '', hash: ''},
+          matches: [],
+        }),
+      );
+
+      expect(descriptors).toContainEqual({title: '無冠の映画 | SHINE'});
+    });
+  });
+
+  describe('Component', () => {
+    it('無冠の映画の総数を出す', () => {
+      renderPage();
+
+      expect(screen.getByText(/6,008/)).toBeInTheDocument();
+    });
+
+    it('無冠の映画の割合を出す', () => {
+      renderPage();
+
+      expect(screen.getByText(/92.3%/)).toBeInTheDocument();
+    });
+
+    it('最も多く敗れた映画を見出しに出す', () => {
+      renderPage();
+
+      expect(
+        screen.getByRole('heading', {level: 2, name: /十五才 学校IV/}),
+      ).toBeInTheDocument();
+    });
+
+    it('その映画の敗北数を出す', () => {
+      renderPage();
+
+      const hero = screen
+        .getByText('最も多く敗れた映画')
+        .closest('section') as HTMLElement;
+
+      expect(within(hero).getByText('2')).toBeInTheDocument();
+    });
+
+    it('敗北した賞と年のタグを出す', () => {
+      renderPage();
+
+      const hero = screen
+        .getByText('最も多く敗れた映画')
+        .closest('section') as HTMLElement;
+      const tags = within(hero).getAllByText(/(カンヌ|アカデミー) \d{4}/);
+
+      expect(tags.map(tag => tag.textContent)).toEqual([
+        'カンヌ 2019',
+        'アカデミー 2020',
+      ]);
+    });
+
+    it('上位の映画に詳細ページへのリンクを張る', () => {
+      renderPage();
+
+      expect(screen.getByRole('link', {name: /ローマの休日/})).toHaveAttribute(
+        'href',
+        '/movies/movie-2',
+      );
+    });
+
+    it('賞の一覧ページへ戻る導線を置く', () => {
+      renderPage();
+
+      expect(
+        screen.getByRole('link', {name: '映画賞・リスト一覧'}),
+      ).toHaveAttribute('href', '/awards');
+    });
+  });
+});

--- a/apps/front/app/routes/uncrowned.tsx
+++ b/apps/front/app/routes/uncrowned.tsx
@@ -1,0 +1,214 @@
+import type {Route} from './+types/uncrowned';
+import {Masthead} from '@/components/editorial/masthead';
+import {PosterFrame} from '@/components/editorial/poster-frame';
+import {SiteFooter} from '@/components/editorial/site-footer';
+import {DEFAULT_LOCALE, getLocaleFromRequest, type Locale} from '@/lib/locale';
+import {SITE_URL, buildSocialMeta} from '@/lib/meta';
+
+type UncrownedAward = {
+  slug: string;
+  name: string;
+  shortLabel: string;
+  organization: string;
+};
+
+type UncrownedLoss = {
+  slug: string;
+  year: number;
+};
+
+type UncrownedMovie = {
+  uid: string;
+  title?: string;
+  year?: number;
+  posterUrl?: string;
+  losses: UncrownedLoss[];
+};
+
+type UncrownedData = {
+  nominatedFilmCount: number;
+  uncrownedFilmCount: number;
+  awards: UncrownedAward[];
+  topMovies: UncrownedMovie[];
+};
+
+export function meta({data}: Route.MetaArgs): Route.MetaDescriptors {
+  const {locale} = data as {locale?: Locale};
+
+  return buildSocialMeta({
+    title: '無冠の映画 | SHINE',
+    description:
+      'ノミネートはされた。しかし一度も勝てなかった。SHINEが記録する映画賞で最も多く敗れた、無冠の映画たちの一覧。',
+    path: '/uncrowned',
+    locale: locale ?? DEFAULT_LOCALE,
+    imageUrl: `${SITE_URL}/og/home.png`,
+    largeImage: true,
+  });
+}
+
+export async function loader({context, request}: Route.LoaderArgs) {
+  const locale = getLocaleFromRequest(request);
+  const apiUrl =
+    (context.cloudflare as {env?: {PUBLIC_API_URL?: string}}).env
+      ?.PUBLIC_API_URL || 'http://localhost:8787';
+
+  const response = await fetch(`${apiUrl}/uncrowned`, {signal: request.signal});
+  if (!response.ok) {
+    throw new Response('Failed to load uncrowned', {status: 502});
+  }
+
+  const body = (await response.json()) as UncrownedData;
+  return {...body, locale};
+}
+
+function LossTags({
+  losses,
+  awards,
+}: {
+  losses: UncrownedLoss[];
+  awards: UncrownedAward[];
+}) {
+  const labels = new Map(awards.map(award => [award.slug, award.shortLabel]));
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {losses.map(loss => (
+        <span
+          key={`${loss.slug}:${loss.year}`}
+          className="border border-ink-muted px-1 py-0.5 font-mono text-[10px] text-ink-muted">
+          {labels.get(loss.slug) ?? loss.slug} {loss.year}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function Uncrowned({loaderData}: Route.ComponentProps) {
+  const {nominatedFilmCount, uncrownedFilmCount, awards, topMovies} =
+    loaderData as UncrownedData;
+  const locale = 'ja';
+  const [leader, ...rest] = topMovies;
+  const uncrownedShare =
+    nominatedFilmCount > 0
+      ? ((uncrownedFilmCount / nominatedFilmCount) * 100).toFixed(1)
+      : '0.0';
+
+  return (
+    <div className="min-h-screen bg-paper text-ink">
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <Masthead locale={locale} />
+
+        <h1 className="font-display font-black text-2xl md:text-3xl tracking-tight mb-2">
+          UNCROWNED
+        </h1>
+        <p className="font-mono text-xs text-ink-muted mb-8">
+          一度も勝てなかった映画たち
+        </p>
+
+        <section className="mb-10 border-t-2 border-b-2 border-ink py-4">
+          <p className="font-display text-sm md:text-base leading-relaxed">
+            SHINEは映画賞を記録してきた。つまり、勝者を数えてきた。
+            <br />
+            だがノミネートされた
+            {nominatedFilmCount.toLocaleString('en-US')}本のうち
+            <span className="font-black text-brand">
+              {uncrownedFilmCount.toLocaleString('en-US')}本
+            </span>
+            ——
+            <span className="font-black">{uncrownedShare}%</span>
+            ——は、一度も勝っていない。
+            <br />
+            ここは、その敗者たちの頁。
+          </p>
+        </section>
+
+        {leader && (
+          <section className="mb-10 border-2 border-ink p-4 shadow-[6px_6px_0_var(--brand)]">
+            <p className="font-mono text-xs text-ink-muted mb-3">
+              最も多く敗れた映画
+            </p>
+            <div className="flex gap-4">
+              <a href={`/movies/${leader.uid}`} className="shrink-0">
+                <PosterFrame
+                  posterUrl={leader.posterUrl}
+                  alt={`${leader.title ?? ''} poster`}
+                  className="w-24 md:w-32"
+                  priority
+                  displaySize="w342"
+                />
+              </a>
+              <div className="flex flex-col justify-center gap-2">
+                <p className="font-display font-black text-5xl leading-none text-brand">
+                  <span>{leader.losses.length}</span>
+                  <span className="text-2xl">敗</span>
+                </p>
+                <h2 className="font-display font-black text-xl md:text-2xl leading-tight">
+                  <a href={`/movies/${leader.uid}`} className="text-ink">
+                    {leader.title ?? 'タイトル不明'}
+                  </a>
+                </h2>
+                {leader.year && (
+                  <p className="font-mono text-xs text-ink-muted">
+                    {leader.year}
+                  </p>
+                )}
+                <LossTags losses={leader.losses} awards={awards} />
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section className="mb-10">
+          <p className="font-mono text-xs text-ink-muted mb-3">
+            敗北を重ねた映画
+          </p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {rest.map(movie => (
+              <div key={movie.uid}>
+                <a
+                  href={`/movies/${movie.uid}`}
+                  className="no-underline text-ink">
+                  <PosterFrame
+                    posterUrl={movie.posterUrl}
+                    alt={`${movie.title ?? ''} poster`}
+                    className="w-full"
+                    displaySize="w342"
+                  />
+                  <span className="mt-1.5 flex items-baseline gap-1.5">
+                    <span className="font-display font-black text-sm text-brand">
+                      {movie.losses.length}敗
+                    </span>
+                    <span className="font-display font-bold text-xs leading-tight">
+                      {movie.title ?? 'タイトル不明'}
+                    </span>
+                  </span>
+                </a>
+                <span className="mt-1 block font-mono text-[10px] text-ink-muted">
+                  {movie.year}
+                </span>
+                <div className="mt-1">
+                  <LossTags losses={movie.losses} awards={awards} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="flex flex-wrap gap-3">
+          <a
+            href="/awards"
+            className="inline-block font-mono text-xs font-bold border-2 border-ink px-3 py-1.5 shadow-[3px_3px_0_var(--ink)] no-underline text-ink">
+            映画賞・リスト一覧
+          </a>
+          <a
+            href="/crossings"
+            className="inline-block font-mono text-xs font-bold border-2 border-ink px-3 py-1.5 shadow-[3px_3px_0_var(--ink)] no-underline text-ink">
+            賞の交差
+          </a>
+        </div>
+
+        <SiteFooter locale={locale} />
+      </div>
+    </div>
+  );
+}

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -148,6 +148,31 @@ export type AwardCrossings = {
   topMovies: CrossingMovie[];
 };
 
+export type UncrownedLoss = {
+  slug: string;
+  year: number;
+};
+
+export type UncrownedMovie = {
+  uid: string;
+  title: string | undefined;
+  year: number | undefined;
+  posterUrl: string | undefined;
+  losses: UncrownedLoss[];
+};
+
+export type Uncrowned = {
+  nominatedFilmCount: number;
+  uncrownedFilmCount: number;
+  awards: Array<{
+    slug: string;
+    name: string;
+    shortLabel: string;
+    organization: string;
+  }>;
+  topMovies: UncrownedMovie[];
+};
+
 export type QuizHint = {
   label: string;
   value: string;


### PR DESCRIPTION
SHINEはこれまで賞の勝者を数えてきたが、記録上ノミネートされた6,506本のうち6,008本（92.3%）は一度も勝っていない。その敗者側を並べる /uncrowned を追加した。

- API: GET /uncrowned。年度型の賞ページ（カンヌ・ヴェネツィア・ベルリン・アカデミー・日本アカデミー・キネ旬×2）での敗北数が多い無冠の映画を返す。リスト型（1001本など）は勝敗に数えない。KVキャッシュ週次。
- front: 最多敗北の映画をヒーローに、敗れた賞と年のタグつきでグリッド表示。awardsページとsitemapに導線を追加。

このページを作る過程で、リメイク作品に旧作のノミネートが誤って紐付いているデータ不良が見つかった（『十五才 学校IV』に『学校』3作のキネ旬、1985年版『ビルマの竪琴』に1956年版のキネ旬）。この2件は本番DBを直接修正済み。同種の疑い32件は別issueにする。