### PR TITLE
TMDb判定から終了済みのGoogle Play Moviesを除外する

### DIFF
--- a/packages/availability/src/__tests__/tmdb.test.ts
+++ b/packages/availability/src/__tests__/tmdb.test.ts
@@ -45,6 +45,46 @@ describe('checkTmdbProviders', () => {
     expect(result.status).toBe('ng');
   });
 
+  it('returns ng when the only JP provider is defunct Google Play Movies', async () => {
+    const fetchSpy = vi.fn(async () =>
+      Response.json({
+        id: 238,
+        results: {
+          JP: {
+            rent: [{provider_id: 3, provider_name: 'Google Play Movies'}],
+            buy: [{provider_id: 3, provider_name: 'Google Play Movies'}],
+          },
+        },
+      }),
+    );
+
+    const result = await checkTmdbProviders(238, 'api-key', fetchSpy);
+
+    expect(result.status).toBe('ng');
+  });
+
+  it('excludes defunct Google Play Movies from detail when other providers exist', async () => {
+    const fetchSpy = vi.fn(async () =>
+      Response.json({
+        id: 238,
+        results: {
+          JP: {
+            rent: [
+              {provider_id: 3, provider_name: 'Google Play Movies'},
+              {provider_id: 10, provider_name: 'Amazon Video'},
+            ],
+          },
+        },
+      }),
+    );
+
+    const result = await checkTmdbProviders(238, 'api-key', fetchSpy);
+
+    expect(result.status).toBe('ok');
+    expect(result.detail).toContain('Amazon Video');
+    expect(result.detail).not.toContain('Google Play Movies');
+  });
+
   it('returns error on HTTP failure', async () => {
     const fetchSpy = vi.fn(
       async () => new Response('unauthorized', {status: 401}),

--- a/packages/availability/src/sources/tmdb.ts
+++ b/packages/availability/src/sources/tmdb.ts
@@ -1,14 +1,25 @@
 import type {FetchLike, SourceCheckResult} from '../types';
 
+type Provider = {provider_id?: number; provider_name?: string};
+
 type WatchProvidersResponse = {
   results?: {
     JP?: {
-      flatrate?: Array<{provider_name?: string}>;
-      rent?: Array<{provider_name?: string}>;
-      buy?: Array<{provider_name?: string}>;
+      flatrate?: Provider[];
+      rent?: Provider[];
+      buy?: Provider[];
     };
   };
 };
+
+// Google Play Movies: 2024-01-17に日本でサービス終了したがJustWatch側のデータが残っている
+const DEFUNCT_PROVIDER_IDS = new Set([3]);
+
+const activeProviders = (providers: Provider[] | undefined) =>
+  (providers ?? []).filter(
+    p =>
+      p.provider_id === undefined || !DEFUNCT_PROVIDER_IDS.has(p.provider_id),
+  );
 
 export async function checkTmdbProviders(
   tmdbId: number,
@@ -30,9 +41,9 @@ export async function checkTmdbProviders(
     const body = (await response.json()) as WatchProvidersResponse;
     const jp = body.results?.JP;
     const offerings = [
-      ...(jp?.flatrate ?? []).map(p => `${p.provider_name}(見放題)`),
-      ...(jp?.rent ?? []).map(p => `${p.provider_name}(レンタル)`),
-      ...(jp?.buy ?? []).map(p => `${p.provider_name}(購入)`),
+      ...activeProviders(jp?.flatrate).map(p => `${p.provider_name}(見放題)`),
+      ...activeProviders(jp?.rent).map(p => `${p.provider_name}(レンタル)`),
+      ...activeProviders(jp?.buy).map(p => `${p.provider_name}(購入)`),
     ];
 
     return offerings.length > 0


### PR DESCRIPTION
「アンラッキー・セックス またはイカれたポルノ」が配信ありと誤判定されていた。

TMDb watch providers（JustWatch由来）がJPのプロバイダとして Google Play Movies(provider_id 3) のレンタル/購入を今も返しているが、Google Play ムービー＆TVは2024-01-17に日本でサービス終了しており実際には視聴できない。checkTmdbProvidersで終了済みプロバイダを除外し、それしか無い場合はngにする。

マージ後、既存のok判定レコードは残るため該当映画の再チェックを別途行う。