### PR TITLE
リメイク・同名作への誤紐付けノミネーション23件を修正する

### DIFF
--- a/apps/scrapers/data/misattributed-nominations.json
+++ b/apps/scrapers/data/misattributed-nominations.json
@@ -1,0 +1,225 @@
+[
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Foreign Film",
+    "ceremonyYear": 1925,
+    "specialMention": "9位",
+    "wrongImdbId": "tt0033028",
+    "correctImdbId": "tt0015310",
+    "correctTitle": "シー・ホーク",
+    "correctYear": 1924
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1931,
+    "specialMention": "4位",
+    "wrongImdbId": "tt0025312",
+    "correctImdbId": null,
+    "correctTitle": "一本刀土俵入り",
+    "correctYear": 1931
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1935,
+    "specialMention": "10位",
+    "wrongImdbId": "tt0057710",
+    "correctImdbId": "tt0027237",
+    "correctTitle": "雪之丞変化",
+    "correctYear": 1935
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1936,
+    "specialMention": "7位",
+    "wrongImdbId": "tt0202229",
+    "correctImdbId": null,
+    "correctTitle": "兄いもうと",
+    "correctYear": 1936
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1938,
+    "specialMention": "10位",
+    "wrongImdbId": "tt1994569",
+    "correctImdbId": "tt0452421",
+    "correctTitle": "太陽の子",
+    "correctYear": 1938
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1947,
+    "specialMention": "2位",
+    "wrongImdbId": "tt0171802",
+    "correctImdbId": "tt0342973",
+    "correctTitle": "戦争と平和",
+    "correctYear": 1947
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1948,
+    "specialMention": "2位",
+    "wrongImdbId": "tt0057561",
+    "correctImdbId": "tt0040230",
+    "correctTitle": "手をつなぐ子等",
+    "correctYear": 1948
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1948,
+    "specialMention": "6位",
+    "wrongImdbId": "tt0056051",
+    "correctImdbId": "tt0040413",
+    "correctTitle": "破戒",
+    "correctYear": 1948
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Foreign Film",
+    "ceremonyYear": 1955,
+    "specialMention": "6位",
+    "wrongImdbId": "tt0079820",
+    "correctImdbId": "tt0044414",
+    "correctTitle": "やぶにらみの暴君",
+    "correctYear": 1952
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1959,
+    "specialMention": "2位",
+    "wrongImdbId": "tt3893038",
+    "correctImdbId": "tt0053121",
+    "correctTitle": "野火",
+    "correctYear": 1959
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1959,
+    "specialMention": "5位",
+    "wrongImdbId": "tt0055233",
+    "correctImdbId": "tt0053114",
+    "correctTitle": "人間の條件　第１部純愛篇／第２部激怒篇",
+    "correctYear": 1959
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1969,
+    "specialMention": "5位",
+    "wrongImdbId": "tt0104395",
+    "correctImdbId": "tt0186193",
+    "correctTitle": "橋のない川",
+    "correctYear": 1969
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1970,
+    "specialMention": "9位",
+    "wrongImdbId": "tt0104395",
+    "correctImdbId": "tt1995321",
+    "correctTitle": "橋のない川 第二部",
+    "correctYear": 1970
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1971,
+    "specialMention": "4位",
+    "wrongImdbId": "tt0323921",
+    "correctImdbId": "tt0320441",
+    "correctTitle": "戦争と人間　第二部",
+    "correctYear": 1971
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 1973,
+    "specialMention": "10位",
+    "wrongImdbId": "tt0323921",
+    "correctImdbId": "tt0072139",
+    "correctTitle": "戦争と人間　完結編",
+    "correctYear": 1973
+  },
+  {
+    "organization": "Kinema Junpo",
+    "category": "Best Japanese Film",
+    "ceremonyYear": 2024,
+    "specialMention": "8位",
+    "wrongImdbId": "tt8764582",
+    "correctImdbId": "tt34144683",
+    "correctTitle": "青春ジャック 止められるか、俺たちを2",
+    "correctYear": 2024
+  },
+  {
+    "organization": "Cannes Film Festival",
+    "category": "Palme d'Or",
+    "ceremonyYear": 1951,
+    "wrongImdbId": "tt0109340",
+    "correctImdbId": "tt0043362",
+    "correctTitle": "The Browning Version",
+    "correctYear": 1951
+  },
+  {
+    "organization": "Cannes Film Festival",
+    "category": "Palme d'Or",
+    "ceremonyYear": 1952,
+    "wrongImdbId": "tt0048455",
+    "correctImdbId": "tt0045251",
+    "correctTitle": "Othello",
+    "correctYear": 1951
+  },
+  {
+    "organization": "Cannes Film Festival",
+    "category": "Palme d'Or",
+    "ceremonyYear": 1956,
+    "wrongImdbId": "tt0099266",
+    "correctImdbId": "tt0048359",
+    "correctTitle": "Mother",
+    "correctYear": 1955
+  },
+  {
+    "organization": "Cannes Film Festival",
+    "category": "Palme d'Or",
+    "ceremonyYear": 1958,
+    "wrongImdbId": "tt1078600",
+    "correctImdbId": "tt0051155",
+    "correctTitle": "Vengeance",
+    "correctYear": 1958
+  },
+  {
+    "organization": "Cannes Film Festival",
+    "category": "Palme d'Or",
+    "ceremonyYear": 1988,
+    "wrongImdbId": "tt28277817",
+    "correctImdbId": "tt0094747",
+    "correctTitle": "Bird",
+    "correctYear": 1988
+  },
+  {
+    "organization": "Cannes Film Festival",
+    "category": "Palme d'Or",
+    "ceremonyYear": 1988,
+    "wrongImdbId": "tt0241303",
+    "correctImdbId": "tt0094868",
+    "correctTitle": "Chocolat",
+    "correctYear": 1988
+  },
+  {
+    "organization": "Cannes Film Festival",
+    "category": "Palme d'Or",
+    "ceremonyYear": 1996,
+    "wrongImdbId": "tt0375679",
+    "correctImdbId": "tt0115964",
+    "correctTitle": "Crash",
+    "correctYear": 1996
+  }
+]

--- a/apps/scrapers/package.json
+++ b/apps/scrapers/package.json
@@ -11,6 +11,7 @@
     "assign-imdb-ids": "tsx src/assign-imdb-ids-cli.ts",
     "backfill-posters": "tsx src/backfill-posters-cli.ts",
     "delete-orphan-movies": "tsx src/delete-orphan-movies-cli.ts",
+    "fix-misattributed-nominations": "tsx src/fix-misattributed-nominations-cli.ts",
     "import-imdb-list": "tsx src/import-imdb-list-cli.ts",
     "availability-check": "tsx src/availability-check-cli.ts",
     "japanese-translations": "tsx src/japanese-translations-cli.ts",

--- a/apps/scrapers/src/__tests__/fix-misattributed-nominations.test.ts
+++ b/apps/scrapers/src/__tests__/fix-misattributed-nominations.test.ts
@@ -1,0 +1,318 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {and, eq} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {translations} from '@shine/database/schema/translations';
+import {migrate} from 'drizzle-orm/libsql/migrator';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  fixMisattributedNominations,
+  type MisattributedNomination,
+} from '../fix-misattributed-nominations';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const migrationsFolder = path.resolve(
+  currentDirectory,
+  '../../../../packages/database/migrations',
+);
+
+type TestDatabase = ReturnType<typeof getDatabase>;
+
+async function createTestEnvironment(): Promise<{
+  environment: Environment;
+  database: TestDatabase;
+}> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'shine-misattr-'));
+  const environment: Environment = {
+    TURSO_DATABASE_URL: `file:${path.join(directory, 'test.db')}`,
+    TURSO_AUTH_TOKEN: '',
+    TMDB_API_KEY: 'test-key',
+  };
+  const database = getDatabase(environment);
+  await migrate(database, {migrationsFolder});
+  await database
+    .insert(awardOrganizations)
+    .values({uid: 'org', name: 'Kinema Junpo'});
+  await database
+    .insert(awardCategories)
+    .values({uid: 'cat', organizationUid: 'org', name: 'Best Japanese Film'});
+  await database
+    .insert(awardCeremonies)
+    .values({uid: 'ceremony', organizationUid: 'org', year: 1959});
+  return {environment, database};
+}
+
+async function seedMovie(
+  database: TestDatabase,
+  values: {
+    uid: string;
+    title: string;
+    year: number;
+    imdbId?: string;
+    deleted?: boolean;
+  },
+): Promise<void> {
+  await database.insert(movies).values({
+    uid: values.uid,
+    year: values.year,
+    imdbId: values.imdbId,
+    deletedAt: values.deleted ? Math.floor(Date.now() / 1000) : undefined,
+  });
+  await database.insert(translations).values({
+    resourceType: 'movie_title',
+    resourceUid: values.uid,
+    languageCode: 'ja',
+    content: values.title,
+    isDefault: 1,
+  });
+}
+
+const entry: MisattributedNomination = {
+  organization: 'Kinema Junpo',
+  category: 'Best Japanese Film',
+  ceremonyYear: 1959,
+  specialMention: '2位',
+  wrongImdbId: 'tt3893038',
+  correctImdbId: 'tt0053121',
+  correctTitle: '野火',
+  correctYear: 1959,
+};
+
+describe('fixMisattributedNominations', () => {
+  let environment: Environment;
+  let database: TestDatabase;
+
+  beforeEach(async () => {
+    ({environment, database} = await createTestEnvironment());
+    await seedMovie(database, {
+      uid: 'wrong-movie',
+      title: '野火',
+      year: 2015,
+      imdbId: 'tt3893038',
+    });
+    await database.insert(nominations).values({
+      uid: 'nomination',
+      movieUid: 'wrong-movie',
+      ceremonyUid: 'ceremony',
+      categoryUid: 'cat',
+      isWinner: 0,
+      specialMention: '2位',
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('ノミネーションを正しい映画に付け替える', async () => {
+    await seedMovie(database, {
+      uid: 'correct-movie',
+      title: '野火',
+      year: 1959,
+      imdbId: 'tt0053121',
+    });
+
+    await fixMisattributedNominations({environment, entries: [entry]});
+
+    const [row] = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.uid, 'nomination'));
+    expect(row.movieUid).toBe('correct-movie');
+  });
+
+  it('付け替えても順位は保持される', async () => {
+    await seedMovie(database, {
+      uid: 'correct-movie',
+      title: '野火',
+      year: 1959,
+      imdbId: 'tt0053121',
+    });
+
+    await fixMisattributedNominations({environment, entries: [entry]});
+
+    const [row] = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.uid, 'nomination'));
+    expect(row.specialMention).toBe('2位');
+  });
+
+  it('ソフト削除された正しい映画を復活させて使う', async () => {
+    await seedMovie(database, {
+      uid: 'correct-movie',
+      title: '野火',
+      year: 1959,
+      imdbId: 'tt0053121',
+      deleted: true,
+    });
+
+    await fixMisattributedNominations({environment, entries: [entry]});
+
+    const [movie] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.uid, 'correct-movie'));
+    expect(movie.deletedAt).toBeNull();
+  });
+
+  it('移動先が同じ賞のノミネーションを既に持つ場合は元の行を削除する', async () => {
+    await seedMovie(database, {
+      uid: 'correct-movie',
+      title: '野火',
+      year: 1959,
+      imdbId: 'tt0053121',
+    });
+    await database.insert(nominations).values({
+      uid: 'existing',
+      movieUid: 'correct-movie',
+      ceremonyUid: 'ceremony',
+      categoryUid: 'cat',
+      isWinner: 0,
+      specialMention: '2位',
+    });
+
+    await fixMisattributedNominations({environment, entries: [entry]});
+
+    const rows = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.uid, 'nomination'));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('対象のノミネーションが無ければ何もしない', async () => {
+    await seedMovie(database, {
+      uid: 'correct-movie',
+      title: '野火',
+      year: 1959,
+      imdbId: 'tt0053121',
+    });
+
+    await fixMisattributedNominations({environment, entries: [entry]});
+    const stats = await fixMisattributedNominations({
+      environment,
+      entries: [entry],
+    });
+
+    expect(stats.skipped).toBe(1);
+    expect(stats.repointed).toBe(0);
+  });
+
+  it('dry-runでは付け替えない', async () => {
+    await seedMovie(database, {
+      uid: 'correct-movie',
+      title: '野火',
+      year: 1959,
+      imdbId: 'tt0053121',
+    });
+
+    await fixMisattributedNominations({
+      environment,
+      entries: [entry],
+      dryRun: true,
+    });
+
+    const [row] = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.uid, 'nomination'));
+    expect(row.movieUid).toBe('wrong-movie');
+  });
+
+  it('正しい映画がDBに無ければTMDbから作成する', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL) => {
+        const url = String(input);
+        if (url.includes('/find/tt0053121')) {
+          return Response.json(
+            {movie_results: [{id: 42, media_type: 'movie'}]},
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/movie/42')) {
+          return Response.json(
+            {
+              id: 42,
+              title: 'Fires on the Plain',
+              original_language: 'ja',
+              release_date: '1959-11-03',
+            },
+            {status: 200},
+          );
+        }
+
+        return new Response('{}', {status: 404});
+      }),
+    );
+
+    const stats = await fixMisattributedNominations({
+      environment,
+      entries: [entry],
+    });
+
+    const [created] = await database
+      .select()
+      .from(movies)
+      .where(eq(movies.imdbId, 'tt0053121'));
+    expect(created.year).toBe(1959);
+    expect(stats.moviesCreated).toBe(1);
+  });
+
+  it('IMDb IDが無い映画はタイトルと年だけで作成する', async () => {
+    const entryWithoutImdbId: MisattributedNomination = {
+      ...entry,
+      correctImdbId: undefined,
+      correctTitle: '兄いもうと',
+      correctYear: 1936,
+    };
+
+    await fixMisattributedNominations({
+      environment,
+      entries: [entryWithoutImdbId],
+    });
+
+    const [row] = await database
+      .select()
+      .from(nominations)
+      .where(eq(nominations.uid, 'nomination'));
+    const [title] = await database
+      .select()
+      .from(translations)
+      .where(
+        and(
+          eq(translations.resourceUid, row.movieUid),
+          eq(translations.languageCode, 'ja'),
+        ),
+      );
+    expect(title.content).toBe('兄いもうと');
+  });
+
+  it('付け替えた映画のUIDを両方返す', async () => {
+    await seedMovie(database, {
+      uid: 'correct-movie',
+      title: '野火',
+      year: 1959,
+      imdbId: 'tt0053121',
+    });
+
+    const stats = await fixMisattributedNominations({
+      environment,
+      entries: [entry],
+    });
+
+    expect(stats.affectedMovieUids.toSorted()).toEqual([
+      'correct-movie',
+      'wrong-movie',
+    ]);
+  });
+});

--- a/apps/scrapers/src/fix-misattributed-nominations-cli.ts
+++ b/apps/scrapers/src/fix-misattributed-nominations-cli.ts
@@ -1,0 +1,101 @@
+/**
+ * リメイクや同名別作品に誤って紐づいたノミネーションを正しい映画へ付け替えるCLI
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {Command} from 'commander';
+import {
+  assertDatabaseEnvironment,
+  buildEnvironment,
+  loadEnvironmentFiles,
+} from './common/environment';
+import {
+  fixMisattributedNominations,
+  type MisattributedNomination,
+} from './fix-misattributed-nominations';
+
+loadEnvironmentFiles();
+const environment = buildEnvironment(process.env);
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const dataFilePath = path.resolve(
+  currentDirectory,
+  '../data/misattributed-nominations.json',
+);
+
+async function loadEntries(): Promise<MisattributedNomination[]> {
+  const raw = await fs.readFile(dataFilePath, 'utf8');
+  const parsed = JSON.parse(raw) as Array<
+    Omit<MisattributedNomination, 'correctImdbId' | 'specialMention'> & {
+      correctImdbId: string | null;
+      specialMention?: string | null;
+    }
+  >;
+
+  return parsed.map(entry => ({
+    ...entry,
+    correctImdbId: entry.correctImdbId ?? undefined,
+    specialMention: entry.specialMention ?? undefined,
+  }));
+}
+
+const program = new Command();
+
+program
+  .name('fix-misattributed-nominations')
+  .description(
+    [
+      'data/misattributed-nominations.json の定義に従って、',
+      'リメイクや同名別作品に誤紐付けされたノミネーションを正しい映画へ付け替えます。',
+      '正しい映画がDBに無ければTMDbから作成し、ソフト削除されていれば復活させます。',
+    ].join('\n'),
+  )
+  .option('--dry-run', '書き込みは行わず、対象のみ表示', false)
+  .addHelpText(
+    'after',
+    `
+例:
+  pnpm run scrapers:fix-misattributed-nominations --dry-run
+  pnpm run scrapers:fix-misattributed-nominations
+`,
+  )
+  .action(async (options: {dryRun: boolean}) => {
+    assertDatabaseEnvironment(environment);
+
+    const entries = await loadEntries();
+    console.log(`修正定義: ${entries.length}件`);
+
+    const stats = await fixMisattributedNominations({
+      environment,
+      entries,
+      dryRun: options.dryRun,
+      throttleMs: 250,
+    });
+
+    console.log('\n結果:');
+    console.log(`  付け替え: ${stats.repointed}`);
+    console.log(`  重複削除: ${stats.deletedDuplicate}`);
+    console.log(`  映画作成: ${stats.moviesCreated}`);
+    console.log(`  映画復活: ${stats.moviesRevived}`);
+    console.log(`  対象なし: ${stats.skipped}`);
+    console.log(`  失敗: ${stats.failed}`);
+
+    if (stats.affectedMovieUids.length > 0) {
+      console.log('\nキャッシュ無効化が必要な映画UID:');
+      for (const uid of stats.affectedMovieUids) {
+        console.log(`  ${uid}`);
+      }
+    }
+
+    if (stats.failed > 0) {
+      process.exitCode = 1;
+    }
+  });
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  console.error('修正処理中にエラーが発生しました:', error);
+  process.exitCode = 1;
+}

--- a/apps/scrapers/src/fix-misattributed-nominations.ts
+++ b/apps/scrapers/src/fix-misattributed-nominations.ts
@@ -1,0 +1,358 @@
+import {and, eq, isNull} from 'drizzle-orm';
+import {getDatabase, type Environment} from '@shine/database';
+import {awardCategories} from '@shine/database/schema/award-categories';
+import {awardCeremonies} from '@shine/database/schema/award-ceremonies';
+import {awardOrganizations} from '@shine/database/schema/award-organizations';
+import {movies} from '@shine/database/schema/movies';
+import {nominations} from '@shine/database/schema/nominations';
+import {referenceUrls} from '@shine/database/schema/reference-urls';
+import {translations} from '@shine/database/schema/translations';
+import {
+  fetchTMDBImages,
+  fetchTMDBMovieDetails,
+  findTMDBByImdbId,
+  savePosterUrls,
+  type TMDBMovieData,
+} from './common/tmdb-utilities';
+
+export type MisattributedNomination = {
+  organization: string;
+  category: string;
+  ceremonyYear: number;
+  specialMention?: string | undefined;
+  wrongImdbId: string;
+  correctImdbId: string | undefined;
+  correctTitle: string;
+  correctYear: number;
+};
+
+export type FixMisattributedStats = {
+  repointed: number;
+  deletedDuplicate: number;
+  moviesCreated: number;
+  moviesRevived: number;
+  skipped: number;
+  failed: number;
+  affectedMovieUids: string[];
+};
+
+type Database = ReturnType<typeof getDatabase>;
+
+const CJK_PATTERN = /[぀-ヿ一-鿿]/;
+
+type FixOptions = {
+  environment: Environment;
+  entries: MisattributedNomination[];
+  dryRun?: boolean;
+  throttleMs?: number;
+};
+
+const sleep = async (ms: number): Promise<void> =>
+  new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+
+async function findTargetNomination(
+  database: Database,
+  entry: MisattributedNomination,
+): Promise<{uid: string; movieUid: string} | undefined> {
+  const rows = await database
+    .select({uid: nominations.uid, movieUid: nominations.movieUid})
+    .from(nominations)
+    .innerJoin(movies, eq(movies.uid, nominations.movieUid))
+    .innerJoin(
+      awardCeremonies,
+      eq(awardCeremonies.uid, nominations.ceremonyUid),
+    )
+    .innerJoin(
+      awardOrganizations,
+      eq(awardOrganizations.uid, awardCeremonies.organizationUid),
+    )
+    .innerJoin(
+      awardCategories,
+      eq(awardCategories.uid, nominations.categoryUid),
+    )
+    .where(
+      and(
+        eq(movies.imdbId, entry.wrongImdbId),
+        eq(awardCeremonies.year, entry.ceremonyYear),
+        eq(awardOrganizations.name, entry.organization),
+        eq(awardCategories.name, entry.category),
+        entry.specialMention
+          ? eq(nominations.specialMention, entry.specialMention)
+          : undefined,
+      ),
+    );
+
+  if (rows.length > 1) {
+    throw new Error(
+      `${entry.organization} ${entry.ceremonyYear} ${entry.wrongImdbId} に一致するノミネーションが${rows.length}件あります`,
+    );
+  }
+
+  return rows[0];
+}
+
+async function findMovieByImdbId(
+  database: Database,
+  imdbId: string,
+): Promise<{uid: string; deletedAt: number | null} | undefined> {
+  const [row] = await database
+    .select({uid: movies.uid, deletedAt: movies.deletedAt})
+    .from(movies)
+    .where(eq(movies.imdbId, imdbId));
+  return row;
+}
+
+async function findMovieByTitleAndYear(
+  database: Database,
+  title: string,
+  year: number,
+): Promise<string | undefined> {
+  const [row] = await database
+    .select({uid: movies.uid})
+    .from(movies)
+    .innerJoin(translations, eq(translations.resourceUid, movies.uid))
+    .where(
+      and(
+        isNull(movies.deletedAt),
+        eq(movies.year, year),
+        eq(translations.resourceType, 'movie_title'),
+        eq(translations.content, title),
+      ),
+    );
+  return row?.uid;
+}
+
+async function createMovie(
+  database: Database,
+  environment: Environment,
+  entry: MisattributedNomination,
+  details: TMDBMovieData | undefined,
+): Promise<string> {
+  const [movie] = await database
+    .insert(movies)
+    .values({
+      imdbId: entry.correctImdbId,
+      tmdbId: details?.id,
+      originalLanguage: details?.original_language ?? 'ja',
+      year: entry.correctYear,
+      releaseDate: details?.release_date || undefined,
+    })
+    .returning();
+
+  const titleValues: Array<typeof translations.$inferInsert> = [
+    {
+      resourceType: 'movie_title',
+      resourceUid: movie.uid,
+      languageCode: 'en',
+      content: details?.title ?? entry.correctTitle,
+      isDefault: 1,
+    },
+  ];
+
+  if (CJK_PATTERN.test(entry.correctTitle)) {
+    titleValues.push({
+      resourceType: 'movie_title',
+      resourceUid: movie.uid,
+      languageCode: 'ja',
+      content: entry.correctTitle,
+      isDefault: 0,
+    });
+  }
+
+  await database.insert(translations).values(titleValues).onConflictDoNothing();
+
+  if (entry.correctImdbId) {
+    await database
+      .insert(referenceUrls)
+      .values({
+        movieUid: movie.uid,
+        url: `https://www.imdb.com/title/${entry.correctImdbId}/`,
+        sourceType: 'imdb',
+        languageCode: 'en',
+        isPrimary: 1,
+      })
+      .onConflictDoNothing();
+  }
+
+  if (details?.id) {
+    await database
+      .insert(referenceUrls)
+      .values({
+        movieUid: movie.uid,
+        url: `https://www.themoviedb.org/movie/${details.id}`,
+        sourceType: 'other',
+        languageCode: 'en',
+        description: 'TMDb entry',
+        isPrimary: 0,
+      })
+      .onConflictDoNothing();
+  }
+
+  if (details?.id && environment.TMDB_API_KEY) {
+    const images = await fetchTMDBImages(
+      details.id,
+      'movie',
+      environment.TMDB_API_KEY,
+    );
+
+    if (images) {
+      await savePosterUrls(movie.uid, images.posters, environment);
+    }
+  }
+
+  return movie.uid;
+}
+
+async function resolveCorrectMovie(
+  database: Database,
+  environment: Environment,
+  entry: MisattributedNomination,
+  stats: FixMisattributedStats,
+): Promise<string> {
+  if (entry.correctImdbId) {
+    const existing = await findMovieByImdbId(database, entry.correctImdbId);
+
+    if (existing) {
+      if (existing.deletedAt !== null) {
+        await database
+          .update(movies)
+          // eslint-disable-next-line unicorn/no-null -- 論理削除の解除はnullで表す
+          .set({deletedAt: null})
+          .where(eq(movies.uid, existing.uid));
+        stats.moviesRevived++;
+      }
+
+      return existing.uid;
+    }
+  } else {
+    const existing = await findMovieByTitleAndYear(
+      database,
+      entry.correctTitle,
+      entry.correctYear,
+    );
+
+    if (existing) {
+      return existing;
+    }
+  }
+
+  const tmdbApiKey = environment.TMDB_API_KEY;
+  let details: TMDBMovieData | undefined;
+  if (entry.correctImdbId && tmdbApiKey) {
+    const found = await findTMDBByImdbId(entry.correctImdbId, tmdbApiKey);
+    if (found?.mediaType === 'movie') {
+      details = await fetchTMDBMovieDetails(found.tmdbId, tmdbApiKey, 'en-US');
+    }
+  }
+
+  const uid = await createMovie(database, environment, entry, details);
+  stats.moviesCreated++;
+  return uid;
+}
+
+async function hasSameNomination(
+  database: Database,
+  nominationUid: string,
+  movieUid: string,
+): Promise<boolean> {
+  const [target] = await database
+    .select({
+      ceremonyUid: nominations.ceremonyUid,
+      categoryUid: nominations.categoryUid,
+    })
+    .from(nominations)
+    .where(eq(nominations.uid, nominationUid));
+
+  const rows = await database
+    .select({uid: nominations.uid})
+    .from(nominations)
+    .where(
+      and(
+        eq(nominations.movieUid, movieUid),
+        eq(nominations.ceremonyUid, target.ceremonyUid),
+        eq(nominations.categoryUid, target.categoryUid),
+      ),
+    );
+
+  return rows.length > 0;
+}
+
+export async function fixMisattributedNominations({
+  environment,
+  entries,
+  dryRun = false,
+  throttleMs = 0,
+}: FixOptions): Promise<FixMisattributedStats> {
+  const database = getDatabase(environment);
+  const stats: FixMisattributedStats = {
+    repointed: 0,
+    deletedDuplicate: 0,
+    moviesCreated: 0,
+    moviesRevived: 0,
+    skipped: 0,
+    failed: 0,
+    affectedMovieUids: [],
+  };
+  const affected = new Set<string>();
+
+  for (const entry of entries) {
+    const label = `${entry.organization} ${entry.ceremonyYear}${
+      entry.specialMention ? ` ${entry.specialMention}` : ''
+    } ${entry.correctTitle}`;
+
+    try {
+      const nomination = await findTargetNomination(database, entry);
+
+      if (!nomination) {
+        console.log(`  対象なし（修正済み）: ${label}`);
+        stats.skipped++;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(
+          `  [dry-run] ${label}: ${entry.wrongImdbId} → ${entry.correctImdbId ?? '(IMDb ID無し)'}`,
+        );
+        stats.repointed++;
+        continue;
+      }
+
+      const correctMovieUid = await resolveCorrectMovie(
+        database,
+        environment,
+        entry,
+        stats,
+      );
+
+      if (await hasSameNomination(database, nomination.uid, correctMovieUid)) {
+        await database
+          .delete(nominations)
+          .where(eq(nominations.uid, nomination.uid));
+        stats.deletedDuplicate++;
+        console.log(`  重複のため削除: ${label}`);
+      } else {
+        await database
+          .update(nominations)
+          .set({movieUid: correctMovieUid})
+          .where(eq(nominations.uid, nomination.uid));
+        stats.repointed++;
+        console.log(`  付け替え: ${label}`);
+      }
+
+      affected.add(nomination.movieUid);
+      affected.add(correctMovieUid);
+
+      if (throttleMs > 0) {
+        await sleep(throttleMs);
+      }
+    } catch (error) {
+      console.error(`  失敗: ${label}`, error);
+      stats.failed++;
+    }
+  }
+
+  stats.affectedMovieUids = [...affected];
+  return stats;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "scrapers:assign-imdb-ids": "pnpm --filter @shine/scrapers run assign-imdb-ids",
     "scrapers:backfill-posters": "pnpm --filter @shine/scrapers run backfill-posters",
     "scrapers:delete-orphan-movies": "pnpm --filter @shine/scrapers run delete-orphan-movies",
+    "scrapers:fix-misattributed-nominations": "pnpm --filter @shine/scrapers run fix-misattributed-nominations",
     "scripts:soft-delete-orphan-movies": "tsx scripts/soft-delete-orphan-movies.ts",
     "db:studio": "node scripts/setup-database-environment.cjs drizzle-kit studio",
     "db:generate": "node scripts/setup-database-environment.cjs drizzle-kit generate",


### PR DESCRIPTION
issue #294 の続き。キネマ旬報16件・カンヌ7件のノミネーションが、リメイクや同名別作品に付いていたのを正しい映画へ付け替えた。

原因は日本語Wikipediaの記事名をWikidata(P345)で引くと最新のリメイク版が返ること。『野火』の記事は塚本晋也版(2015)、『あにいもうと』は今井正版(1976)を指すので、キネ旬1959年度・1936年度のノミネートがそちらに付いていた。カンヌ側も同様で、セクションリンク（`橋のない川#映画版`）や英語版の曖昧さ回避で新しい方を掴んでいた。

修正定義は `apps/scrapers/data/misattributed-nominations.json` に置き、CLIで適用する。正しい映画がDBに無ければTMDbから作成し、ソフト削除済みなら復活させる。移動先が既に同じ賞のノミネーションを持つ場合は元の行を削除する。冪等なので再実行しても対象なしになる。

本番適用済み。20本を新規作成、3本は既存レコードへ付け替え。カンヌ4作品の邦題をWikidataから補完した。

issueの検出クエリ（セレモニー年が公開年より2年以上前）に残る12件は誤検出で、映画祭プレミアと一般公開のズレ。『新ドイツ零年』のヴェネツィア1991や『愛のむきだし』のような正常なケースなので手を触れていない。キネ旬日本映画は公開年度と一致するはずなので `m.year != c.year` で洗い直し、1年差の裾から3件（戦争と人間の第二部・完結編、青春ジャック）を拾って一緒に直した。他の賞の1年差は未点検。