### PR TITLE
映画詳細とselectionsのキャッシュをWorkers KVに移行する

### DIFF
--- a/apps/api/src/__tests__/admin-mutations-cache.test.ts
+++ b/apps/api/src/__tests__/admin-mutations-cache.test.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {createJWT} from '../auth';
+import {adminMoviesRoutes} from '../routes/admin/movies';
+import {adminNominationsRoutes} from '../routes/admin/nominations';
+import {moviesRoutes} from '../routes/movies';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+const JWT_SECRET = 'test-jwt-secret';
+
+type MovieDetailResponse = {
+  year: number;
+  nominations: Array<{uid: string}>;
+};
+
+function createKvStub(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) {
+      const value = store.get(key);
+      return value === undefined ? undefined : JSON.parse(value);
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  } as unknown as KVNamespace;
+}
+
+async function createTestEnvironment(): Promise<Environment> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-test-'));
+  const environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+    JWT_SECRET,
+  } as Environment;
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+
+  await database.insert(movies).values({uid: 'movie-1', year: 2020});
+  await database
+    .insert(awardOrganizations)
+    .values({uid: 'org-1', name: 'Test Award'});
+  await database
+    .insert(awardCeremonies)
+    .values({uid: 'ceremony-1', organizationUid: 'org-1', year: 2020});
+  await database.insert(awardCategories).values({
+    uid: 'category-1',
+    organizationUid: 'org-1',
+    name: 'Best Picture',
+  });
+  await database.insert(nominations).values({
+    uid: 'nomination-1',
+    movieUid: 'movie-1',
+    ceremonyUid: 'ceremony-1',
+    categoryUid: 'category-1',
+    isWinner: 1,
+  });
+  await database.insert(translations).values({
+    resourceType: 'movie_title',
+    resourceUid: 'movie-1',
+    languageCode: 'ja',
+    content: '映画1',
+    isDefault: 1,
+  });
+
+  environment.CACHE_KV = createKvStub();
+  return environment;
+}
+
+async function getMovieDetailStatus(environment: Environment): Promise<number> {
+  const response = await moviesRoutes.request(
+    '/movie-1?locale=ja',
+    {},
+    environment,
+  );
+  return response.status;
+}
+
+async function getMovieDetailBody(
+  environment: Environment,
+): Promise<MovieDetailResponse> {
+  const response = await moviesRoutes.request(
+    '/movie-1?locale=ja',
+    {},
+    environment,
+  );
+  return (await response.json()) as MovieDetailResponse;
+}
+
+describe('admin mutations cache invalidation', () => {
+  let environment: Environment;
+  let authHeaders: {Authorization: string};
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+    authHeaders = {Authorization: `Bearer ${await createJWT(JWT_SECRET)}`};
+  });
+
+  it('admin映画削除後に映画詳細キャッシュが無効化される', async () => {
+    expect(await getMovieDetailStatus(environment)).toBe(200);
+
+    const response = await adminMoviesRoutes.request(
+      '/movies/movie-1',
+      {method: 'DELETE', headers: authHeaders},
+      environment,
+    );
+    expect(response.status).toBe(200);
+
+    expect(await getMovieDetailStatus(environment)).toBe(404);
+  });
+
+  it('admin映画更新後に映画詳細キャッシュが無効化される', async () => {
+    const before = await getMovieDetailBody(environment);
+    expect(before.year).toBe(2020);
+
+    const response = await adminMoviesRoutes.request(
+      '/movies/movie-1',
+      {
+        method: 'PUT',
+        headers: {...authHeaders, 'Content-Type': 'application/json'},
+        body: JSON.stringify({year: 2021}),
+      },
+      environment,
+    );
+    expect(response.status).toBe(200);
+
+    const after = await getMovieDetailBody(environment);
+    expect(after.year).toBe(2021);
+  });
+
+  it('adminノミネート削除後に映画詳細キャッシュが無効化される', async () => {
+    const before = await getMovieDetailBody(environment);
+    expect(before.nominations).toHaveLength(1);
+
+    const response = await adminNominationsRoutes.request(
+      '/nominations/nomination-1',
+      {method: 'DELETE', headers: authHeaders},
+      environment,
+    );
+    expect(response.status).toBe(200);
+
+    const after = await getMovieDetailBody(environment);
+    expect(after.nominations).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/article-links-cache.test.ts
+++ b/apps/api/src/__tests__/article-links-cache.test.ts
@@ -30,6 +30,22 @@ type MovieDetailResponse = {
   articleLinks: Array<{uid: string; url: string; title: string}>;
 };
 
+function createKvStub(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    async get(key: string) {
+      const value = store.get(key);
+      return value === undefined ? undefined : JSON.parse(value);
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  } as unknown as KVNamespace;
+}
+
 function createStatefulCacheStub() {
   const store = new Map<string, Response>();
   return {
@@ -277,5 +293,63 @@ describe('article links cache invalidation', () => {
     expect(response.status).toBe(200);
 
     expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+  });
+});
+
+async function insertArticleLinkDirectly(
+  environment: Environment,
+): Promise<void> {
+  await getDatabase(environment).insert(articleLinks).values({
+    movieUid: 'movie-1',
+    url: 'https://example.com/article',
+    title: 'Test Article',
+    submitterIp: 'test-ip',
+  });
+}
+
+describe('article links cache invalidation (CACHE_KV)', () => {
+  let environment: Environment;
+
+  beforeEach(async () => {
+    environment = await createTestEnvironment();
+    environment.CACHE_KV = createKvStub();
+  });
+
+  it('映画詳細がKVにキャッシュされる', async () => {
+    expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+
+    await insertArticleLinkDirectly(environment);
+
+    expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+  });
+
+  it('投稿後にKV上の映画詳細キャッシュが無効化される', async () => {
+    expect(await getMovieArticleLinks(environment, 'ja')).toEqual([]);
+
+    await submitArticleLink(environment);
+
+    expect(await getMovieArticleLinks(environment, 'ja')).toContain(
+      'https://example.com/article',
+    );
+  });
+
+  it('selectionsがKVにキャッシュされる', async () => {
+    await insertDailySelection(environment);
+    expect(await getDailySelectionArticleLinks(environment)).toEqual([]);
+
+    await insertArticleLinkDirectly(environment);
+
+    expect(await getDailySelectionArticleLinks(environment)).toEqual([]);
+  });
+
+  it('投稿後にKV上のselectionsキャッシュが無効化される', async () => {
+    await insertDailySelection(environment);
+    expect(await getDailySelectionArticleLinks(environment)).toEqual([]);
+
+    await submitArticleLink(environment);
+
+    expect(await getDailySelectionArticleLinks(environment)).toContain(
+      'https://example.com/article',
+    );
   });
 });

--- a/apps/api/src/routes/admin/article-links.ts
+++ b/apps/api/src/routes/admin/article-links.ts
@@ -6,8 +6,6 @@ import {EdgeCache, getMovieCacheKeysForAllLocales} from '../../utils/cache';
 
 export const adminArticleLinksRoutes = new Hono<{Bindings: Environment}>();
 
-const cache = new EdgeCache();
-
 async function invalidateMovieCache(
   environment: Environment,
   movieUid: string | undefined,
@@ -16,6 +14,7 @@ async function invalidateMovieCache(
     return;
   }
 
+  const cache = new EdgeCache(undefined, environment.CACHE_KV);
   await Promise.all(
     getMovieCacheKeysForAllLocales(movieUid).map(async key =>
       cache.delete(key),

--- a/apps/api/src/routes/admin/article-links.ts
+++ b/apps/api/src/routes/admin/article-links.ts
@@ -1,8 +1,8 @@
 import {type Environment} from '@shine/database';
 import {Hono} from 'hono';
 import {authMiddleware} from '../../auth';
-import {AdminService, SelectionsService} from '../../services';
-import {EdgeCache, getMovieCacheKeysForAllLocales} from '../../utils/cache';
+import {AdminService} from '../../services';
+import {invalidateMovieCaches} from '../../services/movie-cache-invalidation';
 
 export const adminArticleLinksRoutes = new Hono<{Bindings: Environment}>();
 
@@ -14,15 +14,7 @@ async function invalidateMovieCache(
     return;
   }
 
-  const cache = new EdgeCache(undefined, environment.CACHE_KV);
-  await Promise.all(
-    getMovieCacheKeysForAllLocales(movieUid).map(async key =>
-      cache.delete(key),
-    ),
-  );
-  await new SelectionsService(environment).purgeSelectionCachesForMovie(
-    movieUid,
-  );
+  await invalidateMovieCaches(environment, movieUid);
 }
 
 // Flag article as spam

--- a/apps/api/src/routes/admin/movies.ts
+++ b/apps/api/src/routes/admin/movies.ts
@@ -9,13 +9,17 @@ import {translations} from '@shine/database/schema/translations';
 import {Hono} from 'hono';
 import {authMiddleware} from '../../auth';
 import {sanitizeText} from '../../middleware/sanitizer';
-import {AdminService} from '../../services';
+import {AdminService, SelectionsService} from '../../services';
 import {
   ConflictError,
   NotFoundError,
   TmdbConfigurationError,
   ValidationError,
 } from '../../services/errors';
+import {
+  invalidateMovieCaches,
+  invalidateMovieDetailsCache,
+} from '../../services/movie-cache-invalidation';
 import {syncTmdbData, type TmdbSyncResult} from '../../services/tmdb-sync';
 import {parsePagination} from '../../utils/pagination';
 
@@ -225,7 +229,9 @@ adminMoviesRoutes.delete('/movies/:id', authMiddleware, async c => {
       return c.json({error: 'Missing id parameter'}, 400);
     }
 
+    await new SelectionsService(c.env).purgeSelectionCachesForMovie(movieId);
     await adminService.deleteMovie(movieId);
+    await invalidateMovieDetailsCache(c.env, movieId);
 
     return c.json({success: true});
   } catch (error) {
@@ -305,6 +311,7 @@ adminMoviesRoutes.put('/movies/:id', authMiddleware, async c => {
         .update(movies)
         .set(updateData)
         .where(eq(movies.uid, movieId));
+      await invalidateMovieCaches(c.env, movieId);
     }
 
     return c.json({success: true});
@@ -329,6 +336,8 @@ adminMoviesRoutes.put('/movies/:id/imdb-id', authMiddleware, async c => {
       imdbId,
       fetchTMDBData: refreshData,
     });
+
+    await invalidateMovieCaches(c.env, movieId);
 
     return c.json({
       success: true,
@@ -439,6 +448,8 @@ adminMoviesRoutes.put('/movies/:id/tmdb-id', authMiddleware, async c => {
         // Continue without failing the main operation
       }
     }
+
+    await invalidateMovieCaches(c.env, movieId);
 
     return c.json({
       success: true,
@@ -562,6 +573,8 @@ adminMoviesRoutes.post(
         fetchResults.postersAdded = syncResult.postersAdded;
         fetchResults.translationsAdded = syncResult.translationsAdded;
 
+        await invalidateMovieCaches(c.env, movieId);
+
         return c.json({
           success: true,
           fetchResults,
@@ -627,6 +640,8 @@ adminMoviesRoutes.post('/movies/:id/refresh-tmdb', authMiddleware, async c => {
         refreshMediaType,
         c.env,
       );
+
+      await invalidateMovieCaches(c.env, movieId);
 
       return c.json({
         success: true,
@@ -834,6 +849,9 @@ adminMoviesRoutes.post(
         // Finally, delete the source movie
         await tx.delete(movies).where(eq(movies.uid, sourceId));
       });
+
+      await invalidateMovieDetailsCache(c.env, sourceId);
+      await invalidateMovieCaches(c.env, targetId);
 
       return c.json({
         success: true,

--- a/apps/api/src/routes/admin/nominations.ts
+++ b/apps/api/src/routes/admin/nominations.ts
@@ -5,6 +5,7 @@ import {movies} from '@shine/database/schema/movies';
 import {nominations} from '@shine/database/schema/nominations';
 import {Hono} from 'hono';
 import {authMiddleware} from '../../auth';
+import {invalidateMovieCaches} from '../../services/movie-cache-invalidation';
 
 export const adminNominationsRoutes = new Hono<{Bindings: Environment}>();
 
@@ -100,6 +101,8 @@ adminNominationsRoutes.post(
         })
         .returning();
 
+      await invalidateMovieCaches(c.env, movieId);
+
       return c.json(newNomination[0]);
     } catch (error) {
       console.error('Error adding nomination:', error);
@@ -124,7 +127,7 @@ adminNominationsRoutes.put(
 
       // Check if nomination exists
       const nomination = await database
-        .select({uid: nominations.uid})
+        .select({uid: nominations.uid, movieUid: nominations.movieUid})
         .from(nominations)
         .where(eq(nominations.uid, nominationId))
         .limit(1);
@@ -141,6 +144,8 @@ adminNominationsRoutes.put(
           specialMention: specialMention || undefined,
         })
         .where(eq(nominations.uid, nominationId));
+
+      await invalidateMovieCaches(c.env, nomination[0].movieUid);
 
       return c.json({success: true});
     } catch (error) {
@@ -164,7 +169,7 @@ adminNominationsRoutes.delete(
 
       // Check if nomination exists
       const nomination = await database
-        .select({uid: nominations.uid})
+        .select({uid: nominations.uid, movieUid: nominations.movieUid})
         .from(nominations)
         .where(eq(nominations.uid, nominationId))
         .limit(1);
@@ -177,6 +182,8 @@ adminNominationsRoutes.delete(
       await database
         .delete(nominations)
         .where(eq(nominations.uid, nominationId));
+
+      await invalidateMovieCaches(c.env, nomination[0].movieUid);
 
       return c.json({success: true});
     } catch (error) {

--- a/apps/api/src/routes/admin/posters.ts
+++ b/apps/api/src/routes/admin/posters.ts
@@ -2,6 +2,7 @@ import {type Environment} from '@shine/database';
 import {Hono} from 'hono';
 import {authMiddleware} from '../../auth';
 import {AdminService} from '../../services';
+import {invalidateMovieCaches} from '../../services/movie-cache-invalidation';
 
 export const adminPostersRoutes = new Hono<{Bindings: Environment}>();
 
@@ -44,6 +45,8 @@ adminPostersRoutes.post('/movies/:id/posters', authMiddleware, async c => {
       isPrimary,
     });
 
+    await invalidateMovieCaches(c.env, movieId);
+
     return c.json(newPoster);
   } catch (error) {
     console.error('Error adding poster:', error);
@@ -65,6 +68,7 @@ adminPostersRoutes.delete(
       }
 
       await adminService.deletePoster(movieId, posterId);
+      await invalidateMovieCaches(c.env, movieId);
 
       return c.json({success: true});
     } catch (error) {

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -17,12 +17,11 @@ import {
   AvailabilityService,
   buildOnDemandRunners,
   MoviesService,
-  SelectionsService,
 } from '../services';
+import {invalidateMovieCaches} from '../services/movie-cache-invalidation';
 import {
   checkETag,
   createCachedResponse,
-  getMovieCacheKeysForAllLocales,
   normalizeCacheLocale,
   createETag,
   EdgeCache,
@@ -44,16 +43,6 @@ type TurnstileVerificationResponse = {
   action?: string;
   cdata?: string;
 };
-
-async function invalidateMovieDetailsCache(
-  environment: Environment,
-  movieId: string,
-): Promise<void> {
-  const cache = new EdgeCache(undefined, environment.CACHE_KV);
-  await Promise.all(
-    getMovieCacheKeysForAllLocales(movieId).map(async key => cache.delete(key)),
-  );
-}
 
 async function verifyTurnstileToken(
   secretKey: string | undefined,
@@ -362,7 +351,7 @@ moviesRoutes.post('/:id/translations', authMiddleware, async c => {
       isDefault,
     );
 
-    await invalidateMovieDetailsCache(c.env, movieId);
+    await invalidateMovieCaches(c.env, movieId);
 
     console.log(
       `Cache invalidated for movie ${movieId} after translation update`,
@@ -392,7 +381,7 @@ moviesRoutes.delete('/:id/translations/:lang', authMiddleware, async c => {
 
     await moviesService.deleteMovieTranslation(movieId, languageCode);
 
-    await invalidateMovieDetailsCache(c.env, movieId);
+    await invalidateMovieCaches(c.env, movieId);
 
     console.log(
       `Cache invalidated for movie ${movieId} after translation deletion`,
@@ -531,8 +520,7 @@ moviesRoutes.post('/:id/article-links', async c => {
       })
       .returning();
 
-    await invalidateMovieDetailsCache(c.env, movieId);
-    await new SelectionsService(c.env).purgeSelectionCachesForMovie(movieId);
+    await invalidateMovieCaches(c.env, movieId);
 
     return c.json(newArticle[0], 201);
   } catch (error) {

--- a/apps/api/src/routes/movies.ts
+++ b/apps/api/src/routes/movies.ts
@@ -33,7 +33,6 @@ import {parsePagination} from '../utils/pagination';
 
 export const moviesRoutes = new Hono<{Bindings: Environment}>();
 
-const cache = new EdgeCache();
 const TURNSTILE_VERIFY_ENDPOINT =
   'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 
@@ -45,6 +44,16 @@ type TurnstileVerificationResponse = {
   action?: string;
   cdata?: string;
 };
+
+async function invalidateMovieDetailsCache(
+  environment: Environment,
+  movieId: string,
+): Promise<void> {
+  const cache = new EdgeCache(undefined, environment.CACHE_KV);
+  await Promise.all(
+    getMovieCacheKeysForAllLocales(movieId).map(async key => cache.delete(key)),
+  );
+}
 
 async function verifyTurnstileToken(
   secretKey: string | undefined,
@@ -139,6 +148,7 @@ moviesRoutes.get('/:id', async c => {
     }
 
     const locale = c.req.query('locale') || 'ja';
+    const cache = new EdgeCache(undefined, c.env.CACHE_KV);
 
     // Check cache first
     const cacheLocale = normalizeCacheLocale(locale);
@@ -352,12 +362,7 @@ moviesRoutes.post('/:id/translations', authMiddleware, async c => {
       isDefault,
     );
 
-    // Invalidate movie details cache
-    await Promise.all(
-      getMovieCacheKeysForAllLocales(movieId).map(async key =>
-        cache.delete(key),
-      ),
-    );
+    await invalidateMovieDetailsCache(c.env, movieId);
 
     console.log(
       `Cache invalidated for movie ${movieId} after translation update`,
@@ -387,12 +392,7 @@ moviesRoutes.delete('/:id/translations/:lang', authMiddleware, async c => {
 
     await moviesService.deleteMovieTranslation(movieId, languageCode);
 
-    // Invalidate movie details cache
-    await Promise.all(
-      getMovieCacheKeysForAllLocales(movieId).map(async key =>
-        cache.delete(key),
-      ),
-    );
+    await invalidateMovieDetailsCache(c.env, movieId);
 
     console.log(
       `Cache invalidated for movie ${movieId} after translation deletion`,
@@ -531,12 +531,7 @@ moviesRoutes.post('/:id/article-links', async c => {
       })
       .returning();
 
-    // Invalidate movie details cache
-    await Promise.all(
-      getMovieCacheKeysForAllLocales(movieId).map(async key =>
-        cache.delete(key),
-      ),
-    );
+    await invalidateMovieDetailsCache(c.env, movieId);
     await new SelectionsService(c.env).purgeSelectionCachesForMovie(movieId);
 
     return c.json(newArticle[0], 201);

--- a/apps/api/src/services/movie-cache-invalidation.ts
+++ b/apps/api/src/services/movie-cache-invalidation.ts
@@ -1,0 +1,25 @@
+import {type Environment} from '@shine/database';
+import {EdgeCache, getMovieCacheKeysForAllLocales} from '../utils/cache';
+import {SelectionsService} from './selections-service';
+
+export async function invalidateMovieDetailsCache(
+  environment: Environment,
+  movieUid: string,
+): Promise<void> {
+  const cache = new EdgeCache(undefined, environment.CACHE_KV);
+  await Promise.all(
+    getMovieCacheKeysForAllLocales(movieUid).map(async key =>
+      cache.delete(key),
+    ),
+  );
+}
+
+export async function invalidateMovieCaches(
+  environment: Environment,
+  movieUid: string,
+): Promise<void> {
+  await invalidateMovieDetailsCache(environment, movieUid);
+  await new SelectionsService(environment).purgeSelectionCachesForMovie(
+    movieUid,
+  );
+}

--- a/apps/api/src/services/movies-service.ts
+++ b/apps/api/src/services/movies-service.ts
@@ -1,4 +1,4 @@
-import {and, eq, inArray, isNull, sql} from '@shine/database';
+import {and, eq, inArray, isNull, sql, type Environment} from '@shine/database';
 import {articleLinks} from '@shine/database/schema/article-links';
 import {awardCategories} from '@shine/database/schema/award-categories';
 import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
@@ -22,7 +22,12 @@ import {BaseService} from './base-service';
 import type {MovieSelection, SearchOptions} from '@shine/types';
 
 export class MoviesService extends BaseService {
-  private readonly cache = new EdgeCache();
+  private readonly cache: EdgeCache;
+
+  constructor(environment: Environment) {
+    super(environment);
+    this.cache = new EdgeCache(undefined, environment.CACHE_KV);
+  }
 
   async searchMovies(options: SearchOptions) {
     const {page, limit, query, year, language, hasAwards} = options;

--- a/apps/api/src/services/selections-service.ts
+++ b/apps/api/src/services/selections-service.ts
@@ -34,7 +34,10 @@ type SelectionType = 'daily' | 'weekly' | 'monthly';
 export class SelectionsService extends BaseService {
   private readonly cache: EdgeCache;
 
-  constructor(environment: Environment, cache = new EdgeCache()) {
+  constructor(
+    environment: Environment,
+    cache = new EdgeCache(undefined, environment.CACHE_KV),
+  ) {
     super(environment);
     this.cache = cache;
   }


### PR DESCRIPTION
PR #295 のフォローアップ。2つの問題に対応する。

**1. キャッシュのKV移行**

映画詳細（full/basic）とselectionsのキャッシュはCache API（coloローカル）に乗っており、記事リンク投稿時の無効化がリクエストを受けたcoloにしか効かなかった。CACHE_KVに移行して無効化を全リージョンに効かせる。

- GET /movies/:id・MoviesService・SelectionsService・admin記事リンクのEdgeCacheを `c.env.CACHE_KV` 付きで生成するように変更（読み書き・無効化を一括で切り替え）
- CACHE_KVバインディングがないテスト環境では従来どおりCache APIにフォールバック
- デプロイ後はKVが空の状態から始まるため、既存のCache APIエントリは読まれなくなりTTLで自然消滅する

**2. admin映画ミューテーションの無効化漏れ**

admin側の映画削除・更新・IMDb/TMDb ID変更・TMDbリフレッシュ・マージ・ポスター・ノミネート操作にキャッシュ無効化が皆無だった。KV移行でキャッシュがグローバルになると、削除した映画が最大24時間配信され続けるなど実害が広がるため、このブランチで一括対応する。

- 無効化を `invalidateMovieCaches` / `invalidateMovieDetailsCache`（services/movie-cache-invalidation.ts）に集約
- admin の全映画ミューテーションハンドラ成功時に呼び出し（映画削除はselections purge→削除→詳細purgeの順）
- ノミネートPUT/DELETEは存在チェックのselectにmovieUidを含めて無効化対象を特定