### PR TITLE
記事リンク操作後に映画詳細キャッシュを無効化する

### DIFF
--- a/apps/api/src/__tests__/article-links-cache.test.ts
+++ b/apps/api/src/__tests__/article-links-cache.test.ts
@@ -4,13 +4,19 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {getDatabase, type Environment} from '@shine/database';
 import {articleLinks} from '@shine/database/schema/article-links';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movieSelections} from '@shine/database/schema/movie-selections';
 import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
 import {translations} from '@shine/database/schema/translations';
 import {migrate} from 'drizzle-orm/libsql/migrator';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import {createJWT} from '../auth';
 import {adminArticleLinksRoutes} from '../routes/admin/article-links';
 import {moviesRoutes} from '../routes/movies';
+import {selectionsRoutes} from '../routes/selections';
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(
@@ -53,6 +59,24 @@ async function createTestEnvironment(): Promise<Environment> {
   await migrate(database, {migrationsFolder});
 
   await database.insert(movies).values({uid: 'movie-1', year: 2020});
+  await database
+    .insert(awardOrganizations)
+    .values({uid: 'org-1', name: 'Test Award'});
+  await database
+    .insert(awardCeremonies)
+    .values({uid: 'ceremony-1', organizationUid: 'org-1', year: 2020});
+  await database.insert(awardCategories).values({
+    uid: 'category-1',
+    organizationUid: 'org-1',
+    name: 'Best Picture',
+  });
+  await database.insert(nominations).values({
+    uid: 'nomination-1',
+    movieUid: 'movie-1',
+    ceremonyUid: 'ceremony-1',
+    categoryUid: 'category-1',
+    isWinner: 1,
+  });
   await database.insert(translations).values([
     {
       resourceType: 'movie_title',
@@ -103,6 +127,35 @@ async function getMovieArticleLinks(
   );
   const body = (await response.json()) as MovieDetailResponse;
   return body.articleLinks.map(link => link.url);
+}
+
+function todayDateString(): string {
+  const now = new Date();
+  const month = (now.getMonth() + 1).toString().padStart(2, '0');
+  const day = now.getDate().toString().padStart(2, '0');
+  return `${now.getFullYear()}-${month}-${day}`;
+}
+
+async function insertDailySelection(environment: Environment): Promise<void> {
+  await getDatabase(environment).insert(movieSelections).values({
+    selectionType: 'daily',
+    selectionDate: todayDateString(),
+    movieId: 'movie-1',
+  });
+}
+
+async function getDailySelectionArticleLinks(
+  environment: Environment,
+): Promise<string[]> {
+  const response = await selectionsRoutes.request(
+    '/?locale=ja',
+    {},
+    environment,
+  );
+  const body = (await response.json()) as {
+    daily: {articleLinks: Array<{url: string}>};
+  };
+  return body.daily.articleLinks.map(link => link.url);
 }
 
 describe('article links cache invalidation', () => {
@@ -167,6 +220,40 @@ describe('article links cache invalidation', () => {
     expect(response.status).toBe(200);
 
     expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+  });
+
+  it('投稿後に当日のselectionsキャッシュが無効化される', async () => {
+    await insertDailySelection(environment);
+    expect(await getDailySelectionArticleLinks(environment)).toEqual([]);
+
+    await submitArticleLink(environment);
+
+    expect(await getDailySelectionArticleLinks(environment)).toContain(
+      'https://example.com/article',
+    );
+  });
+
+  it('admin削除後に当日のselectionsキャッシュが無効化される', async () => {
+    await insertDailySelection(environment);
+    await submitArticleLink(environment);
+    const [article] = await getDatabase(environment)
+      .select({uid: articleLinks.uid})
+      .from(articleLinks);
+    expect(await getDailySelectionArticleLinks(environment)).toContain(
+      'https://example.com/article',
+    );
+
+    const token = await createJWT(JWT_SECRET);
+    await adminArticleLinksRoutes.request(
+      `/article-links/${article.uid}`,
+      {
+        method: 'DELETE',
+        headers: {Authorization: `Bearer ${token}`},
+      },
+      environment,
+    );
+
+    expect(await getDailySelectionArticleLinks(environment)).toEqual([]);
   });
 
   it('adminスパム報告後に映画詳細キャッシュが無効化される', async () => {

--- a/apps/api/src/__tests__/article-links-cache.test.ts
+++ b/apps/api/src/__tests__/article-links-cache.test.ts
@@ -1,0 +1,194 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {articleLinks} from '@shine/database/schema/article-links';
+import {movies} from '@shine/database/schema/movies';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {createJWT} from '../auth';
+import {adminArticleLinksRoutes} from '../routes/admin/article-links';
+import {moviesRoutes} from '../routes/movies';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+const JWT_SECRET = 'test-jwt-secret';
+
+type MovieDetailResponse = {
+  articleLinks: Array<{uid: string; url: string; title: string}>;
+};
+
+function createStatefulCacheStub() {
+  const store = new Map<string, Response>();
+  return {
+    async match(key: string) {
+      return store.get(key)?.clone();
+    },
+    async put(key: string, response: Response) {
+      store.set(key, response);
+    },
+    async delete(key: string) {
+      return store.delete(key);
+    },
+    async keys() {
+      return [...store.keys()].map(key => new Request(key));
+    },
+  } as unknown as Cache;
+}
+
+async function createTestEnvironment(): Promise<Environment> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-test-'));
+  const environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+    JWT_SECRET,
+  } as Environment;
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+
+  await database.insert(movies).values({uid: 'movie-1', year: 2020});
+  await database.insert(translations).values([
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-1',
+      languageCode: 'en',
+      content: 'Movie One',
+      isDefault: 1,
+    },
+    {
+      resourceType: 'movie_title',
+      resourceUid: 'movie-1',
+      languageCode: 'ja',
+      content: '映画1',
+      isDefault: 0,
+    },
+  ]);
+
+  return environment;
+}
+
+async function submitArticleLink(
+  environment: Environment,
+  url = 'https://example.com/article',
+): Promise<Response> {
+  return moviesRoutes.request(
+    '/movie-1/article-links',
+    {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        url,
+        title: 'Test Article',
+        captchaToken: 'test-token',
+      }),
+    },
+    environment,
+  );
+}
+
+async function getMovieArticleLinks(
+  environment: Environment,
+  locale: string,
+): Promise<string[]> {
+  const response = await moviesRoutes.request(
+    `/movie-1?locale=${locale}`,
+    {},
+    environment,
+  );
+  const body = (await response.json()) as MovieDetailResponse;
+  return body.articleLinks.map(link => link.url);
+}
+
+describe('article links cache invalidation', () => {
+  let environment: Environment;
+  const originalCaches = (globalThis as {caches?: unknown}).caches;
+
+  beforeEach(async () => {
+    (globalThis as {caches?: unknown}).caches = {
+      default: createStatefulCacheStub(),
+    };
+    environment = await createTestEnvironment();
+  });
+
+  afterEach(() => {
+    (globalThis as {caches?: unknown}).caches = originalCaches;
+  });
+
+  it('記事リンクを投稿すると201で保存される', async () => {
+    const response = await submitArticleLink(environment);
+
+    expect(response.status).toBe(201);
+  });
+
+  it('投稿後にjaロケールの映画詳細キャッシュが無効化される', async () => {
+    expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+
+    await submitArticleLink(environment);
+
+    expect(await getMovieArticleLinks(environment, 'ja')).toContain(
+      'https://example.com/article',
+    );
+  });
+
+  it('投稿後にenロケールの映画詳細キャッシュが無効化される', async () => {
+    expect(await getMovieArticleLinks(environment, 'en')).toEqual([]);
+
+    await submitArticleLink(environment);
+
+    expect(await getMovieArticleLinks(environment, 'en')).toContain(
+      'https://example.com/article',
+    );
+  });
+
+  it('admin削除後に映画詳細キャッシュが無効化される', async () => {
+    await submitArticleLink(environment);
+    const [article] = await getDatabase(environment)
+      .select({uid: articleLinks.uid})
+      .from(articleLinks);
+    expect(await getMovieArticleLinks(environment, 'ja')).toContain(
+      'https://example.com/article',
+    );
+
+    const token = await createJWT(JWT_SECRET);
+    const response = await adminArticleLinksRoutes.request(
+      `/article-links/${article.uid}`,
+      {
+        method: 'DELETE',
+        headers: {Authorization: `Bearer ${token}`},
+      },
+      environment,
+    );
+    expect(response.status).toBe(200);
+
+    expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+  });
+
+  it('adminスパム報告後に映画詳細キャッシュが無効化される', async () => {
+    await submitArticleLink(environment);
+    const [article] = await getDatabase(environment)
+      .select({uid: articleLinks.uid})
+      .from(articleLinks);
+    expect(await getMovieArticleLinks(environment, 'ja')).toContain(
+      'https://example.com/article',
+    );
+
+    const token = await createJWT(JWT_SECRET);
+    const response = await adminArticleLinksRoutes.request(
+      `/article-links/${article.uid}/spam`,
+      {
+        method: 'POST',
+        headers: {Authorization: `Bearer ${token}`},
+      },
+      environment,
+    );
+    expect(response.status).toBe(200);
+
+    expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+  });
+});

--- a/apps/api/src/routes/admin/article-links.ts
+++ b/apps/api/src/routes/admin/article-links.ts
@@ -1,14 +1,17 @@
 import {type Environment} from '@shine/database';
 import {Hono} from 'hono';
 import {authMiddleware} from '../../auth';
-import {AdminService} from '../../services';
+import {AdminService, SelectionsService} from '../../services';
 import {EdgeCache, getMovieCacheKeysForAllLocales} from '../../utils/cache';
 
 export const adminArticleLinksRoutes = new Hono<{Bindings: Environment}>();
 
 const cache = new EdgeCache();
 
-async function invalidateMovieCache(movieUid: string | undefined) {
+async function invalidateMovieCache(
+  environment: Environment,
+  movieUid: string | undefined,
+) {
   if (!movieUid) {
     return;
   }
@@ -17,6 +20,9 @@ async function invalidateMovieCache(movieUid: string | undefined) {
     getMovieCacheKeysForAllLocales(movieUid).map(async key =>
       cache.delete(key),
     ),
+  );
+  await new SelectionsService(environment).purgeSelectionCachesForMovie(
+    movieUid,
   );
 }
 
@@ -33,7 +39,7 @@ adminArticleLinksRoutes.post(
       }
 
       const movieUid = await adminService.flagArticleAsSpam(articleId);
-      await invalidateMovieCache(movieUid);
+      await invalidateMovieCache(c.env, movieUid);
 
       return c.json({success: true});
     } catch (error) {
@@ -56,7 +62,7 @@ adminArticleLinksRoutes.delete(
       }
 
       const movieUid = await adminService.deleteArticleLink(articleId);
-      await invalidateMovieCache(movieUid);
+      await invalidateMovieCache(c.env, movieUid);
 
       return c.json({success: true});
     } catch (error) {

--- a/apps/api/src/routes/admin/article-links.ts
+++ b/apps/api/src/routes/admin/article-links.ts
@@ -2,8 +2,23 @@ import {type Environment} from '@shine/database';
 import {Hono} from 'hono';
 import {authMiddleware} from '../../auth';
 import {AdminService} from '../../services';
+import {EdgeCache, getMovieCacheKeysForAllLocales} from '../../utils/cache';
 
 export const adminArticleLinksRoutes = new Hono<{Bindings: Environment}>();
+
+const cache = new EdgeCache();
+
+async function invalidateMovieCache(movieUid: string | undefined) {
+  if (!movieUid) {
+    return;
+  }
+
+  await Promise.all(
+    getMovieCacheKeysForAllLocales(movieUid).map(async key =>
+      cache.delete(key),
+    ),
+  );
+}
 
 // Flag article as spam
 adminArticleLinksRoutes.post(
@@ -17,7 +32,8 @@ adminArticleLinksRoutes.post(
         return c.json({error: 'Missing id parameter'}, 400);
       }
 
-      await adminService.flagArticleAsSpam(articleId);
+      const movieUid = await adminService.flagArticleAsSpam(articleId);
+      await invalidateMovieCache(movieUid);
 
       return c.json({success: true});
     } catch (error) {
@@ -39,7 +55,8 @@ adminArticleLinksRoutes.delete(
         return c.json({error: 'Missing id parameter'}, 400);
       }
 
-      await adminService.deleteArticleLink(articleId);
+      const movieUid = await adminService.deleteArticleLink(articleId);
+      await invalidateMovieCache(movieUid);
 
       return c.json({success: true});
     } catch (error) {

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -17,6 +17,7 @@ import {
   AvailabilityService,
   buildOnDemandRunners,
   MoviesService,
+  SelectionsService,
 } from '../services';
 import {
   checkETag,
@@ -536,6 +537,7 @@ moviesRoutes.post('/:id/article-links', async c => {
         cache.delete(key),
       ),
     );
+    await new SelectionsService(c.env).purgeSelectionCachesForMovie(movieId);
 
     return c.json(newArticle[0], 201);
   } catch (error) {

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -530,6 +530,13 @@ moviesRoutes.post('/:id/article-links', async c => {
       })
       .returning();
 
+    // Invalidate movie details cache
+    await Promise.all(
+      getMovieCacheKeysForAllLocales(movieId).map(async key =>
+        cache.delete(key),
+      ),
+    );
+
     return c.json(newArticle[0], 201);
   } catch (error) {
     console.error('Error submitting article link:', error);

--- a/apps/api/src/services/admin-service.ts
+++ b/apps/api/src/services/admin-service.ts
@@ -806,17 +806,21 @@ export class AdminService extends BaseService {
       );
   }
 
-  async flagArticleAsSpam(articleId: string): Promise<void> {
-    await this.database
+  async flagArticleAsSpam(articleId: string): Promise<string | undefined> {
+    const updated = await this.database
       .update(articleLinks)
       .set({isSpam: true})
-      .where(eq(articleLinks.uid, articleId));
+      .where(eq(articleLinks.uid, articleId))
+      .returning({movieUid: articleLinks.movieUid});
+    return updated[0]?.movieUid;
   }
 
-  async deleteArticleLink(articleId: string): Promise<void> {
-    await this.database
+  async deleteArticleLink(articleId: string): Promise<string | undefined> {
+    const deleted = await this.database
       .delete(articleLinks)
-      .where(eq(articleLinks.uid, articleId));
+      .where(eq(articleLinks.uid, articleId))
+      .returning({movieUid: articleLinks.movieUid});
+    return deleted[0]?.movieUid;
   }
 
   async mergeMovies(options: MergeMoviesOptions): Promise<void> {

--- a/apps/api/src/services/selections-service.ts
+++ b/apps/api/src/services/selections-service.ts
@@ -1,6 +1,7 @@
 import {
   and,
   eq,
+  inArray,
   isNull,
   notInArray,
   sql,
@@ -360,6 +361,43 @@ export class SelectionsService extends BaseService {
       CACHEABLE_LOCALES.map(async locale =>
         this.cache.delete(getCacheKeyForSelection(type, selectionDate, locale)),
       ),
+    );
+  }
+
+  async purgeSelectionCachesForMovie(
+    movieUid: string,
+    date = new Date(),
+  ): Promise<void> {
+    const types: SelectionType[] = ['daily', 'weekly', 'monthly'];
+    const current = await this.database
+      .select({
+        selectionType: movieSelections.selectionType,
+        selectionDate: movieSelections.selectionDate,
+      })
+      .from(movieSelections)
+      .where(
+        and(
+          eq(movieSelections.movieId, movieUid),
+          inArray(
+            movieSelections.selectionDate,
+            types.map(type => this.getSelectionDate(date, type)),
+          ),
+        ),
+      );
+
+    await Promise.all(
+      current
+        .filter(
+          selection =>
+            selection.selectionDate ===
+            this.getSelectionDate(date, selection.selectionType),
+        )
+        .map(async selection =>
+          this.purgeSelectionCache(
+            selection.selectionType,
+            selection.selectionDate,
+          ),
+        ),
     );
   }
 


### PR DESCRIPTION
記事リンクを投稿しても映画詳細ページに反映されない問題の修正。

GET /movies/:id は24時間TTLのEdgeCacheに乗っているが、POST /movies/:id/article-links が挿入後にキャッシュを無効化していなかったため、投稿が成功してもページに表示されず、投稿が壊れているように見えていた（実際に同一記事が3回投稿されていた）。

- POST /movies/:id/article-links の挿入後に getMovieCacheKeysForAllLocales で全ロケールのキャッシュを削除（translations エンドポイントと同じパターン）
- admin の記事リンク削除・スパム報告も同様に無効化（削除・スパム化しても表示され続ける同根のバグ）
- AdminService の flagArticleAsSpam / deleteArticleLink が movieUid を返すように変更